### PR TITLE
chore(urls): rename admin -> legacy-admin, free up admin for solid v2

### DIFF
--- a/apps/admin-solid/wrangler.toml
+++ b/apps/admin-solid/wrangler.toml
@@ -14,12 +14,20 @@ enabled = true
 
 # Build-time inlined as PUBLIC_*; runtime override available via wrangler vars
 [vars]
-PUBLIC_STATE_API = "https://anipotts-state.anipotts.workers.dev"
+PUBLIC_STATE_API = "https://api.anipotts.com"
 
-# Custom domain. Uncomment after admin-v2.anipotts.com is added in CF dashboard
-# (or auto-bound via wrangler routes once token has zone:edit).
+# Custom domain. Claims admin.anipotts.com directly (legacy Next admin moves
+# to legacy-admin.anipotts.com in apps/admin/wrangler.toml). Cutover sequence
+# documented in apps/admin/wrangler.toml.
+#
+# Either:
+#   (a) Add via CF dashboard once the legacy admin has vacated the hostname:
+#       Workers & Pages > anipotts-admin-solid > Settings > Triggers >
+#       Add Custom Domain > admin.anipotts.com
+#   (b) Set CLOUDFLARE_API_TOKEN with Zone:Edit + Workers Routes:Edit and
+#       uncomment the block below; `wrangler deploy` will manage the binding.
 #
 # [[routes]]
-# pattern = "admin-v2.anipotts.com"
+# pattern = "admin.anipotts.com"
 # custom_domain = true
 # zone_id = "d56476e2905a2a19ad86aaa4b7c719c2"

--- a/apps/admin/wrangler.toml
+++ b/apps/admin/wrangler.toml
@@ -5,9 +5,18 @@ account_id = "0f856093bdcd34a7da1bde5ee4385163"
 main = ".open-next/worker.js"
 workers_dev = false
 
-# Custom domain
+# Custom domain. Renamed from admin.anipotts.com to legacy-admin.anipotts.com
+# on 2026-05-14 to free up admin.anipotts.com for the SolidStart admin v2
+# (apps/admin-solid). Cutover sequence:
+#   1. Land this PR (worker still serves on whichever route is bound).
+#   2. In CF dashboard: Workers & Pages > anipotts-admin > Settings > Triggers.
+#      Add Custom Domain "legacy-admin.anipotts.com". Wait for cert (~30s).
+#   3. Update CF Access policy to cover legacy-admin.anipotts.com (same group).
+#   4. Verify legacy-admin loads + auth works.
+#   5. Remove "admin.anipotts.com" custom domain from this Worker.
+#   6. Add "admin.anipotts.com" to anipotts-admin-solid Worker (PR #44).
 [[routes]]
-pattern = "admin.anipotts.com/*"
+pattern = "legacy-admin.anipotts.com/*"
 zone_id = "d56476e2905a2a19ad86aaa4b7c719c2"
 
 [assets]


### PR DESCRIPTION
## Summary

Per the personal-cloud-architecture build (PR #44), the SolidStart admin v2 is taking over `admin.anipotts.com` directly (no `admin-v2` intermediate hostname). The legacy Next.js admin moves to `legacy-admin.anipotts.com` to stay accessible during the parity period.

## Changes

- **`apps/admin/wrangler.toml`** route: `admin.anipotts.com/*` to `legacy-admin.anipotts.com/*`
- **`apps/admin-solid/wrangler.toml`**:
  - `PUBLIC_STATE_API` switched from `*.workers.dev` to `https://api.anipotts.com`
  - Custom-domain TODO updated to claim `admin.anipotts.com` directly

## Owner cutover sequence (NOT in this PR)

1. CF dashboard: add custom domain `legacy-admin.anipotts.com` to `anipotts-admin` Worker
2. Update CF Access policy to cover `legacy-admin` (same access group)
3. Verify `legacy-admin.anipotts.com` loads + auth
4. Remove `admin.anipotts.com` custom domain from `anipotts-admin`
5. Add `admin.anipotts.com` custom domain to `anipotts-admin-solid` Worker
6. Add `api.anipotts.com` custom domain to `anipotts-state` Worker

All three binds need the CF dashboard or a `CLOUDFLARE_API_TOKEN` with `Zone:Edit` + `Workers Routes:Edit` scopes. The wrangler OAuth token used in this session is `Zone:Read` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)