### PR TITLE
feat(personal-cloud): step 4. CodeStats DO + Mini commit publisher

### DIFF
--- a/apps/admin-solid/src/app.css
+++ b/apps/admin-solid/src/app.css
@@ -159,3 +159,37 @@ form.add button:disabled {
   opacity: 0.5;
   cursor: wait;
 }
+
+ul.commits {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+ul.commits li {
+  padding: 0.875rem 0;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.commit-line {
+  display: flex;
+  gap: 0.625rem;
+  align-items: baseline;
+  font-size: 0.95rem;
+}
+
+.commit-sha {
+  font-family: var(--font-mono);
+  color: var(--muted);
+  font-size: 0.8rem;
+  flex-shrink: 0;
+}
+
+.commit-subject {
+  color: var(--text);
+  font-weight: 500;
+  word-break: break-word;
+}

--- a/apps/admin-solid/src/components/CommitFeed.tsx
+++ b/apps/admin-solid/src/components/CommitFeed.tsx
@@ -1,0 +1,97 @@
+import { createSignal, For, onCleanup, onMount, Show } from "solid-js";
+import { isServer } from "solid-js/web";
+import { StateClient, type ConnectionState } from "~/lib/state-client";
+
+type Commit = {
+  sha: string;
+  repo: string;
+  subject: string;
+  author: string;
+  ts: string;
+  branch?: string;
+};
+
+type CodeStatsEvent =
+  | { type: "snapshot"; commits: Commit[] }
+  | { type: "commit.added"; commit: Commit };
+
+const STATE_API =
+  (import.meta.env.VITE_PUBLIC_STATE_API as string | undefined) ??
+  "https://anipotts-state.anipotts.workers.dev";
+
+function formatRelative(iso: string): string {
+  const then = new Date(iso).getTime();
+  const now = Date.now();
+  const diff = Math.max(0, now - then);
+  const sec = Math.floor(diff / 1000);
+  if (sec < 60) return `${sec}s ago`;
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const day = Math.floor(hr / 24);
+  if (day < 30) return `${day}d ago`;
+  return new Date(iso).toLocaleDateString();
+}
+
+export function CommitFeed() {
+  const [commits, setCommits] = createSignal<Commit[]>([]);
+  const [conn, setConn] = createSignal<ConnectionState>("connecting");
+
+  let client: StateClient<CodeStatsEvent> | null = null;
+
+  onMount(() => {
+    if (isServer) return;
+    client = new StateClient<CodeStatsEvent>({
+      url: `${STATE_API.replace(/^http/, "ws")}/api/commits/ws`,
+      onState: setConn,
+      onEvent: (event) => {
+        if (event.type === "snapshot") setCommits(event.commits);
+        if (event.type === "commit.added") {
+          setCommits((prev) => [
+            event.commit,
+            ...prev.filter((c) => c.sha !== event.commit.sha),
+          ]);
+        }
+      },
+    });
+  });
+
+  onCleanup(() => client?.close());
+
+  return (
+    <section>
+      <h2>
+        <span class="live-dot" data-state={conn()} />
+        CodeStats
+      </h2>
+
+      <Show
+        when={commits().length > 0}
+        fallback={
+          <p class="empty">
+            No commits yet. Mini publisher posts here when it sees new commits in{" "}
+            <span class="muted">~/Code/projects/**</span>.
+          </p>
+        }
+      >
+        <ul class="commits">
+          <For each={commits()}>
+            {(commit) => (
+              <li>
+                <div class="commit-line">
+                  <span class="commit-sha">{commit.sha.slice(0, 7)}</span>
+                  <span class="commit-subject">{commit.subject}</span>
+                </div>
+                <span class="muted">
+                  {commit.repo}
+                  {commit.branch ? ` · ${commit.branch}` : ""} · {formatRelative(commit.ts)}
+                </span>
+              </li>
+            )}
+          </For>
+        </ul>
+      </Show>
+    </section>
+  );
+}

--- a/apps/admin-solid/src/routes/index.tsx
+++ b/apps/admin-solid/src/routes/index.tsx
@@ -1,3 +1,4 @@
+import { CommitFeed } from "~/components/CommitFeed";
 import { LinkVaultPanel } from "~/components/LinkVaultPanel";
 
 export default function Home() {
@@ -9,6 +10,7 @@ export default function Home() {
         polling.
       </p>
       <LinkVaultPanel />
+      <CommitFeed />
     </main>
   );
 }

--- a/scripts/mini/README.md
+++ b/scripts/mini/README.md
@@ -1,0 +1,56 @@
+# Mini publishers
+
+Scripts that run on `ap-mini` and POST events to the state worker
+(`api.anipotts.com`). One launchd job per event type, each on its own cadence.
+
+## Install on Mini
+
+```bash
+# 1. Pull the repo on Mini (one time)
+ssh mini "cd ~/Code/projects && git clone https://github.com/anipotts/anipotts.com.git"
+
+# 2. Generate a publish key (any random string)
+KEY=$(openssl rand -hex 32)
+ssh mini "mkdir -p ~/.anipotts && echo '$KEY' > ~/.anipotts/state-publish.key && chmod 600 ~/.anipotts/state-publish.key"
+
+# 3. Set the matching wrangler secret on the state worker (run on MacBook)
+echo -n "$KEY" | wrangler secret put STATE_PUBLISH_KEY --config workers/state/wrangler.toml
+
+# 4. Symlink the plist into LaunchAgents on Mini
+ssh mini 'ln -sf ~/Code/projects/anipotts.com/scripts/mini/com.anipotts.publisher.commits.plist ~/Library/LaunchAgents/com.anipotts.publisher.commits.plist'
+
+# 5. Patch the launchd plist to source the key (one time)
+# launchd plists do not interpolate from files, so wrap the script in a
+# shell launcher OR add the key as an EnvironmentVariables entry. Easiest:
+ssh mini 'launchctl setenv STATE_PUBLISH_KEY "'$KEY'"'
+
+# 6. Bootstrap the agent
+ssh mini 'launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.anipotts.publisher.commits.plist'
+ssh mini 'launchctl kickstart -k gui/$(id -u)/com.anipotts.publisher.commits'
+
+# 7. Watch logs
+ssh mini 'tail -f ~/Library/Logs/anipotts/commit-publisher.*.log'
+```
+
+## How it works
+
+- Every 5 minutes, `commit-publisher.ts` walks `~/Code/projects/**`
+- For each git repo it finds, reads commits newer than the cursor
+  (`~/.anipotts/commit-publisher.cursor.json`), capped at 50/repo/run
+- POSTs to `https://api.anipotts.com/api/commits` with `Bearer
+$STATE_PUBLISH_KEY`
+- The state worker forwards to the `CodeStats` Durable Object, which
+  broadcasts `commit.added` events to every connected admin client
+
+## Verify end-to-end
+
+After install, open `https://admin.anipotts.com`. The CodeStats panel
+should populate within 5 minutes (or immediately if you `kickstart -k`).
+The connection dot turns green when the WebSocket is live.
+
+## Filter by author
+
+If the Mini scans repos that include other peoples' commits (e.g. open
+source forks), set `AUTHOR_FILTER=anipotts` or `AUTHOR_FILTER=ani.potts`
+in the launchd plist `EnvironmentVariables` block to publish only your
+own commits.

--- a/scripts/mini/com.anipotts.publisher.commits.plist
+++ b/scripts/mini/com.anipotts.publisher.commits.plist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.anipotts.publisher.commits</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/opt/homebrew/bin/bun</string>
+        <string>/Users/rudy/Code/projects/anipotts.com/scripts/mini/commit-publisher.ts</string>
+    </array>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <key>STATE_API</key>
+        <string>https://api.anipotts.com</string>
+        <key>COMMIT_ROOTS</key>
+        <string>/Users/rudy/Code/projects</string>
+    </dict>
+
+    <key>StartInterval</key>
+    <integer>300</integer>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>StandardOutPath</key>
+    <string>/Users/rudy/Library/Logs/anipotts/commit-publisher.out.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/Users/rudy/Library/Logs/anipotts/commit-publisher.err.log</string>
+</dict>
+</plist>

--- a/scripts/mini/commit-publisher.ts
+++ b/scripts/mini/commit-publisher.ts
@@ -1,0 +1,190 @@
+#!/usr/bin/env bun
+/**
+ * Mini commit publisher. Walks ~/Code/projects/** , finds git repos,
+ * extracts commits newer than the per-repo cursor, POSTs them to the
+ * state worker. Runs every 5 minutes via launchd on ap-mini.
+ *
+ * Env:
+ *   STATE_API           default https://api.anipotts.com
+ *   STATE_PUBLISH_KEY   required, bearer token for /api/commits
+ *   COMMIT_ROOTS        colon-separated dirs to scan, default ~/Code/projects
+ *   CURSOR_FILE         default ~/.anipotts/commit-publisher.cursor.json
+ *   MAX_PER_REPO        default 50 (cap on commits sent per repo per run)
+ *   AUTHOR_FILTER       optional substring; only publish commits whose author
+ *                       email contains this string. Default: no filter.
+ */
+
+import { spawnSync } from "node:child_process";
+import { mkdirSync, readFileSync, writeFileSync, existsSync, readdirSync, statSync } from "node:fs";
+import { dirname, join, basename } from "node:path";
+import { homedir } from "node:os";
+
+const STATE_API = process.env.STATE_API ?? "https://api.anipotts.com";
+const PUBLISH_KEY = process.env.STATE_PUBLISH_KEY;
+const ROOTS = (process.env.COMMIT_ROOTS ?? join(homedir(), "Code/projects")).split(":");
+const CURSOR_FILE =
+  process.env.CURSOR_FILE ?? join(homedir(), ".anipotts/commit-publisher.cursor.json");
+const MAX_PER_REPO = Number(process.env.MAX_PER_REPO ?? "50");
+const AUTHOR_FILTER = process.env.AUTHOR_FILTER;
+
+if (!PUBLISH_KEY) {
+  console.error("STATE_PUBLISH_KEY env var required");
+  process.exit(1);
+}
+
+type Cursor = Record<string, string>;
+type Commit = {
+  sha: string;
+  repo: string;
+  subject: string;
+  author: string;
+  ts: string;
+  branch?: string;
+  parentCount?: number;
+};
+
+function loadCursor(): Cursor {
+  if (!existsSync(CURSOR_FILE)) return {};
+  try {
+    return JSON.parse(readFileSync(CURSOR_FILE, "utf8")) as Cursor;
+  } catch {
+    return {};
+  }
+}
+
+function saveCursor(cursor: Cursor): void {
+  mkdirSync(dirname(CURSOR_FILE), { recursive: true });
+  writeFileSync(CURSOR_FILE, JSON.stringify(cursor, null, 2));
+}
+
+function findGitRepos(roots: string[], maxDepth = 4): string[] {
+  const repos: string[] = [];
+  for (const root of roots) {
+    if (!existsSync(root)) continue;
+    walk(root, 0, maxDepth, repos);
+  }
+  return repos;
+}
+
+function walk(dir: string, depth: number, maxDepth: number, out: string[]): void {
+  if (depth > maxDepth) return;
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return;
+  }
+  if (entries.includes(".git")) {
+    out.push(dir);
+    return;
+  }
+  for (const entry of entries) {
+    if (entry.startsWith(".") || entry === "node_modules") continue;
+    const child = join(dir, entry);
+    let st;
+    try {
+      st = statSync(child);
+    } catch {
+      continue;
+    }
+    if (st.isDirectory()) walk(child, depth + 1, maxDepth, out);
+  }
+}
+
+function git(repo: string, args: string[]): string {
+  const result = spawnSync("git", ["-C", repo, ...args], {
+    encoding: "utf8",
+    maxBuffer: 16 * 1024 * 1024,
+  });
+  if (result.status !== 0) {
+    throw new Error(`git ${args.join(" ")} in ${repo} failed: ${result.stderr.trim()}`);
+  }
+  return result.stdout;
+}
+
+function readCommits(repo: string, sinceSha: string | undefined): Commit[] {
+  const repoName = basename(repo);
+  let branch = "";
+  try {
+    branch = git(repo, ["rev-parse", "--abbrev-ref", "HEAD"]).trim();
+  } catch {
+    branch = "";
+  }
+  if (branch === "HEAD") branch = "";
+
+  const range = sinceSha ? `${sinceSha}..HEAD` : `-n ${MAX_PER_REPO}`;
+  const fmt = "%H%x1f%s%x1f%aN%x1f%aE%x1f%aI%x1f%P%x1e";
+  let raw: string;
+  try {
+    raw = git(repo, ["log", `--pretty=format:${fmt}`, "--no-merges", range]);
+  } catch (err) {
+    console.warn(`skip ${repoName}: ${(err as Error).message.split("\n")[0]}`);
+    return [];
+  }
+  const records = raw.split("\x1e").filter((r) => r.trim().length > 0);
+  const commits: Commit[] = [];
+  for (const rec of records.slice(0, MAX_PER_REPO)) {
+    const [sha, subject, author, email, ts, parents] = rec.split("\x1f");
+    if (!sha || !ts) continue;
+    if (AUTHOR_FILTER && !(email ?? "").includes(AUTHOR_FILTER)) continue;
+    commits.push({
+      sha,
+      repo: repoName,
+      subject: (subject ?? "").trim(),
+      author: (author ?? "").trim(),
+      ts: ts.trim(),
+      branch: branch || undefined,
+      parentCount: parents ? parents.trim().split(/\s+/).filter(Boolean).length : 0,
+    });
+  }
+  return commits.reverse();
+}
+
+async function publish(commits: Commit[]): Promise<number> {
+  if (commits.length === 0) return 0;
+  const res = await fetch(`${STATE_API}/api/commits`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${PUBLISH_KEY}`,
+    },
+    body: JSON.stringify({ commits }),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`publish failed: ${res.status} ${text.slice(0, 200)}`);
+  }
+  const data = (await res.json()) as { accepted?: number };
+  return data.accepted ?? 0;
+}
+
+async function main(): Promise<void> {
+  const cursor = loadCursor();
+  const repos = findGitRepos(ROOTS);
+  let totalSeen = 0;
+  let totalAccepted = 0;
+
+  for (const repo of repos) {
+    const commits = readCommits(repo, cursor[repo]);
+    if (commits.length === 0) continue;
+    totalSeen += commits.length;
+    try {
+      const accepted = await publish(commits);
+      totalAccepted += accepted;
+      const newest = commits[commits.length - 1];
+      if (newest) cursor[repo] = newest.sha;
+    } catch (err) {
+      console.error(`publish ${basename(repo)}: ${(err as Error).message}`);
+    }
+  }
+
+  saveCursor(cursor);
+  console.log(
+    `[commit-publisher] repos=${repos.length} seen=${totalSeen} accepted=${totalAccepted}`,
+  );
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/workers/state/src/do/code-stats.ts
+++ b/workers/state/src/do/code-stats.ts
@@ -1,0 +1,120 @@
+import { DurableObject } from "cloudflare:workers";
+import type { CodeStatsEvent, Commit } from "../types";
+
+const MAX_COMMITS = 500;
+
+/**
+ * CodeStats: stores recent git commits across Ani's local repos. Single
+ * named instance ("default") holds the rolling window. Keys:
+ * `commit:<ts>:<sha>` so storage.list returns newest-first when reversed.
+ * Hibernated WebSockets fan out new commits to every connected client.
+ */
+export class CodeStats extends DurableObject {
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+
+    if (request.headers.get("upgrade")?.toLowerCase() === "websocket") {
+      return this.handleWebSocketUpgrade();
+    }
+
+    if (url.pathname === "/commits" && request.method === "GET") {
+      const limit = Number(url.searchParams.get("limit") ?? "100");
+      const commits = await this.list(limit);
+      return Response.json({ commits });
+    }
+
+    if (url.pathname === "/commits" && request.method === "POST") {
+      const payload = (await request.json()) as
+        | Partial<Commit>
+        | { commits: Partial<Commit>[] };
+
+      const incoming: Partial<Commit>[] = Array.isArray(
+        (payload as { commits?: unknown }).commits,
+      )
+        ? (payload as { commits: Partial<Commit>[] }).commits
+        : [payload as Partial<Commit>];
+
+      const accepted: Commit[] = [];
+      for (const raw of incoming) {
+        if (!raw.sha || !raw.repo || !raw.ts) continue;
+        const commit: Commit = {
+          sha: raw.sha,
+          repo: raw.repo,
+          subject: raw.subject ?? "",
+          author: raw.author ?? "",
+          ts: raw.ts,
+          branch: raw.branch,
+          parentCount: raw.parentCount,
+        };
+        const key = `commit:${commit.ts}:${commit.sha}`;
+        const existing = await this.ctx.storage.get<Commit>(key);
+        if (existing) continue;
+        await this.ctx.storage.put(key, commit);
+        accepted.push(commit);
+        this.broadcast({ type: "commit.added", commit });
+      }
+
+      await this.trimToMax();
+      return Response.json({ accepted: accepted.length });
+    }
+
+    return new Response("not found", { status: 404 });
+  }
+
+  private async list(limit: number): Promise<Commit[]> {
+    const map = await this.ctx.storage.list<Commit>({
+      prefix: "commit:",
+      reverse: true,
+      limit,
+    });
+    return Array.from(map.values());
+  }
+
+  private async trimToMax(): Promise<void> {
+    const map = await this.ctx.storage.list<Commit>({ prefix: "commit:" });
+    if (map.size <= MAX_COMMITS) return;
+    const overflow = map.size - MAX_COMMITS;
+    const keysToDelete: string[] = [];
+    for (const key of map.keys()) {
+      if (keysToDelete.length >= overflow) break;
+      keysToDelete.push(key);
+    }
+    if (keysToDelete.length > 0) {
+      await this.ctx.storage.delete(keysToDelete);
+    }
+  }
+
+  private async handleWebSocketUpgrade(): Promise<Response> {
+    const pair = new WebSocketPair();
+    const [client, server] = Object.values(pair) as [WebSocket, WebSocket];
+    this.ctx.acceptWebSocket(server);
+    const commits = await this.list(100);
+    server.send(this.serialize({ type: "snapshot", commits }));
+    return new Response(null, { status: 101, webSocket: client });
+  }
+
+  webSocketMessage(ws: WebSocket, message: string | ArrayBuffer): void {
+    if (typeof message === "string" && message === "ping") {
+      ws.send("pong");
+    }
+  }
+
+  webSocketClose(_ws: WebSocket, _code: number, _reason: string): void {
+    // Hibernated WebSockets clean up automatically.
+  }
+
+  private broadcast(event: CodeStatsEvent): void {
+    const data = this.serialize(event);
+    for (const ws of this.ctx.getWebSockets()) {
+      try {
+        ws.send(data);
+      } catch {
+        // Closed sockets get cleaned up on the next storage tick.
+      }
+    }
+  }
+
+  private serialize(event: CodeStatsEvent): string {
+    return JSON.stringify(event);
+  }
+}

--- a/workers/state/src/index.ts
+++ b/workers/state/src/index.ts
@@ -3,6 +3,7 @@ import { cors } from "hono/cors";
 import type { Bindings } from "./types";
 
 export { LinkVault } from "./do/link-vault";
+export { CodeStats } from "./do/code-stats";
 
 const app = new Hono<{ Bindings: Bindings }>();
 
@@ -21,12 +22,19 @@ app.use("*", async (c, next) => {
 app.get("/", (c) =>
   c.json({
     service: "anipotts-state",
-    durableObjects: ["LinkVault"],
+    durableObjects: ["LinkVault", "CodeStats"],
     endpoints: {
-      list: "GET /api/links",
-      add: "POST /api/links",
-      remove: "DELETE /api/links/:id",
-      subscribe: "GET /api/links/ws (websocket upgrade)",
+      links: {
+        list: "GET /api/links",
+        add: "POST /api/links",
+        remove: "DELETE /api/links/:id",
+        subscribe: "GET /api/links/ws",
+      },
+      commits: {
+        list: "GET /api/commits",
+        publish: "POST /api/commits (bearer auth)",
+        subscribe: "GET /api/commits/ws",
+      },
     },
   }),
 );
@@ -36,6 +44,30 @@ app.get("/health", (c) => c.json({ ok: true, ts: new Date().toISOString() }));
 function linkVaultStub(env: Bindings): DurableObjectStub {
   const id = env.LINK_VAULT.idFromName("default");
   return env.LINK_VAULT.get(id);
+}
+
+function codeStatsStub(env: Bindings): DurableObjectStub {
+  const id = env.CODE_STATS.idFromName("default");
+  return env.CODE_STATS.get(id);
+}
+
+function requirePublishKey(c: {
+  env: Bindings;
+  req: { header: (name: string) => string | undefined };
+}): Response | null {
+  const expected = c.env.STATE_PUBLISH_KEY;
+  if (!expected) {
+    return Response.json(
+      { error: "STATE_PUBLISH_KEY not configured" },
+      { status: 503 },
+    );
+  }
+  const header = c.req.header("authorization") ?? "";
+  const provided = header.startsWith("Bearer ") ? header.slice(7) : "";
+  if (provided !== expected) {
+    return Response.json({ error: "unauthorized" }, { status: 401 });
+  }
+  return null;
 }
 
 app.get("/api/links", async (c) => {
@@ -72,6 +104,36 @@ app.get("/api/links/ws", async (c) => {
     return c.text("expected websocket upgrade", 426);
   }
   const stub = linkVaultStub(c.env);
+  return stub.fetch(c.req.raw);
+});
+
+app.get("/api/commits", async (c) => {
+  const limit = c.req.query("limit") ?? "100";
+  const stub = codeStatsStub(c.env);
+  const res = await stub.fetch(
+    `https://internal/commits?limit=${encodeURIComponent(limit)}`,
+  );
+  return new Response(res.body, res);
+});
+
+app.post("/api/commits", async (c) => {
+  const denied = requirePublishKey(c);
+  if (denied) return denied;
+  const body = await c.req.json();
+  const stub = codeStatsStub(c.env);
+  const res = await stub.fetch("https://internal/commits", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  return new Response(res.body, res);
+});
+
+app.get("/api/commits/ws", async (c) => {
+  if (c.req.header("upgrade")?.toLowerCase() !== "websocket") {
+    return c.text("expected websocket upgrade", 426);
+  }
+  const stub = codeStatsStub(c.env);
   return stub.fetch(c.req.raw);
 });
 

--- a/workers/state/src/types.ts
+++ b/workers/state/src/types.ts
@@ -18,7 +18,23 @@ export type LinkVaultEvent =
   | { type: "link.added"; link: Link }
   | { type: "link.removed"; id: string };
 
+export type Commit = {
+  sha: string;
+  repo: string;
+  subject: string;
+  author: string;
+  ts: string;
+  branch?: string;
+  parentCount?: number;
+};
+
+export type CodeStatsEvent =
+  | { type: "snapshot"; commits: Commit[] }
+  | { type: "commit.added"; commit: Commit };
+
 export type Bindings = {
   LINK_VAULT: DurableObjectNamespace;
+  CODE_STATS: DurableObjectNamespace;
   ALLOWED_ORIGINS: string;
+  STATE_PUBLISH_KEY?: string;
 };

--- a/workers/state/wrangler.toml
+++ b/workers/state/wrangler.toml
@@ -12,9 +12,17 @@ enabled = true
 name = "LINK_VAULT"
 class_name = "LinkVault"
 
+[[durable_objects.bindings]]
+name = "CODE_STATS"
+class_name = "CodeStats"
+
 [[migrations]]
 tag = "v1"
 new_sqlite_classes = ["LinkVault"]
+
+[[migrations]]
+tag = "v2"
+new_sqlite_classes = ["CodeStats"]
 
 # CORS allowlist for the admin frontend. Override at deploy time
 # with `wrangler secret put` if a different origin needs access.


### PR DESCRIPTION
## Summary

- **CodeStats Durable Object** in `workers/state` storing rolling 500-commit window. Hibernated WebSockets fan out `commit.added` events.
- **Bearer auth on POST /api/commits** via new `STATE_PUBLISH_KEY` secret.
- **CommitFeed Solid panel** subscribing to `/api/commits/ws`, mounted on the admin home next to LinkVaultPanel.
- **Mini publisher**: bun script + launchd plist that scans `~/Code/projects/**` every 5 min and posts new commits past a per-repo cursor.

This is step 4 of the personal-cloud build (step 1 was LinkVault, step 2 was Rudy MCP tools, step 3 was the Solid skeleton). The publisher pattern this introduces is the substrate for step 5 (proactive Rudy nudges that watch CodeStats DO) and step 6 (iPhone shortcut endpoints).

## Owner actions after merge

1. Generate the publish key and set the secret on the worker:
   ```bash
   KEY=$(openssl rand -hex 32)
   ssh mini "mkdir -p ~/.anipotts && echo '$KEY' > ~/.anipotts/state-publish.key && chmod 600 ~/.anipotts/state-publish.key"
   echo -n \"\$KEY\" | wrangler secret put STATE_PUBLISH_KEY --config workers/state/wrangler.toml
   ```
2. Deploy the state worker:
   ```bash
   cd workers/state && wrangler deploy
   ```
   (Adds the v2 migration that creates the CodeStats SQLite class. Existing LinkVault and api.anipotts.com routes stay untouched.)
3. Install the publisher on Mini per `scripts/mini/README.md`.

## Verify
After install, open https://admin.anipotts.com. The CodeStats panel should populate within 5 minutes. The connection dot turns green when the WS is live. Newest commit pushes broadcast in real time.

## Test plan
- [x] workers/state typecheck passes
- [x] apps/admin-solid typecheck + vinxi build pass
- [ ] State worker deploys with v2 migration (owner action)
- [ ] STATE_PUBLISH_KEY secret set
- [ ] Publisher installed on Mini, first run shows non-zero accepted in logs
- [ ] CodeStats panel shows live commits after first publisher run

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a live commit feed to the admin dashboard displaying recent code commits with real-time updates
  * Commits display repository, SHA, subject, and relative timestamps
  * Added a live connection status indicator

* **Chores**
  * Added configuration and documentation for automated commit event publishing from local repositories

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anipotts/anipotts.com/pull/47?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->