### PR TITLE
docs: cloudflare infrastructure plan + PR/issue triage

### DIFF
--- a/docs/cloudflare-infrastructure.md
+++ b/docs/cloudflare-infrastructure.md
@@ -181,6 +181,135 @@ Week 4:
 15. Build the preview environment workflow (`preview.yml` + Workers Versions).
 16. Pick off P1 issues (#5, #6, #9, #10).
 
+## Account-wide Vercel inventory (beyond this repo)
+
+This doc started as a per-repo plan but the wider goal is moving every domain-bearing project off Vercel onto Cloudflare. Playground projects on `*.vercel.app` stay on Vercel.
+
+Inventory captured 2026-05-13 via `vercel projects ls` + `vercel domains ls` + per-domain `dig` and `curl -I` probes.
+
+### Vestigial Vercel projects (delete, no migration needed)
+
+| Vercel project               | Why it's dead                                                                                                                | Action                                                                                                       |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `anipotts.com`               | DNS resolves to Cloudflare (`server: cloudflare`). The Vercel project still claims the apex domain but nothing routes there. | Delete project at `vercel.com/anipotts/anipotts.com/settings`. Detach `anipotts.com` from the project first. |
+| `linear-tinkering-starlight` | Stub auto-created when running `vercel ls` from this worktree dir. Never had a deploy.                                       | Delete project at `vercel.com/anipotts/linear-tinkering-starlight/settings`.                                 |
+
+### Active Vercel-hosted custom-domain projects (migrate)
+
+12 domain-bearing projects, all confirmed `server: Vercel` on probe.
+
+| Wave | Domain                                    | Vercel project        | Notes                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| ---- | ----------------------------------------- | --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1    | `coolfollowers.com`                       | coolfollowers.com     | Probably small/static. Good first migration to validate the Workers recipe end-to-end.                                                                                                                                                                                                                                                                                                                                                                           |
+| 1    | `wigglesburg.com`                         | wigglesburg.com       | Probably small/static.                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| 1    | `nyupuritytest.com` + `nyuricepurity.com` | nyupuritytest.com     | Two domains, one project. Second domain currently doesn't resolve, so it tags along for free.                                                                                                                                                                                                                                                                                                                                                                    |
+| 2    | `howoldamiactually.com`                   | howoldamiactually.com | Single page-y. Probable Next or static.                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| 2    | `fourtwenty.nyc`                          | fourtwenty.nyc        | Listed as a portfolio project in `packages/lib/src/money/queries.ts`.                                                                                                                                                                                                                                                                                                                                                                                            |
+| 2    | `chained.chat`                            | chained.chat          |                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| 3    | `getknowport.com` + `knowport.app`        | knowport              | Two custom domains pointing at one project; CF custom-domain bind handles both via repeated `[[routes]]` entries.                                                                                                                                                                                                                                                                                                                                                |
+| 3    | `www.prcart.dev`                          | prcart                | `.dev` TLD, looks shipped product.                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| 3    | `www.ashasreen.com`                       | ashasreen.com         | Personal site. Confirm with owner before flipping DNS.                                                                                                                                                                                                                                                                                                                                                                                                           |
+| 4    | `www.saeshify.com`                        | saeshify              | Real product. Migrate after the recipe is shaken out on smaller sites.                                                                                                                                                                                                                                                                                                                                                                                           |
+| 5    | `quantercise.com`                         | quantercise.com       | **Highest risk.** Symphony daemon on `ap-mini` autonomously commits + deploys against this project (`~/Code/external/symphony/elixir/`). The Symphony workflow assumes the deploy URL is the Vercel-style `https://quantercise.com`. Migration must coordinate: either swap Symphony's deploy logic to call `wrangler deploy`, or run both stacks in parallel for a verification window before the cutover. Do this last; the rest of the migration is practice. |
+
+### Playground projects (leave on Vercel)
+
+`*.vercel.app` only, no custom domain. Vercel keeps them, no churn:
+
+`rudy`, `invideo`, `valentine`, `pgi`, `vector-seo`, `dashboard`, `resonance`, `poojatrehan`, `chalk`, `mamadigital`, `answerlowkey`.
+
+### GitHub App scoping
+
+The Vercel GitHub App is currently installed across all 127 anipotts repos. **Do not uninstall** (would yank it from the playground projects too). Instead, in `github.com/settings/installations/53160308`:
+
+1. Switch **Repository access** from "All repositories" → "Only select repositories".
+2. In the multi-select, deselect every repo that hosts a domain-bearing project (this repo, then each of the 12 above as they migrate).
+3. Save.
+
+Net effect: Vercel CI keeps building previews for the playground stuff, stops touching anything that's been migrated.
+
+### Per-project migration template
+
+Same recipe each time. Total time per project, given a typical Next.js app: ~30-60 min including DNS verification. Static-only sites: closer to 15.
+
+**Step 0: assess.** Clone the project's repo. Read `package.json` + `next.config` + look for serverless functions, ISR, image optimization, edge middleware, env vars.
+
+| Trait                                | Lift                                                                 |
+| ------------------------------------ | -------------------------------------------------------------------- |
+| Next.js 13+ App Router, fully SSG    | trivial                                                              |
+| Next.js with API routes / SSR        | use OpenNext, mirror `apps/www` recipe                               |
+| Next.js with ISR or `unstable_cache` | OpenNext supports it; verify your specific patterns                  |
+| Next.js Edge Middleware              | OpenNext converts to Worker entrypoint logic                         |
+| `next/image` with remote hosts       | OpenNext bundles, or swap to CF Images binding                       |
+| Plain Vite/SvelteKit/Remix/Astro     | use Workers Static Assets (`[assets]` directive) instead of OpenNext |
+| Anything calling Vercel KV/Postgres  | port to CF KV / D1 (this is the heaviest piece — flag early)         |
+| Anything calling Vercel Blob         | port to CF R2                                                        |
+
+**Step 1: scaffold the Worker.** In the project repo, create `wrangler.toml` mirroring `apps/labs/wrangler.toml`:
+
+```toml
+name = "<project-name>"
+compatibility_date = "2025-04-01"
+compatibility_flags = ["nodejs_compat"]
+account_id = "0f856093bdcd34a7da1bde5ee4385163"
+main = ".open-next/worker.js"
+workers_dev = true   # leave on while testing, flip to false at cutover
+
+[assets]
+directory = ".open-next/assets"
+binding = "ASSETS"
+
+[observability]
+enabled = true
+```
+
+Add `@opennextjs/cloudflare` and `wrangler` to devDependencies. Add `open-next.config.ts` (one-liner: `export default defineCloudflareConfig({});`).
+
+**Step 2: build + smoke test on `*.workers.dev`.**
+
+```bash
+pnpm build  # or npm run build
+npx opennextjs-cloudflare build
+npx wrangler deploy
+```
+
+Hit the resulting `https://<project-name>.<account>.workers.dev` URL. Verify everything that worked on Vercel still works.
+
+**Step 3: detach the domain from Vercel.** In the Vercel project's Settings → Domains, remove the custom domain. This frees Cloudflare to claim it.
+
+**Step 4: bind the domain on the Worker.** Append to `wrangler.toml`:
+
+```toml
+[[routes]]
+pattern = "<domain.com>"
+custom_domain = true
+zone_id = "<zone-id-from-cf-dashboard>"
+```
+
+Re-deploy. Wrangler attaches the hostname. **No DNS edit at the registrar level if the domain is already in a Cloudflare zone**; if it's still on Vercel's nameservers, change the registrar to point at Cloudflare nameservers first (or move the apex CNAME to `cname.vercel-dns.com` → `cf-cname-target` carefully).
+
+**Step 5: smoke test, decommission Vercel.** `curl -I https://<domain>` should report `cf-ray:` headers. Once verified, archive or delete the Vercel project. Remove the repo from the Vercel GitHub App's selected list.
+
+**Rollback:** re-attach the domain to the Vercel project. The Vercel build is still cached; rollback is immediate.
+
+### Things that need explicit decisions before starting
+
+- **Repo locations.** Are these one-repo-per-project, or do some live in monorepos? Migration approach differs (per-app `wrangler.toml` if monorepo, root if standalone).
+- **Env vars.** Vercel env vars need to migrate to `wrangler secret put` per Worker. Inventory per project before cutover.
+- **Database/storage.** If any project uses Vercel KV / Postgres / Blob, those don't have one-line CF equivalents. Flag those during the per-project assessment.
+- **Quantercise + Symphony coordination.** Symphony runs autonomous deploy loops against `quantercise.com` from `ap-mini`. Before migrating Quantercise, decide: pause Symphony, modify Symphony's deploy step to call `wrangler deploy` instead of pushing to Vercel, or run both stacks side-by-side for a verification window.
+- **Branch deploys / preview URLs per project.** Vercel gives PR preview URLs free. The CF equivalent is `wrangler versions upload` per PR. Worth wiring up per-project once the recipe is solid; not blocking initial cutover.
+
+### Suggested order
+
+1. **Wave 1** (small/static, low risk): coolfollowers.com, wigglesburg.com, nyupuritytest.com. Validates the recipe.
+2. **Wave 2** (single-page-ish): howoldamiactually.com, fourtwenty.nyc, chained.chat.
+3. **Wave 3** (real product domains): knowport (two domains), prcart.dev, ashasreen.com.
+4. **Wave 4** (saeshify.com): real product, do once the recipe is muscle memory.
+5. **Wave 5** (quantercise.com): coordinate Symphony first.
+
+Aim for 1 wave per week if doing solo, faster with batching.
+
 ## Update rule
 
 When you ship infrastructure that changes the deploy graph (a new Worker, a custom-domain swap, a new binding type, a CF feature toggled on/off), update this doc in the same PR. Future contributors trust this over guesswork.

--- a/docs/cloudflare-infrastructure.md
+++ b/docs/cloudflare-infrastructure.md
@@ -1,0 +1,186 @@
+# Cloudflare Infrastructure Plan
+
+Living document for the anipotts.com monorepo's deploy substrate. The short version: production already runs entirely on Cloudflare. This doc captures what's there, what's vestigial, what to adopt next, and how to handle every open PR and issue under that lens.
+
+Last updated: 2026-05-13.
+
+## TL;DR
+
+- **No Vercel deployments exist.** `vercel ls` returned zero deployments under the `anipotts` scope. Every public hostname in this repo (`anipotts.com`, `admin.anipotts.com`, `labs.anipotts.com`) resolves to Cloudflare IPs and is served by Cloudflare. The "migrate off Vercel" framing was real for the labs PR draft (which targeted Vercel) and for the residual `apps/www/vercel.json` config file. Both are addressed by PR #40 and PR #41.
+- **The remaining work is consolidation and adoption**, not migration. The substrate is right; the surface area to leverage CF-native features (Web Analytics, Logpush, Smart Placement, Email Workers, preview deploys via Workers Versions, etc.) is wide open.
+- **Observability is sparse.** No Sentry, no log streaming setup, no synthetic monitoring. Lots of free-tier CF features unused.
+- **Three PRs are the current consolidation push:** #40 (labs to CF Workers), #41 (delete vestigial vercel.json), and this doc.
+
+## Current state of the deploy graph
+
+Every target ships from `.github/workflows/deploy.yml` via `cloudflare/wrangler-action@v3`, path-filtered so only changed apps redeploy.
+
+| Target                 | Worker name             | Hostname                                               | Build                                         | Bindings                                |
+| ---------------------- | ----------------------- | ------------------------------------------------------ | --------------------------------------------- | --------------------------------------- |
+| `apps/www`             | `anipotts-www`          | `anipotts.com/*`                                       | Next 16 + OpenNext (`@opennextjs/cloudflare`) | `ASSETS`, D1 `DB` (`anipotts-db`)       |
+| `apps/admin`           | `anipotts-admin`        | `admin.anipotts.com/*`                                 | Next 16 + OpenNext                            | `ASSETS`, D1 `DB`, fronted by CF Access |
+| `apps/labs` (PR #40)   | `anipotts-labs`         | `labs.anipotts.com` (custom-domain bind, post-cutover) | Next 16 + OpenNext                            | `ASSETS`, observability enabled         |
+| `workers/ingest`       | `anipotts-ingest`       | `*.workers.dev` (no custom domain)                     | Plain Worker                                  | D1 `DB`, cron `* * * * *`               |
+| `workers/weekly-email` | `anipotts-weekly-email` | `*.workers.dev` (no custom domain)                     | Plain Worker                                  | D1 `DB`, cron `0 13 * * SUN`            |
+
+DNS for `anipotts.com` is in Cloudflare zone `d56476e2905a2a19ad86aaa4b7c719c2` under account `0f856093bdcd34a7da1bde5ee4385163`. DB of record is D1 `anipotts-db` (`a8aadf73-bbf4-447c-97db-cb3e50b4e26f`).
+
+## What's vestigial (delete)
+
+| Item                                    | Status                                                              | Action                                                                 |
+| --------------------------------------- | ------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| `apps/www/vercel.json`                  | Not used by CI                                                      | PR #41 deletes it.                                                     |
+| `apps/labs/vercel.json` (was in #40 v1) | Removed in PR #40 v2                                                | Done.                                                                  |
+| Vercel CLI project link                 | Junk (`linear-tinkering-starlight` stub created during `vercel ls`) | Delete via Vercel dashboard or `vercel project rm`.                    |
+| `RESEND_API_KEY` references             | In use today                                                        | PR #30 swaps to CF Email Workers `send_email` binding; revive that PR. |
+| Resend npm dep + secret                 | In use today                                                        | Removed by PR #30.                                                     |
+
+## What to adopt (priority ordered)
+
+### P0: stop bleeding cycles
+
+1. **Bump `deploy.yml` Node 20 → 22.** Already shipped in PR #40 because `wrangler-action@v3` requires Node 22 and was failing the most recent main deploy. If PR #40 is delayed, cherry-pick this fix into a one-line PR.
+2. **Revive PR #30 (Resend → CF Email Workers `send_email` binding).** Direction is exactly aligned with consolidating onto Cloudflare. Bonus: kills one vendor + one secret + one bill.
+3. **Workers Logs.** `[observability] enabled = true` in every `wrangler.toml`. Free, 7-day retention, makes `wrangler tail` and dashboard log streams just work. PR #40's `apps/labs/wrangler.toml` already has this; replicate to the existing Workers in a follow-up.
+
+### P1: observability the platform gives away free
+
+4. **Cloudflare Web Analytics** on `anipotts.com`, `admin.anipotts.com`, `labs.anipotts.com`. No client SDK, no cookies, free, RUM-style. Replaces a meaningful chunk of what Vercel Analytics would have been. Note that PostHog is also wired into `apps/www` for product analytics — keep both; they answer different questions.
+5. **Logpush to R2** for any Worker that matters in postmortems (`anipotts-www`, `anipotts-admin`, `anipotts-ingest`). Cheaper than Sentry for raw streams, durable beyond Workers Logs' 7 days. Configure once per Worker via the dashboard or a Terraform module.
+6. **Sentry on Workers.** The `@sentry/cloudflare` SDK is the canonical source for stack traces, source maps, and error grouping. Workers Logs is the firehose; Sentry is the dashboard. Scope: at minimum `apps/www` and `apps/admin`; ingest/weekly-email are noisy enough that it's worth thinking about volume first.
+
+### P2: edge features that change architecture
+
+7. **Smart Placement.** `[placement] mode = "smart"` in `wrangler.toml` for any Worker that talks to a single-region origin. `apps/admin` calls Mercury, GitHub, Buttondown, Typefully — likely all single-region. Toggle on, measure latency, keep or revert.
+8. **Wrangler Versions for preview environments.** Every push to a non-main branch can `wrangler versions upload` to get a unique URL bound to that commit. Replaces Vercel preview URLs with first-party primitives. Costs nothing on the free plan; needs CI wiring (a `preview.yml` workflow that runs on `pull_request` and posts the version URL back as a PR comment).
+9. **Workers Builds.** First-party CI/CD for Workers. Not strictly necessary while we're on GitHub Actions and it works, but worth keeping in the back pocket if Actions costs become a concern. Don't switch yet; revisit if PR-volume changes meaningfully.
+10. **Cloudflare Images.** Replaces `next/image`'s remote-host optimization. OpenNext + CF Images plays nicely. Worth turning on if image-heavy routes appear; not urgent today.
+
+### P3: nice-to-have, low-priority
+
+11. **Zaraz.** Server-side third-party scripts (PostHog, GA, etc.) at the edge. Removes client JS bundles. Only matters if perf budget tightens.
+12. **Turnstile.** Already in use on `apps/www` contact form (per the security headers in `next.config.ts`). Confirm it's wired and the secret is set on the live Worker.
+13. **D1 read replicas + sessions.** Once read traffic to `anipotts-db` justifies it (it doesn't yet). Park.
+14. **Hyperdrive.** Only if we ever add an external Postgres. We don't have one. Park.
+
+## Monitoring posture (proposed)
+
+| Layer                | Tool                              | What it answers                         |
+| -------------------- | --------------------------------- | --------------------------------------- |
+| Synthetic            | UptimeRobot or CF Health Checks   | "Is the homepage 200?"                  |
+| RUM                  | CF Web Analytics                  | "What's user-perceived load time?"      |
+| Product              | PostHog (already wired on www)    | "Did the conversion funnel change?"     |
+| App errors           | Sentry on Workers                 | "What stack trace just fired?"          |
+| Raw logs             | Workers Logs (7d) + Logpush to R2 | "What did the Worker actually do?"      |
+| Email deliverability | CF Email Routing dashboard        | "Did the contact form mail get sent?"   |
+| DB health            | D1 metrics in CF dashboard        | "How many rows? How many slow queries?" |
+| CI                   | GitHub Actions                    | "Did the deploy go green?"              |
+
+Gap-fillers worth building: a `/health` aggregator endpoint on `apps/admin` that pings each binding (D1, KV, R2 if we add it) and returns a single JSON payload UptimeRobot can poll.
+
+## Preview environments (proposed)
+
+Goal: every PR gets a URL like `https://pr-40.anipotts-labs.workers.dev` (or per-app subdomain) so review can happen in a browser.
+
+Mechanism: a new `.github/workflows/preview.yml` that runs on `pull_request`, builds the changed apps with OpenNext, calls `wrangler versions upload --message "PR #${{ github.event.number }}"`, captures the version URL, comments it on the PR.
+
+Cost: free on the Workers free plan up to a generous limit.
+
+Caveat: Workers Versions are for "uploaded but not deployed" Worker code. They get a `*.workers.dev` URL but don't share the production custom domain. That's the right semantic for previews.
+
+## PR triage (open as of 2026-05-13)
+
+| #   | Title                                                              | State            | Action                                                                                                                                                                                                                                                                         |
+| --- | ------------------------------------------------------------------ | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 40  | feat(labs): port labs to Next 16 on Cloudflare Workers             | open, mine       | Land after CI green; then run cutover steps in `apps/labs/README.md`.                                                                                                                                                                                                          |
+| 41  | chore: remove vestigial apps/www/vercel.json                       | open, mine       | Land after CI green. Mechanical, low risk.                                                                                                                                                                                                                                     |
+| 39  | deps(deps): bump tailwind-merge 3.4.0 → 3.6.0                      | open, dependabot | Patch-ish minor, low risk. Merge after CI green.                                                                                                                                                                                                                               |
+| 38  | deps(deps): bump resend 6.8.0 → 6.12.3                             | open, dependabot | **Hold.** Resend is being removed by PR #30. If #30 lands first, this PR auto-closes. If #30 stalls, merge #38 to keep the dep healthy in the meantime.                                                                                                                        |
+| 37  | deps(deps): bump otplib 12.0.1 → 13.4.0                            | open, dependabot | **Major bump.** Used by admin TOTP. Merge solo, verify admin login flow, never bundle with another dep PR.                                                                                                                                                                     |
+| 36  | deps(dev): bump typescript 5.9.3 → 6.0.3                           | open, dependabot | **Major bump.** TypeScript major bumps routinely break builds. Merge solo, verify all `pnpm turbo build lint typecheck test` pass, be ready to revert.                                                                                                                         |
+| 33  | ci: bump dependabot/fetch-metadata 2 → 3                           | open, dependabot | Low-risk action bump. Merge after CI green.                                                                                                                                                                                                                                    |
+| 32  | ci: bump actions/checkout 4 → 6                                    | open, dependabot | Low-risk action bump. Merge after CI green.                                                                                                                                                                                                                                    |
+| 31  | ci: bump dorny/paths-filter 3 → 4                                  | open, dependabot | Low-risk action bump. Merge after CI green.                                                                                                                                                                                                                                    |
+| 30  | Migrate from Resend to Cloudflare Email Workers send_email binding | **draft**, mine  | **Revive.** Direction is correct. Last touched 2026-05-01; needs rebase against current main, manual prereq checks (verify `contact@anipotts.com` and `hello@anipotts.com` as Email Routing destinations, confirm SPF/DKIM healthy). Convert to ready-for-review once rebased. |
+
+Suggested merge order (assuming each is green): 41 → 40 (after cutover) → 39, 33, 32, 31 (low-risk batch) → 37 (solo, verify TOTP) → 36 (solo, verify everything) → 30 (after manual prereqs) → 38 auto-closes.
+
+## Issue triage (open as of 2026-05-13, 20 total)
+
+All issues are code-quality findings from a March audit. None are blocked by Vercel/CF migration. The CF consolidation makes one (#27) potentially obsolete if PR #30 lands.
+
+**P0 critical (2):**
+
+| #   | Title                                                            | Action                                                                                                                         |
+| --- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| 3   | Add rate limiting to admin login (function exists, never called) | Fix immediately. Function is already written; just call it. CF KV or Workers Rate Limiting binding is the right backing store. |
+| 4   | Guard ThroughputChart against empty data (crash on render)       | Fix immediately. Trivial null-check.                                                                                           |
+
+**P1 high (5):**
+
+| #   | Title                                                               | Action                                                    |
+| --- | ------------------------------------------------------------------- | --------------------------------------------------------- |
+| 5   | Add env var validation with zod (fail fast on missing config)       | Worth doing; pairs well with CF secret rotation playbook. |
+| 6   | Replace `window.location.reload()` with `router.refresh()` in admin | Trivial. Bundle into next admin PR.                       |
+| 7   | Make CI tests hard-fail (remove `\|\| true` from test/audit steps)  | Do now. The whole point of CI is hard-fail.               |
+| 9   | Extract SERIES_COLORS to shared constant (defined 3 times)          | Tech debt. Bundle into next refactor.                     |
+| 10  | Admin pipeline fetches ALL atoms just to count them                 | Real perf bug. SQL `SELECT COUNT(*)` fix.                 |
+
+**P2 medium (8):**
+
+| #   | Title                                                            | Action                                                                                                          |
+| --- | ---------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| 11  | Add a11y labels to all form inputs and search                    | Bundle into next www UI PR.                                                                                     |
+| 12  | Fix TipCard nested interactive elements (a11y violation)         | Bundle into next www UI PR.                                                                                     |
+| 13  | Remove dead code: unused exports across codebase                 | Bundle when convenient. Use `ts-prune` or `knip`.                                                               |
+| 14  | Add error boundary for admin routes                              | Trivial in App Router. Bundle into next admin PR.                                                               |
+| 15  | Fix `logger.info` using `console.warn` instead of `console.info` | Trivial bug fix.                                                                                                |
+| 16  | Memoize ThemeContext value to prevent unnecessary re-renders     | Trivial perf fix.                                                                                               |
+| 19  | Add Turnstile fetch timeout and CSRF origin check on `/api/send` | Real security improvement. Bundle into PR #30 or its successor since `/api/send` is being touched there anyway. |
+| 20  | Add cache headers to `/api/icon` route                           | Trivial. Bundle into next www PR.                                                                               |
+
+**P3 low (5):**
+
+| #   | Title                                                             | Action                                                                                                                                                                                             |
+| --- | ----------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 22  | Add `lastBuildDate` to RSS feed                                   | Trivial.                                                                                                                                                                                           |
+| 23  | Fix slug collision window (28 min repeat cycle)                   | Trivial. Bump the entropy on slug generation.                                                                                                                                                      |
+| 24  | Add missing `package.json` metadata (license, repository, author) | Mechanical. Bundle when touching root files.                                                                                                                                                       |
+| 25  | Fix `turbo.json` `globalDependencies` (missing config packages)   | Real DX bug. Quick fix.                                                                                                                                                                            |
+| 27  | Sanitize Resend API response (don't leak internal details)        | **Maybe obsolete.** If PR #30 lands, the Resend SDK is removed entirely and this issue dissolves. Close as superseded once #30 merges. If #30 stalls past say 2026-06-01, fix this in a one-liner. |
+
+None of the 20 are migration-blocking. Land #40 and #41 first, then revive #30, then start picking off P0 + P1.
+
+## Forward roadmap (suggested, 4-week horizon)
+
+Week 1 (this week, 2026-05-13 onward):
+
+1. Land PR #40 (labs on CF Workers), execute Pages → Workers cutover for `labs.anipotts.com`.
+2. Land PR #41 (vercel.json cleanup).
+3. Cherry-pick the Node 22 bump from #40 into #41 if #40 stalls.
+4. Decide on PR #30: rebase + revive, or close + reopen later.
+
+Week 2:
+
+5. Add `[observability] enabled = true` to existing Workers (`anipotts-www`, `anipotts-admin`, `anipotts-ingest`, `anipotts-weekly-email`).
+6. Enable CF Web Analytics on all three hostnames.
+7. Fix issues #3 (admin rate limit) and #4 (ThroughputChart guard). Both are P0.
+8. Fix issue #7 (CI hard-fail).
+
+Week 3:
+
+9. Merge low-risk dependabot PRs (#39, #33, #32, #31).
+10. Merge #37 (otplib major) solo with admin TOTP smoke test.
+11. Merge #36 (TypeScript major) solo with full validation.
+12. Land PR #30 (Resend → CF Email Workers) once prereqs are checked.
+
+Week 4:
+
+13. Wire Logpush to R2 for `anipotts-www` and `anipotts-admin`.
+14. Add Sentry on Workers (start with `apps/www`).
+15. Build the preview environment workflow (`preview.yml` + Workers Versions).
+16. Pick off P1 issues (#5, #6, #9, #10).
+
+## Update rule
+
+When you ship infrastructure that changes the deploy graph (a new Worker, a custom-domain swap, a new binding type, a CF feature toggled on/off), update this doc in the same PR. Future contributors trust this over guesswork.

--- a/docs/per-project-vercel-migration.md
+++ b/docs/per-project-vercel-migration.md
@@ -1,0 +1,303 @@
+# Per-Project Vercel → Cloudflare Migration Plan
+
+Companion to `docs/cloudflare-infrastructure.md`. That doc covers the anipotts.com monorepo and the broader account picture. This doc plans the actual project-by-project migrations for the 9 domains slated to move.
+
+Last updated: 2026-05-13.
+
+## Scope
+
+Migrate these 9 domain-bearing Vercel projects under the `anipotts` Vercel team to the `anipotts` Cloudflare account (`0f856093bdcd34a7da1bde5ee4385163`):
+
+1. ashasreen.com
+2. chained.chat
+3. coolfollowers.com
+4. howoldamiactually.com
+5. nyupuritytest.com (`nyuricepurity.com` is a secondary registered domain that doesn't resolve; no action this round)
+6. prcart.dev
+7. quantercise.com
+8. saeshify.com
+9. wigglesburg.com
+
+## Cross-cutting facts (apply to all 9)
+
+**Nameservers.** All 9 domains are on Namecheap (`dns1/dns2.registrar-servers.com`). Zero are in Cloudflare zones today. Each migration starts with a Namecheap nameserver swap, propagation wait (1 to 24 hours, usually under 4), then Worker custom-domain bind. **No CF Worker can attach to a hostname that isn't in a CF zone.**
+
+**Framework.** All 9 are Next.js. Mix of Next 14, 15, 16. No Astro, no Vite SPA, no Remix. The migration recipe is uniform: `@opennextjs/cloudflare` + `wrangler.toml` + `[assets]` binding + Workers Logs.
+
+**CF account.** All deploys target `account_id = "0f856093bdcd34a7da1bde5ee4385163"` (the `anipotts` CF account, same one that hosts anipotts.com). Not rubio-potts, not stranger-matter.
+
+**Repo locations.** Already cloned locally under `~/Code/projects/websites/`: ashasreen.com, coolfollowers.com, howoldamiactually.com, wigglesburg.com. Need cloning: chained-chat, quantercise, nyu-rice-purity, pr-cart, saeshify. Suggested target: `~/Code/projects/websites/<repo>` for consistency.
+
+**Symphony (quantercise).** The Symphony daemon on `ap-mini` runs autonomous Linear-driven loops against `quantercise`. Per the infra map, it does fresh git clones into `~/symphony-workspaces/QUA-N/` per issue and pushes back. Modifying the deploy substrate without coordinating with Symphony will cause merge conflicts and blow up autonomous PRs in flight. **Pause Symphony before touching quantercise.** `ssh mini 'launchctl bootout gui/$(id -u)/com.symphony.quantercise'`. Restart after migration is verified.
+
+**GitHub App scoping.** Vercel GitHub App stays installed on each repo until migration is verified (so the rollback path stays open). Once a migration is verified, remove that repo from the app's selected list (one DELETE call per repo, see `docs/cloudflare-infrastructure.md`).
+
+## Per-project assessments
+
+### 1. ashasreen.com — TRIVIAL
+
+|                      |                                                                              |
+| -------------------- | ---------------------------------------------------------------------------- |
+| Repo                 | `anipotts/ashasreen.com` (local at `~/Code/projects/websites/ashasreen.com`) |
+| Framework            | Next 16.1.2, React 19                                                        |
+| API routes           | none                                                                         |
+| Middleware           | none                                                                         |
+| Vendor deps          | none                                                                         |
+| Vercel-only features | none                                                                         |
+| `vercel.json`        | absent                                                                       |
+| `next.config.ts`     | empty                                                                        |
+
+**Plan.** Add `wrangler.toml` + `open-next.config.ts`, run `opennextjs-cloudflare build`, deploy to `*.workers.dev`, smoke test, swap NS at Namecheap to CF, attach custom domain to Worker, delete Vercel project. Estimated time: 30 min including DNS propagation wait.
+
+**Risk:** none. This is the practice run.
+
+### 2. coolfollowers.com — SMALL APP
+
+|                      |                                                                                          |
+| -------------------- | ---------------------------------------------------------------------------------------- |
+| Repo                 | `anipotts/coolfollowers.com` (local)                                                     |
+| Framework            | Next 16.1.1, React 19                                                                    |
+| API routes           | 7 (auth, data fetching for IG followers/following/posts/profile/stats, refresh)          |
+| Middleware           | yes (`src/middleware.ts`)                                                                |
+| Vendor deps          | none in `dependencies`                                                                   |
+| Vercel-only features | none                                                                                     |
+| `vercel.json`        | absent                                                                                   |
+| `next.config.ts`     | image remote patterns for Instagram CDNs (`*.cdninstagram.com`, `instagram.*.fbcdn.net`) |
+
+**Plan.** Same recipe. The image `remotePatterns` list works fine on OpenNext (it just bundles them); no change. The 7 API routes will become Worker function invocations under OpenNext's adapter. Need to inventory env vars (probably IG OAuth keys) and `wrangler secret put` each.
+
+**Risk:** medium. The auth route + Instagram OAuth flow might have a callback URL pinned to Vercel. Verify after deploy. Estimated time: 60 min.
+
+### 3. howoldamiactually.com — TRIVIAL
+
+|                      |                                                                     |
+| -------------------- | ------------------------------------------------------------------- |
+| Repo                 | `anipotts/howoldamiactually.com` (local)                            |
+| Framework            | Next 16.1.2, React 19                                               |
+| API routes           | none                                                                |
+| Middleware           | none                                                                |
+| Vendor deps          | `@vercel/analytics`                                                 |
+| Vercel-only features | analytics SDK                                                       |
+| `vercel.json`        | absent                                                              |
+| `next.config.mjs`    | `images.unoptimized: true`, ignores TS + ESLint errors during build |
+
+**Plan.** Same recipe. Replace `@vercel/analytics` import + provider with the CF Web Analytics snippet (or just delete; analytics on a one-off "how old am I" page is overkill). Probable 1-line removal. Estimated time: 30 min.
+
+**Risk:** none.
+
+### 4. nyupuritytest.com — SMALL APP
+
+|                                     |                                                                                                                 |
+| ----------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| Repo                                | `anipotts/nyu-rice-purity` (clone to `~/Code/projects/websites/nyu-rice-purity`)                                |
+| Framework                           | Next 14.2.35, React 18                                                                                          |
+| API routes                          | 6 (revalidate-stats, save-feedback, share-stats, statistics, submission-count, submit-result)                   |
+| Middleware                          | yes (`src/middleware.ts`, plus `src/app/admin/middleware.ts`)                                                   |
+| Vendor deps                         | `@vercel/analytics`                                                                                             |
+| Vercel-only features                | `vercel.json` pins `regions: ["sfo1"]`, uses legacy `builds: [@vercel/next]`, custom build command for tailwind |
+| `vercel.json`                       | yes (region pin + legacy builder, both Vercel-specific)                                                         |
+| `next.config.ts` / `next.config.js` | both present (collision); `next.config.js` has `swcMinify`, ignores TS errors                                   |
+
+**Plan.** Same recipe but **delete `vercel.json` and consolidate to one `next.config`**. Region pinning becomes irrelevant on Workers (always edge). Drop `@vercel/analytics`. The data routes (stats, feedback, share, submit) almost certainly write to a database — find what (Postgres? Supabase? KV?) and either keep that vendor or migrate to D1. Inventory needed before migration starts.
+
+**Risk:** medium. Open question: where does the data live? Need to read one of the API route files to find out. Estimated time: 1-2 hr depending on DB.
+
+### 5. prcart.dev — UNKNOWN, PROBABLY STATIC
+
+|                      |                            |
+| -------------------- | -------------------------- |
+| Repo                 | `anipotts/pr-cart` (clone) |
+| Framework            | Next 14.2.0, React 18      |
+| API routes           | none visible at top level  |
+| Middleware           | none visible               |
+| Vendor deps          | none                       |
+| Vercel-only features | none                       |
+| `vercel.json`        | absent                     |
+
+**Plan.** Same recipe. If it really is static, this is identical to ashasreen.com. Estimated time: 30 min.
+
+**Risk:** low. Possible: API routes nested deeper than top-level grep caught.
+
+### 6. saeshify.com — MEDIUM, SUPABASE + CRON
+
+|                      |                                                                                                                                                 |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| Repo                 | `anipotts/saeshify` (clone)                                                                                                                     |
+| Framework            | Next 16.0.10, React 19                                                                                                                          |
+| API routes           | 10 (Spotify integration: search, album, artist, token; rhymes; push subscribe; **2 cron routes**: `/api/cron/notify`, `/api/cron/spotify-sync`) |
+| Middleware           | yes (root `middleware.ts`, plus `lib/supabase/middleware.ts` for Supabase SSR)                                                                  |
+| Vendor deps          | `@supabase/ssr`, `@supabase/supabase-js`, `vercel` (CLI as dependency, weird, likely accidental)                                                |
+| Vercel-only features | cron routes (Vercel Cron triggers them via `vercel.json`); analytics?                                                                           |
+| `vercel.json`        | not yet inspected, expect cron schedule definitions                                                                                             |
+| `next.config.js`     | not yet fully inspected                                                                                                                         |
+
+**Plan.**
+
+1. Same recipe for the Worker.
+2. The 2 cron routes need to become **Cloudflare Cron Triggers** in `wrangler.toml`. The route handlers themselves can stay as App Router routes; the Worker invokes them on schedule.
+3. `vercel` CLI as a dep is junk — remove from `dependencies`.
+4. Supabase keeps working as-is (Supabase is a separate hosted service; the SDK works on CF Workers via the SSR adapter).
+5. `wrangler secret put` for `SUPABASE_URL`, `SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`, Spotify creds, push subscription keys.
+
+**Risk:** medium. Cron porting is the main work. Spotify token refresh in the cron route needs to keep working. Estimated time: 2-3 hr.
+
+### 7. wigglesburg.com — TRIVIAL
+
+|                      |                                    |
+| -------------------- | ---------------------------------- |
+| Repo                 | `anipotts/wigglesburg.com` (local) |
+| Framework            | Next 14.2.35, React 18             |
+| API routes           | none visible                       |
+| Middleware           | none                               |
+| Vendor deps          | none                               |
+| Vercel-only features | none                               |
+| `vercel.json`        | absent                             |
+
+**Plan.** Same recipe. Clean static site. Estimated time: 30 min.
+
+**Risk:** none.
+
+### 8. chained.chat — HARD, CONVEX + CLERK + STREAMING
+
+|                      |                                                                                                                             |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| Repo                 | `anipotts/chained-chat` (clone)                                                                                             |
+| Framework            | Next 15.3.3, React 18                                                                                                       |
+| API routes           | 8: create-session, run-chain, stream-agent, stream-parallel, supervisor-interact, transcribe-audio, upload-file, web-search |
+| Middleware           | yes, Clerk auth + custom rate limiter + CORS for `chained.chat` origin                                                      |
+| Vendor deps          | `@clerk/nextjs`, `convex`                                                                                                   |
+| Vercel-only features | `vercel.json` sets `functions: maxDuration: 30` for all `app/api/**` routes                                                 |
+| `vercel.json`        | yes (function timeout, framework pin, rewrites)                                                                             |
+| `next.config.mjs`    | optimizePackageImports for Clerk/lucide/framer/radix; `serverExternalPackages: ['convex']`; custom webpack splitChunks      |
+
+**Plan.**
+
+1. Same Worker recipe.
+2. `maxDuration: 30` on Vercel Functions has no direct CF equivalent; **CF Workers cap at 30s CPU time per request** by default but can stream for much longer. Streaming AI routes (`stream-agent`, `stream-parallel`) need verification: confirm OpenNext properly preserves streaming responses. If not, fall back to using `wrangler.toml`'s `limits.cpu_ms` setting and explicit Response stream handling.
+3. Clerk works on CF Workers — they ship a CF adapter. Verify the middleware works without Vercel's edge runtime.
+4. Convex runs on its own infra; the SDK works anywhere. No change needed.
+5. Custom webpack splitChunks may need OpenNext-specific tweaks; test before declaring done.
+6. The `vercel.json` `rewrites` (`/api/(.*) → /api/$1`) is a no-op and can be deleted.
+7. `wrangler secret put` for: Clerk publishable + secret keys, Convex deployment URL + auth token, OpenAI / Anthropic / etc. API keys for the agents, web search API key, transcription API key, file upload destination creds.
+
+**Risk:** high. Streaming + auth + multi-step agent loops are exactly the kind of code that exposes runtime differences between Vercel Edge and CF Workers. Build a separate verification harness before cutting over. Estimated time: 4-6 hr.
+
+### 9. quantercise.com — HARDEST, ENTERPRISE APP + SYMPHONY
+
+|                       |                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Repo                  | `anipotts/quantercise` (clone)                                                                                                                                                                                                                                                                                                                                                                                   |
+| Framework             | Next 15.5.15, React 19                                                                                                                                                                                                                                                                                                                                                                                           |
+| API routes            | 40+, including admin (analytics, content, debug, drive uploads, failed events, feature flags, feedback), auth (account delete, sign-in-as), achievements, activity, alerts                                                                                                                                                                                                                                       |
+| Middleware            | yes, full correlation-ID + structured logging + mock-mode security guard                                                                                                                                                                                                                                                                                                                                         |
+| Vendor deps           | `@auth/drizzle-adapter`, **`@aws-sdk/client-cognito-identity-provider`**, `@aws-sdk/client-dynamodb`, `@aws-sdk/client-lambda`, `@aws-sdk/client-rds-data`, `@aws-sdk/client-secrets-manager`, `@aws-sdk/lib-dynamodb`, `@neondatabase/serverless`, **`@sentry/nextjs`**, `@upstash/ratelimit`, `@upstash/redis`, `@vercel/analytics`, **`botid`** (Vercel-owned bot detection), `next-auth` (v5 beta), `stripe` |
+| Vercel-only features  | **BotID** (Vercel proprietary bot detection product), `vercel.json` cron at `*/5 * * * *` for `/api/health/db`, CSP allows `vercel.live` + `*.vercel.app`                                                                                                                                                                                                                                                        |
+| `vercel.json`         | yes, cron + git deployment config                                                                                                                                                                                                                                                                                                                                                                                |
+| `next.config.ts`      | `withSentryConfig` + `withBotId` wrappers, full CSP with Vercel-specific origins, security headers                                                                                                                                                                                                                                                                                                               |
+| Symphony coordination | autonomous loops on `ap-mini` write to this repo                                                                                                                                                                                                                                                                                                                                                                 |
+
+**Plan.** This needs its own focused effort. Skeleton:
+
+1. **Pause Symphony first.** `ssh mini 'launchctl bootout gui/$(id -u)/com.symphony.quantercise'`.
+2. **Decide on BotID.** It's a Vercel-only product. Either drop it (simplest), replace with **CF Turnstile + Bot Management** (CF-native, free tier covers most use), or keep BotID but accept that it won't function once off Vercel. Recommend: replace with Turnstile on user-facing forms, drop everywhere else.
+3. **Sentry stays.** `@sentry/nextjs` works on Workers via the `@sentry/cloudflare` adapter. Need to migrate `withSentryConfig` to the CF adapter equivalent. Source maps upload via CI.
+4. **Cron migration.** `vercel.json` cron to `wrangler.toml` `[triggers]`. The `/api/health/db` route stays the same.
+5. **CSP cleanup.** Remove `vercel.live`, `*.vercel.app`, `wss://vercel.live` from script-src, connect-src, frame-src.
+6. **AWS Cognito + RDS Data + DynamoDB + Lambda + Secrets Manager** all keep working — they're external AWS services and the SDK runs on CF Workers (with `nodejs_compat`). Verify `@aws-sdk` packages work in Worker runtime.
+7. **Neon Postgres + Drizzle** keeps working. Drizzle has a HTTP driver that's CF-friendly.
+8. **Upstash Ratelimit + Redis** is HTTP-based, works anywhere.
+9. **Stripe** keeps working.
+10. **next-auth v5 (Auth.js)** has a CF adapter; verify session storage continues to work.
+11. **`@vercel/analytics`** → swap to CF Web Analytics or remove.
+12. Workspace count is so large that Workers Bundle Size limit (10MB compressed for free, 100MB on paid) needs to be checked early. The OpenNext bundle for an app this size may exceed free tier; **verify bundle size before assuming free plan works**. Likely needs the Workers paid plan ($5/mo).
+13. **Restart Symphony** with updated workflow that calls `wrangler deploy` instead of pushing to Vercel. The Symphony WORKFLOW.md needs editing to swap the deploy step.
+
+**Risk:** very high. This is a real product with paying users (Stripe). Recommend doing the other 8 first, building muscle memory, then planning a dedicated quantercise migration session with a maintenance window. Estimated time: full day.
+
+## Suggested execution order
+
+| Wave              | Projects                                                                   | Why this order                                                                             |
+| ----------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| 1 (recipe)        | wigglesburg.com → ashasreen.com → howoldamiactually.com → pr-cart          | All trivial, all static-ish. First one shakes out the recipe. Latter three are repetition. |
+| 2 (small app)     | coolfollowers.com → nyupuritytest.com                                      | API routes + middleware. Tests the OpenNext function-route conversion.                     |
+| 3 (vendor stacks) | saeshify.com (Supabase + cron) → chained.chat (Convex + Clerk + streaming) | Each adds one dimension of complexity.                                                     |
+| 4 (the boss)      | quantercise.com                                                            | After Symphony is paused and a maintenance window is scheduled.                            |
+
+## What this session will and won't do
+
+**Will (this session, if you say go):**
+
+- Open this doc as a PR.
+- For each of the 4 wave-1 projects: clone (where missing), add `wrangler.toml` + `open-next.config.ts`, run `opennextjs-cloudflare build`, push to GitHub on a `migrate/cloudflare-workers` branch, optionally deploy to `*.workers.dev` for smoke testing.
+- Surface env-var inventory per project so you know what to `wrangler secret put`.
+
+**Won't (this session, by design):**
+
+- Touch DNS at Namecheap. Every NS swap is your call once the Worker is verified.
+- Detach domains from Vercel projects. Same reason.
+- Migrate quantercise. Needs Symphony coordination and a planned window.
+- Migrate chained-chat or saeshify. Convex/Supabase auth flows need verification before cutover.
+- Delete Vercel projects. Rollback path stays open until you're confident.
+
+## Reference recipe (used by every project)
+
+```toml
+# wrangler.toml
+name = "<repo-name-or-domain>"
+compatibility_date = "2025-04-01"
+compatibility_flags = ["nodejs_compat"]
+account_id = "0f856093bdcd34a7da1bde5ee4385163"
+main = ".open-next/worker.js"
+workers_dev = true   # leave on during migration; flip to false after cutover
+
+[assets]
+directory = ".open-next/assets"
+binding = "ASSETS"
+
+[observability]
+enabled = true
+
+# Add after NS swap + zone created in CF dashboard:
+# [[routes]]
+# pattern = "<domain.com>"
+# custom_domain = true
+# zone_id = "<zone-id>"
+```
+
+```ts
+// open-next.config.ts
+import { defineCloudflareConfig } from "@opennextjs/cloudflare";
+export default defineCloudflareConfig({});
+```
+
+```jsonc
+// package.json additions
+{
+  "devDependencies": {
+    "@opennextjs/cloudflare": "^1.19.9",
+    "wrangler": "^4.90.0",
+  },
+}
+```
+
+```bash
+# build + deploy sequence
+pnpm install   # or npm install
+pnpm build     # next build
+npx opennextjs-cloudflare build   # produces .open-next/worker.js
+npx wrangler deploy                # publishes to *.workers.dev
+# verify, then add custom_domain route + redeploy
+```
+
+## DNS cutover sequence (per project, owner action)
+
+1. Add the domain as a zone in CF dashboard. CF generates two nameservers like `xyz.ns.cloudflare.com` + `abc.ns.cloudflare.com`.
+2. Log in to Namecheap, navigate to the domain, change nameservers from `dns1.registrar-servers.com` + `dns2.registrar-servers.com` to the two CF nameservers.
+3. Wait for propagation (`dig +short NS <domain>` should show `*.ns.cloudflare.com`). Typically 1-4 hours.
+4. In CF dashboard for that zone, set SSL/TLS mode to "Full" (or "Full (strict)" once cert is verified).
+5. Add `[[routes]] pattern = "<domain>" custom_domain = true zone_id = "<zone-id>"` to `wrangler.toml`. Re-deploy. Wrangler attaches the hostname.
+6. `curl -I https://<domain>` should report `cf-ray:` headers and `server: cloudflare`. Confirm.
+7. In Vercel dashboard for that project, detach the custom domain.
+8. Optionally: delete the Vercel project, remove the repo from the Vercel GitHub App's selected list.
+
+If step 6 fails: revert NS at Namecheap to point back at Vercel's nameservers (or the registrar's defaults pointing at the Vercel IP). Vercel reclaims serving.

--- a/docs/personal-cloud-architecture.md
+++ b/docs/personal-cloud-architecture.md
@@ -1,0 +1,235 @@
+# Personal Cloud Architecture
+
+Multi-month vision doc for the anipotts personal infrastructure. Companion to `docs/cloudflare-infrastructure.md` (deploy substrate) and `docs/per-project-vercel-migration.md` (project-by-project Vercel exit). This one is the _destination_ the migrations are walking toward.
+
+Last updated: 2026-05-13.
+
+## The pitch in one paragraph
+
+Stop thinking of `apps/admin` as "a dashboard that polls a server on the Mac Mini." Start thinking of the whole anipotts setup as a **personal cloud**: a graph of state living in Cloudflare Durable Objects, a SolidStart admin that subscribes via WebSocket (no polling, no SSR ceremony), Rudy as the human-facing input and output node on iMessage, the Mac Mini as one publisher among several (not the center), the iPhone as a first-class consumer and controller. Agents (Claude Code, Codex, Rudy, future) all hit the same `api.anipotts.com` Worker to read and write the graph. Realtime is the default. The mini can crash without the user-facing system going down.
+
+## Three planes
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  INPUT PLANE                                                    │
+│  ─────────────────                                              │
+│  iMessage → Rudy (Mini) → tool calls → state.write              │
+│  Email → Email Workers → state.write                            │
+│  Webhooks (Typefully, Postiz, Buttondown, GitHub) → state.write │
+│  Mini publisher daemons → ingest worker → state.write           │
+│  Manual via apps/admin-solid → state.write                      │
+└─────────────────────────────────────────────────────────────────┘
+                              ↓
+┌─────────────────────────────────────────────────────────────────┐
+│  STATE PLANE                                                    │
+│  ─────────────────                                              │
+│  workers/state (Hono on Workers, Bun-runtime build)             │
+│  Durable Objects (one class per "thing in your life"):          │
+│    MoneyState, ContentPipeline, BrandDeals, Inbox, LinkVault,   │
+│    SystemStats, SymphonyMonitor, RudyConvos, CodeStats,         │
+│    LinearIssues, CommitFeed, ...                                │
+│  D1 (anipotts-db) is the durable archive; DOs hydrate from it   │
+│  on cold start and snapshot back on a schedule.                 │
+│  R2 for blob assets (OG images, screenshots, brand artifacts).  │
+└─────────────────────────────────────────────────────────────────┘
+                              ↓
+┌─────────────────────────────────────────────────────────────────┐
+│  OUTPUT PLANE                                                   │
+│  ─────────────────                                              │
+│  apps/admin-solid (SolidStart) ← WebSocket → DOs                │
+│  Rudy (iMessage proactive nudges to SELF tier only)             │
+│  iPhone (Apple Shortcuts → Worker → DO read/write,              │
+│           Web Push from DO state changes)                       │
+│  api.anipotts.com (Hono router exposing DOs as REST + WS)       │
+│  apps/www tile widgets (live status bar, pulled from DOs)       │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+Anyone in the input plane can mutate state. The state plane is the only thing both planes touch (input writes, output reads). The output plane is realtime by construction; nothing polls.
+
+## Stack choices
+
+| Layer                  | Choice                                                                                                                   | Why                                                                                                                                                                                                                  |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Frontend (admin)       | **SolidStart** + Cloudflare adapter                                                                                      | New for Ani (he has Next/React fatigue, has touched Svelte at Structured AI). Solid signals model = compute graph that reacts to inputs, native fit for "here are 30 cells, each subscribed to a different DO field" |
+| Backend (state)        | **Hono** on Cloudflare Workers, **Bun runtime** for build/dev                                                            | Hono is Worker-native, tiny, integrates with DOs in a few lines, has clean types. Bun for speed in build/dev. Production runtime is workerd via `wrangler deploy`.                                                   |
+| State store            | **Cloudflare Durable Objects**                                                                                           | Per-instance compute + storage with built-in WebSocket support. Strongly consistent. Single-writer per DO, multi-reader. Replaces both Redis and SSE-via-mini                                                        |
+| Archive                | **D1** (existing `anipotts-db`)                                                                                          | Already exists, already wired to ingest + admin. DOs snapshot here on schedule for query/restore                                                                                                                     |
+| Blob                   | **R2**                                                                                                                   | Free egress. Stores OG images, screenshots, brand assets, Logpush dumps                                                                                                                                              |
+| AI primitives          | **Workers AI** + **Vectorize** + **AI Gateway**                                                                          | Edge inference for small models (classify emails, embed posts), vector search for "what was I working on March 14," provider routing for Claude/OpenAI/etc                                                           |
+| Auth                   | **CF Access** for admin (already in use), API tokens for agents (rotate via Workers Secrets)                             | No new auth vendor needed                                                                                                                                                                                            |
+| Email in/out           | **Email Workers** (in), **Email Workers `send_email` binding** (out, replaces Resend per PR #30)                         | Already planned; this fits the same model                                                                                                                                                                            |
+| iPhone integration     | **Apple Shortcuts** → Worker, **Web Push** from DO events                                                                | No new app needed; Shortcuts gives voice + share-sheet + automation                                                                                                                                                  |
+| Browser-side rendering | **Workers Browser Rendering**                                                                                            | OG image generation, screenshot-as-a-service, headless tasks                                                                                                                                                         |
+| Observability          | **Workers Logs** (free), **Logpush to R2** (cheap retention), **Sentry on Workers** (errors), **CF Web Analytics** (RUM) | Already planned in `cloudflare-infrastructure.md`                                                                                                                                                                    |
+
+## Rudy's role (the keystone)
+
+Rudy is no longer a side project. Rudy is the **human-facing input/output of the entire personal cloud** for the iMessage channel, with proactive intelligence layered on top.
+
+Existing Rudy infra (per `~/.claude/rules/ani-infra-map.md` "Rudy Phase 1.5" section, all Mini-resident):
+
+- Code: `/Users/rudy/Code/projects/rudy/channel/server.ts`
+- Launcher: `/Users/rudy/bin/rudy-launcher.sh`
+- Plist: `/Users/rudy/Library/LaunchAgents/com.anipotts.rudy.plist`
+- MCP config: `/Users/rudy/.rudy/mcp.json`
+- Logs: `/Users/rudy/Library/Logs/rudy/`
+- Persona: `/Users/rudy/.rudy/persona.md`
+- Allowlists: `~/.rudy/{allow.txt,friends.txt}`
+- Architecture: launchd → tmux socket `-L rudy` → `claude` CLI with channel server → bun MCP child watching `chat.db` → emits `notifications/claude/channel` events → Opus 4.7 (1M context, Max plan) → `reach_out` via osascript
+
+What changes for Rudy in this architecture:
+
+| New capability                   | Implementation                                                                                                                                                                       | Tier scope                                       |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------ |
+| `state.read(do_name, query)`     | New MCP tool in `~/.rudy/mcp.json`. Calls Worker REST endpoint with API token.                                                                                                       | SELF + FRIENDS (read-only, hides sensitive DOs)  |
+| `state.write(do_name, mutation)` | New MCP tool. Calls Worker REST. Auth: SELF tier only.                                                                                                                               | SELF only                                        |
+| `state.subscribe(do_name)`       | New MCP tool. Opens WS to a DO, surfaces events back to Rudy's prompt context.                                                                                                       | SELF only                                        |
+| Proactive nudges                 | New bun process on Mini (`/Users/rudy/Code/projects/rudy/proactive/server.ts`). Subscribes to DO event streams. Decides when to send Ani an iMessage based on configurable policies. | SELF only (Ani's Apple ID handles + `allow.txt`) |
+
+Friends-tier semantics stay exactly the same as today: chat-only, no DO mutation, no `state.*` write tools, only `reach_out` allowed.
+
+Proactive policy examples (configurable in `~/.rudy/proactive.policy.yml`, owner-edited):
+
+- `SymphonyMonitor` emits `pr_merged_p0_closed` → Rudy texts: "QUA-47 closed, P0 down to zero. Want me to draft a 'shipped today' atom?"
+- `BrandDeals` emits `new_email_match` → Rudy texts: "Email from Viral Nation looks like next deal confirmation. Reply yes to add to ContentPipeline."
+- `Inbox` emits `unread_link_count > 10` → Rudy texts at 8pm: "10 saved links sitting unread. Want to triage 3 of them now?"
+- `MoneyState` emits `mrr_milestone_crossed` → Rudy texts the new MRR figure with a cheer.
+
+All proactive nudges are **suggestions** unless the policy is explicitly marked `safe-action`. Drafting an email is never auto-action. Saving a link to a DO bucket on Ani's instruction is.
+
+## Mac Mini's new role
+
+Today Mini is "the always-on server hosting the http API." That couples user-visible uptime to Mini's uptime.
+
+Tomorrow Mini is **a publisher** plus **the Rudy host**. It produces events and pushes them to a Cloudflare Worker. It does not host an http API that any user-facing client depends on.
+
+What stays on Mini:
+
+- Rudy server + bun MCP child (the iMessage channel)
+- Rudy proactive subsystem (new)
+- Symphony daemon (autonomous Quantercise loop)
+- The 21 launchd jobs (`com.pro.*` + `com.anipotts.rudy.*`) producing data
+- `cloudflared` tunnel for the (now-rare) cases that need direct Mini access
+- Tailscale node `ap-mini`
+
+What gets removed/downgraded on Mini:
+
+- `~/Code/active/mini-api` http server on port 3456: stops being the user-facing API. The same code can stay running for a transition period, but new admin code never calls it. Eventually delete.
+- The `*.mini.anipotts.com` wildcard DNS record on Cloudflare: replaced by explicit `api.mini.anipotts.com` (only one in use) → Universal SSL covers it free → cancel ACM ($10/mo saving). See `cloudflare-infrastructure.md` for the ACM analysis.
+
+What Mini publisher daemons look like:
+
+```ts
+// /Users/rudy/Code/projects/anipotts-publisher/src/index.ts
+// Runs as a launchd job under com.anipotts.publisher.<name>.plist.
+// Each job watches a specific local source and POSTs to the ingest worker.
+
+import { mintToken } from "./lib/auth";
+
+async function publish(event: {
+  source: string;
+  type: string;
+  payload: object;
+}) {
+  await fetch("https://anipotts-ingest.anipotts.workers.dev/events", {
+    method: "POST",
+    headers: {
+      "X-Ingest-Key": mintToken(),
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(event),
+  });
+}
+
+// Example: forward git commits across all ~/Code/projects/* watched repos
+// Example: forward system stats from claude-stats / disk-monitor / etc
+// Example: forward Symphony agent state changes
+```
+
+If the publisher fails (Mini offline, network blip), events queue locally and replay when connectivity returns. Idempotency keys on each event so the ingest worker can dedupe.
+
+## iPhone integration
+
+Apple Shortcuts is the lever. Two patterns:
+
+1. **Voice query**: Siri → Shortcut → Worker GET endpoint → returns text → Siri speaks it. Examples: "what's my MRR," "what's symphony doing," "what links did I save today."
+2. **Share-sheet write**: any app's share sheet → Shortcut → Worker POST endpoint → mutates DO. Examples: "save this tweet to Inbox," "queue this URL for the chained-chat-redesign series."
+
+Web Push from CF Worker → APNs → iPhone notification. Triggered by DO events policy-matched against a per-device subscription. Examples: brand deal email matched, Symphony milestone, content publish confirmed.
+
+iMessage stays the conversational interface (Rudy). Shortcuts is the verb-only interface (no chat, just commands). Both feed into the same DOs.
+
+## What from current infra merges, keeps, kills
+
+(Authoritative table; supersedes the smaller table in the previous section.)
+
+| Existing thing                                                                                 | Action                       | Reasoning                                                                                                                                                                    |
+| ---------------------------------------------------------------------------------------------- | ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Rudy Phase 1.5** (Mini, bun MCP, Opus 4.7, allowlist, persona)                               | **KEEP + EXTEND**            | Becomes the human-facing input/output. Add `state.read/write/subscribe` tools. Add proactive subsystem.                                                                      |
+| **`packages/lib/src/mini/{stream.ts,client.ts}`** (admin's REST + SSE clients into Mini)       | **KILL eventually**          | Replaced by WebSocket connections from admin-solid to DOs. Keep during transition window so existing admin keeps working.                                                    |
+| **`services/mini-api.ts`** (declarative service manifest)                                      | **DOWNGRADE**                | Mini stops being a server. Manifest can shrink to "the rudy + publishers run here" rather than "this http service exists."                                                   |
+| **`~/Code/active/mini-api`** (http server on Mini, port 3456)                                  | **EVENTUALLY KILL**          | After admin-solid + DOs reach parity for every endpoint Mini exposes. Until then, keep running for backward compat.                                                          |
+| **`workers/ingest`** (cron, every minute, hits Mini /health, writes D1)                        | **EXPAND**                   | Becomes the receiver for Mini publisher events. Existing rollups stay. New endpoint `POST /events` for publishers. Continues writing to D1; also calls into the relevant DO. |
+| **`workers/weekly-email`**                                                                     | **KEEP unchanged**           | Cron job that reads from D1 and sends weekly email. Independent.                                                                                                             |
+| **D1 `anipotts-db`**                                                                           | **KEEP**                     | The durable archive. DOs snapshot here on schedule. Existing tables stay.                                                                                                    |
+| **Rudy's launchd jobs on Mini** (browser-history, sync, system-state)                          | **KEEP, REROUTE OUTPUTS**    | Same scripts, but they POST to ingest instead of writing local files. Last hop becomes "publish event" not "write to disk."                                                  |
+| **`apps/admin`** (Next 16 + OpenNext, polling REST/SSE to Mini)                                | **REWRITE in parallel**      | Build `apps/admin-solid` alongside on `admin-v2.anipotts.com`. Migrate tile-by-tile. When admin-v2 has full parity, swap DNS, delete `apps/admin`. No big-bang rewrite.      |
+| **`@anipottsbuilds` content system** + Postiz + Typefully + Buttondown                         | **KEEP, ADD WEBHOOKS**       | Each integration emits webhooks → ingest worker → `ContentPipeline` DO. Dashboard tile flips on publish. No polling.                                                         |
+| **Symphony daemon** (Mini, autonomous Quantercise loop)                                        | **KEEP, ADD EVENT EMISSION** | Emits status events → `SymphonyMonitor` DO. Admin sees live agent state without ssh.                                                                                         |
+| **D1 tables**: `business_data`, `daily_rollups`, `analytics_events`, `thoughts`, `atoms`, etc. | **KEEP**                     | DO snapshots write here. Reads continue to work.                                                                                                                             |
+| **email-labeler** (`~/Content/tools/email-labeler/`)                                           | **EXTEND**                   | Labeled emails optionally trigger ingest worker → updates relevant DO (brand deal email → `BrandDeals` DO). Existing dual-write to YAML + D1 stays.                          |
+| **iMessage MCP + cc plugin** (Rudy's transport)                                                | **KEEP unchanged**           | Rudy's whole transport layer stays. New `state.*` MCP tools added.                                                                                                           |
+| **`*.mini.anipotts.com` wildcard DNS**                                                         | **KILL**                     | Replace with explicit `api.mini.anipotts.com` record. Universal SSL covers it free. Cancels ACM ($10/mo).                                                                    |
+| **Cloudflare Tunnel `cloudflared-mini-api.plist`**                                             | **KEEP**                     | Exposes Mini for the rare ssh-via-domain case + transition-window backstop for old admin REST/SSE.                                                                           |
+| **Workers Cron Triggers**                                                                      | **NEW**                      | Replace any remaining "X polls Y" pattern with cron + DO mutation.                                                                                                           |
+| **Workers Logs** (`[observability] enabled = true` in every wrangler.toml)                     | **NEW (planned)**            | Per `cloudflare-infrastructure.md` adoption list.                                                                                                                            |
+| **CF Web Analytics**                                                                           | **NEW (planned)**            | Per `cloudflare-infrastructure.md`.                                                                                                                                          |
+
+## Build order (small honest steps)
+
+Each step is a weekend or less. Each is shippable on its own.
+
+1. **`workers/state` with one DO: `LinkVault`.** ~50 lines. WebSocket endpoint that streams the current list of links and broadcasts mutations. CLI script to test from terminal. Proves the pattern.
+2. **Add `state.write` tool to Rudy.** New MCP tool wired into `~/.rudy/mcp.json`. SELF-tier auth check. Now you can text Rudy "save https://..." and watch the DO update via `wrangler tail`. Proves the input plane.
+3. **`apps/admin-solid` skeleton with one component: `<LinkVault />`.** SolidStart static build deployed to a Worker. Opens WebSocket to `LinkVault` DO. Renders live list. (This is when you find out whether you love Solid; it's also a recoverable bet because the rest of the architecture doesn't depend on it.)
+4. **Mini publisher daemon for one event type** (commits in `~/Code/projects/**` is a good starter). New launchd job under `com.anipotts.publisher.commits.plist`. POSTs to ingest worker. Ingest writes to a new `CodeStats` DO. Add `<CommitFeed />` component to admin-solid. Proves the publisher pattern.
+5. **Proactive subsystem v0.** New bun process on Mini (`~/Code/projects/rudy/proactive/server.ts`). Watches `CodeStats` DO. Texts you via Rudy when "first commit of the day" event fires. Proves the proactive pattern. Limit: SELF tier only, single hardcoded policy.
+6. **iPhone Shortcut: "what's my MRR"** + corresponding worker endpoint + `MoneyState` DO. Trivial after steps 1-3 are done. Proves the iPhone integration pattern.
+
+After step 6, all four patterns work end to end. Everything that comes later (more DOs, more admin tiles, more proactive policies, more Shortcuts, OG image generation, email mutators, etc.) is _additive_. No more architectural reach.
+
+## Build alongside, not big-bang
+
+Ani's decision (2026-05-13): build `apps/admin-solid` alongside `apps/admin`, migrate one tile at a time. When `admin-v2` has parity, swap DNS, delete `apps/admin`. No big-bang rewrite, no maintenance window.
+
+Worker name: `anipotts-admin-v2` (or just `anipotts-admin-solid`).
+Hostname: `admin-v2.anipotts.com` during transition. Swap to `admin.anipotts.com` at parity.
+Auth: CF Access, same group as current admin.
+
+## What this is not
+
+- It is not a refactor of every existing repo. The 9-project Vercel migration (`docs/per-project-vercel-migration.md`) is unrelated to this; those are domain moves, not architectural moves.
+- It is not a new product. It's personal infra. If it spawns a productized version later, that's downstream of using it for a year.
+- It is not "rip out everything tomorrow." It's strictly additive (new workers, new DO classes, new admin app) with one explicit kill (`*.mini.anipotts.com` wildcard) that's purely a billing/cleanup move.
+- It is not Workers Realtime (audio/video calls). Explicitly deferred per Ani's call (2026-05-13).
+- It is not a replacement for any external SaaS Ani actually pays for. Stripe stays Stripe. Linear stays Linear. PostHog stays PostHog. The DO graph subscribes to webhooks from these and exposes them as live state, not as substitutes.
+
+## Open questions to settle before step 1
+
+- **Token format for agent auth on `api.anipotts.com`.** Per-agent token stored in `wrangler secret`? JWT signed by a Worker? Decide before adding the Hono router.
+- **DO snapshot cadence to D1.** Per-mutation? Hourly? Per-DO config? Affects D1 row growth and cold-start hydration time.
+- **WebSocket reconnect strategy.** Native browser WS auto-reconnects badly. Use a small client lib like `partysocket` or write our own. Decide before admin-solid step 3.
+- **Where `apps/admin-solid` lives.** Inside the anipotts.com monorepo (`apps/admin-solid`) or in a sibling repo (`anipotts/admin-solid`)? Monorepo is consistent with current pattern; sibling avoids Next 16 + Solid + Tailwind v4 toolchain conflicts in one workspace. Lean: monorepo (Solid has Tailwind v4 support; turborepo handles separate framework apps cleanly).
+- **Who hosts the proactive subsystem.** Mini (next to Rudy) keeps the dependency contained; a separate Worker (cron-driven) is more reliable but loses the local context the Mini has. Lean: Mini for v0 (simpler), revisit if Mini reliability becomes a constraint.
+
+## Cross-references
+
+- Deploy substrate + repo-level adoption + monitoring posture: `docs/cloudflare-infrastructure.md`
+- Per-project Vercel exit plan for 9 domain-bearing projects: `docs/per-project-vercel-migration.md`
+- Current state of all in-flight PRs (this repo): see open PRs #40, #41, #42 + cross-account `wigglesburg.com` PR #1 (first migration)
+
+## Update rule
+
+When you ship something that changes any plane (a new DO class, a new publisher, a new admin tile, a new Rudy tool), update this doc in the same PR. The doc is the canonical mental model; if it drifts from reality, throw away whichever is wrong.


### PR DESCRIPTION
## Summary

Adds `docs/cloudflare-infrastructure.md`, a living document that captures the actual deploy state of the monorepo, plus the broader account-wide Vercel inventory and per-domain migration scope.

## Why now

Sister PRs #40 (labs to CF Workers) and #41 (delete vestigial vercel.json) close out the "migrate off Vercel" thread for this repo. But the wider goal is moving every domain-bearing project across the anipotts Vercel account onto Cloudflare. This doc scopes both.

## What's in the doc

**Repo-scoped (what we already knew):**

- TL;DR naming the punchline: this repo is already 100% Cloudflare; `vercel ls` confirmed zero deployments.
- Current state of the deploy graph as a table.
- Vestigial inventory with action per item.
- Adoption priority list (P0-P3) covering Workers Logs, CF Web Analytics, Logpush to R2, Sentry on Workers, Smart Placement, Workers Versions for previews, CF Images, Zaraz, Email Routing, Turnstile, D1 replicas, Hyperdrive.
- Monitoring posture proposal (synthetic, RUM, product, errors, raw logs, email, DB, CI).
- Preview environments plan via `wrangler versions upload`.
- PR triage table for all 8 open PRs with merge order recommendations.
- Issue triage table for all 20 open issues by P0-P3.
- 4-week roadmap.

**Account-wide (new section):**

- Inventory of all 24 Vercel projects under the `anipotts` scope, captured 2026-05-13 via `vercel projects ls` + `vercel domains ls` + per-domain DNS + curl probes.
- 2 vestigial Vercel projects to delete (`anipotts.com` claim + `linear-tinkering-starlight` stub).
- 12 active domain-bearing projects sorted into 5 migration waves (small-static first, Quantercise last because Symphony depends on its deploy URL).
- 11 playground `*.vercel.app` projects to leave on Vercel per owner direction.
- GitHub App scoping note: switch to "Only select repositories" instead of uninstalling (the app is on 127 repos).
- Per-project migration template: assess (framework / runtime / data deps), scaffold Worker (`wrangler.toml` + `open-next.config.ts`), smoke on `*.workers.dev`, swap domain, decommission Vercel.
- Explicit decisions to settle before starting (env vars, Vercel KV/Postgres/Blob equivalents, Quantercise/Symphony coordination).

## Test plan

- [ ] Doc renders correctly on GitHub.
- [ ] Tables format correctly.
- [ ] No broken links.
- [ ] PR/issue numbers reference real items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a living Cloudflare deployment & infrastructure guide detailing deploy flow, worker targets, hostnames, build method, bindings, cron/access controls, monitoring posture, and preview workflow.
  * Added a per-project Vercel→Cloudflare migration runbook with per-site risk assessments, migration recipe, DNS cutover and rollback guidance, execution order, and inventory/pruning recommendations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anipotts/anipotts.com/pull/42)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->