### PR TITLE
chore(routes): wrangler.toml reflects live custom-domain binds

### DIFF
--- a/apps/admin-solid/wrangler.toml
+++ b/apps/admin-solid/wrangler.toml
@@ -16,18 +16,10 @@ enabled = true
 [vars]
 PUBLIC_STATE_API = "https://api.anipotts.com"
 
-# Custom domain. Claims admin.anipotts.com directly (legacy Next admin moves
-# to legacy-admin.anipotts.com in apps/admin/wrangler.toml). Cutover sequence
-# documented in apps/admin/wrangler.toml.
-#
-# Either:
-#   (a) Add via CF dashboard once the legacy admin has vacated the hostname:
-#       Workers & Pages > anipotts-admin-solid > Settings > Triggers >
-#       Add Custom Domain > admin.anipotts.com
-#   (b) Set CLOUDFLARE_API_TOKEN with Zone:Edit + Workers Routes:Edit and
-#       uncomment the block below; `wrangler deploy` will manage the binding.
-#
-# [[routes]]
-# pattern = "admin.anipotts.com"
-# custom_domain = true
-# zone_id = "d56476e2905a2a19ad86aaa4b7c719c2"
+# Custom domain bound 2026-05-14 via CF API. Lives at admin.anipotts.com,
+# fronted by the existing Cloudflare Access policy that previously protected
+# the legacy Next admin (which now serves at legacy-admin.anipotts.com).
+[[routes]]
+pattern = "admin.anipotts.com"
+custom_domain = true
+zone_id = "d56476e2905a2a19ad86aaa4b7c719c2"

--- a/apps/admin/wrangler.toml
+++ b/apps/admin/wrangler.toml
@@ -5,18 +5,12 @@ account_id = "0f856093bdcd34a7da1bde5ee4385163"
 main = ".open-next/worker.js"
 workers_dev = false
 
-# Custom domain. Renamed from admin.anipotts.com to legacy-admin.anipotts.com
-# on 2026-05-14 to free up admin.anipotts.com for the SolidStart admin v2
-# (apps/admin-solid). Cutover sequence:
-#   1. Land this PR (worker still serves on whichever route is bound).
-#   2. In CF dashboard: Workers & Pages > anipotts-admin > Settings > Triggers.
-#      Add Custom Domain "legacy-admin.anipotts.com". Wait for cert (~30s).
-#   3. Update CF Access policy to cover legacy-admin.anipotts.com (same group).
-#   4. Verify legacy-admin loads + auth works.
-#   5. Remove "admin.anipotts.com" custom domain from this Worker.
-#   6. Add "admin.anipotts.com" to anipotts-admin-solid Worker (PR #44).
+# Custom domain bound 2026-05-14 via CF API. Lives at legacy-admin.anipotts.com.
+# Renamed from admin.anipotts.com to make room for the SolidStart admin v2
+# (apps/admin-solid) which now claims the canonical admin.anipotts.com slot.
 [[routes]]
-pattern = "legacy-admin.anipotts.com/*"
+pattern = "legacy-admin.anipotts.com"
+custom_domain = true
 zone_id = "d56476e2905a2a19ad86aaa4b7c719c2"
 
 [assets]

--- a/workers/state/wrangler.toml
+++ b/workers/state/wrangler.toml
@@ -19,12 +19,10 @@ new_sqlite_classes = ["LinkVault"]
 # CORS allowlist for the admin frontend. Override at deploy time
 # with `wrangler secret put` if a different origin needs access.
 [vars]
-ALLOWED_ORIGINS = "https://admin-v2.anipotts.com,http://localhost:3000,http://localhost:3001"
+ALLOWED_ORIGINS = "https://admin.anipotts.com,http://localhost:3000,http://localhost:3001"
 
-# Custom domain bind. Uncomment after the api.anipotts.com hostname
-# is bound to this Worker (do via wrangler routes or CF dashboard).
-#
-# [[routes]]
-# pattern = "api.anipotts.com"
-# custom_domain = true
-# zone_id = "d56476e2905a2a19ad86aaa4b7c719c2"
+# Custom domain bound 2026-05-14 via CF API. Lives at api.anipotts.com.
+[[routes]]
+pattern = "api.anipotts.com"
+custom_domain = true
+zone_id = "d56476e2905a2a19ad86aaa4b7c719c2"


### PR DESCRIPTION
Three custom-domain binds were applied via CF API in the prior session. Updating wrangler.toml so the file reflects live state instead of commented placeholders.

## Live binds (set via API earlier)

- `api.anipotts.com` → `anipotts-state` (Hono + LinkVault DO)
- `legacy-admin.anipotts.com` → `anipotts-admin` (legacy Next admin)
- `admin.anipotts.com` → `anipotts-admin-solid` (SolidStart, fronted by existing CF Access policy)

Plus: `ALLOWED_ORIGINS` in workers/state updated from `admin-v2.*` to `admin.*` to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)