### PR TITLE
ci: add production promotion workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,12 +3,14 @@
 #   CLOUDFLARE_ACCOUNT_ID   - 0f856093bdcd34a7da1bde5ee4385163
 #   ADMIN_PASSWORD          - Admin UI password
 #   BUTTONDOWN_API_KEY      - Buttondown newsletter API key
+#   RESEND_API_KEY          - Resend API key for newsletter worker deployments
+#   NEWSLETTER_MAILING_ADDRESS - Physical mailing address for newsletter issue footers
 #   TYPEFULLY_API_KEY       - Typefully API key
 #   TYPEFULLY_SOCIAL_SET_ID - Typefully social set ID
 #
 # Path-filtered deploys: each deploy-X job only runs when files relevant to
 # that target actually changed. Lockfile / root package.json changes trigger
-# all four (dep updates can affect any target). Docs-only commits skip the
+# every deployed target (dep updates can affect any target). Docs-only commits skip the
 # workflow entirely via paths-ignore. No untrusted input is interpolated
 # into run: blocks anywhere in this workflow.
 
@@ -36,6 +38,7 @@ jobs:
       admin: ${{ steps.filter.outputs.admin }}
       labs: ${{ steps.filter.outputs.labs }}
       ingest: ${{ steps.filter.outputs.ingest }}
+      newsletter: ${{ steps.filter.outputs.newsletter }}
       weekly-email: ${{ steps.filter.outputs.weekly-email }}
     steps:
       - uses: actions/checkout@v4
@@ -64,6 +67,12 @@ jobs:
               - "workers/ingest/**"
               - "package.json"
               - "pnpm-lock.yaml"
+              - ".github/workflows/deploy.yml"
+            newsletter:
+              - "workers/newsletter/**"
+              - "package.json"
+              - "pnpm-lock.yaml"
+              - "pnpm-workspace.yaml"
               - ".github/workflows/deploy.yml"
             weekly-email:
               - "workers/weekly-email/**"
@@ -278,3 +287,58 @@ jobs:
           workingDirectory: workers/weekly-email
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+  deploy-newsletter:
+    name: Deploy newsletter worker
+    needs: [changes, validate]
+    if: needs.changes.outputs.newsletter == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: "10.5.2"
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck newsletter worker
+        run: pnpm --filter @anipotts/newsletter-worker typecheck
+
+      - name: Prepare newsletter secrets
+        run: |
+          node <<'NODE'
+          const fs = require("fs");
+          const path = process.env.NEWSLETTER_SECRETS_FILE;
+          const secrets = {};
+          if (!process.env.RESEND_API_KEY) {
+            console.error("::error::RESEND_API_KEY GitHub secret is missing");
+            process.exit(1);
+          }
+          secrets.RESEND_API_KEY = process.env.RESEND_API_KEY;
+          if (process.env.NEWSLETTER_MAILING_ADDRESS) {
+            secrets.NEWSLETTER_MAILING_ADDRESS = process.env.NEWSLETTER_MAILING_ADDRESS;
+          } else {
+            console.warn("::warning::NEWSLETTER_MAILING_ADDRESS is missing; issue sends will fail until it is set");
+          }
+          fs.writeFileSync(path, JSON.stringify(secrets));
+          NODE
+        env:
+          NEWSLETTER_SECRETS_FILE: ${{ runner.temp }}/newsletter-secrets.json
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+          NEWSLETTER_MAILING_ADDRESS: ${{ secrets.NEWSLETTER_MAILING_ADDRESS }}
+
+      - name: Deploy to Cloudflare Workers
+        run: pnpm exec wrangler --cwd workers/newsletter deploy --keep-vars --secrets-file "$NEWSLETTER_SECRETS_FILE"
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          NEWSLETTER_SECRETS_FILE: ${{ runner.temp }}/newsletter-secrets.json

--- a/.github/workflows/production-promotion.yml
+++ b/.github/workflows/production-promotion.yml
@@ -1,0 +1,269 @@
+name: Production Promotion
+
+on:
+  workflow_dispatch:
+    inputs:
+      apply_newsletter_migration:
+        description: "apply the remote newsletter D1 migration"
+        required: true
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
+      deploy_www:
+        description: "deploy anipotts.com and news.anipotts.com"
+        required: true
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
+      deploy_newsletter:
+        description: "deploy the newsletter queue worker"
+        required: true
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: production-promotion
+  cancel-in-progress: false
+
+jobs:
+  promote:
+    name: Migrate, deploy, and smoke production
+    runs-on: ubuntu-latest
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      NEWSLETTER_MAILING_ADDRESS: ${{ secrets.NEWSLETTER_MAILING_ADDRESS }}
+      PUBLIC_POSTHOG_KEY: ${{ secrets.PUBLIC_POSTHOG_KEY }}
+      PUBLIC_TURNSTILE_SITE_KEY: ${{ secrets.PUBLIC_TURNSTILE_SITE_KEY }}
+      RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+      RESEND_WEBHOOK_SECRET: ${{ secrets.RESEND_WEBHOOK_SECRET }}
+      WRANGLER_SEND_METRICS: "false"
+      NO_COLOR: "1"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: "10.5.2"
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Validate required secrets
+        run: |
+          missing=0
+          for name in CLOUDFLARE_API_TOKEN CLOUDFLARE_ACCOUNT_ID RESEND_API_KEY; do
+            if [ -z "${!name}" ]; then
+              echo "::error::$name GitHub secret is missing"
+              missing=1
+            fi
+          done
+          if [ -z "$NEWSLETTER_MAILING_ADDRESS" ]; then
+            echo "::warning::NEWSLETTER_MAILING_ADDRESS is missing; newsletter issue sends will fail until it is set"
+          fi
+          if [ -z "$RESEND_WEBHOOK_SECRET" ]; then
+            echo "::warning::RESEND_WEBHOOK_SECRET is missing; Resend webhooks will return 501 until configured"
+          fi
+          exit "$missing"
+
+      - name: Build www
+        if: ${{ inputs.deploy_www == 'true' }}
+        run: pnpm turbo build --filter=@anipotts/www
+
+      - name: Typecheck newsletter worker
+        if: ${{ inputs.deploy_newsletter == 'true' }}
+        run: pnpm --filter @anipotts/newsletter-worker typecheck
+
+      - name: Confirm newsletter queues
+        run: |
+          ensure_queue() {
+            local name="$1"
+            if pnpm exec wrangler queues info "$name" >"$RUNNER_TEMP/$name.info" 2>&1; then
+              echo "$name exists"
+              cat "$RUNNER_TEMP/$name.info"
+            else
+              echo "$name missing, creating it"
+              pnpm exec wrangler queues create "$name"
+              pnpm exec wrangler queues info "$name"
+            fi
+          }
+          ensure_queue newsletter-send
+          ensure_queue newsletter-send-dlq
+
+      - name: Apply remote newsletter D1 migration
+        if: ${{ inputs.apply_newsletter_migration == 'true' }}
+        run: |
+          pnpm exec wrangler -c apps/www/wrangler.toml d1 execute anipotts-db \
+            --remote \
+            --file=drizzle/migrations/0005_newsletter_system.sql \
+            --yes
+
+      - name: Smoke remote newsletter D1 schema
+        run: |
+          result="$RUNNER_TEMP/d1-newsletter-tables.json"
+          pnpm exec wrangler -c apps/www/wrangler.toml d1 execute anipotts-db \
+            --remote \
+            --json \
+            --command "SELECT COUNT(*) AS table_count FROM sqlite_master WHERE type = 'table' AND name IN ('newsletter_subscribers','newsletter_preferences','newsletter_issues','newsletter_deliveries','newsletter_events','newsletter_tokens','newsletter_suppressions');" \
+            > "$result"
+          D1_RESULT_FILE="$result" node <<'NODE'
+          const fs = require("fs");
+          const data = JSON.parse(fs.readFileSync(process.env.D1_RESULT_FILE, "utf8"));
+          const collectRows = (value) => {
+            if (!value) return [];
+            if (Array.isArray(value)) return value.flatMap(collectRows);
+            if (Array.isArray(value.results)) return value.results;
+            if (Array.isArray(value.result)) return collectRows(value.result);
+            return [];
+          };
+          const row = collectRows(data)[0];
+          const count = Number(row?.table_count);
+          if (count !== 7) {
+            console.error(`expected 7 newsletter tables, found ${Number.isFinite(count) ? count : "none"}`);
+            process.exit(1);
+          }
+          console.log(`newsletter table count: ${count}`);
+          NODE
+
+      - name: Smoke remote newsletter D1 writes
+        run: |
+          smoke_id="promotion_smoke_${GITHUB_RUN_ID}_${GITHUB_RUN_ATTEMPT}"
+          timestamp="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+          pnpm exec wrangler -c apps/www/wrangler.toml d1 execute anipotts-db \
+            --remote \
+            --command "DELETE FROM newsletter_events WHERE id = '$smoke_id';" \
+            --yes
+          pnpm exec wrangler -c apps/www/wrangler.toml d1 execute anipotts-db \
+            --remote \
+            --command "INSERT INTO newsletter_events (id, type, payload, created_at) VALUES ('$smoke_id', 'promotion_smoke', '{}', '$timestamp');" \
+            --yes
+          result="$RUNNER_TEMP/d1-newsletter-write.json"
+          pnpm exec wrangler -c apps/www/wrangler.toml d1 execute anipotts-db \
+            --remote \
+            --json \
+            --command "SELECT COUNT(*) AS smoke_count FROM newsletter_events WHERE id = '$smoke_id';" \
+            > "$result"
+          D1_RESULT_FILE="$result" node <<'NODE'
+          const fs = require("fs");
+          const data = JSON.parse(fs.readFileSync(process.env.D1_RESULT_FILE, "utf8"));
+          const collectRows = (value) => {
+            if (!value) return [];
+            if (Array.isArray(value)) return value.flatMap(collectRows);
+            if (Array.isArray(value.results)) return value.results;
+            if (Array.isArray(value.result)) return collectRows(value.result);
+            return [];
+          };
+          const row = collectRows(data)[0];
+          const count = Number(row?.smoke_count);
+          if (count !== 1) {
+            console.error(`expected smoke row count 1, found ${Number.isFinite(count) ? count : "none"}`);
+            process.exit(1);
+          }
+          console.log(`newsletter write smoke rows: ${count}`);
+          NODE
+          pnpm exec wrangler -c apps/www/wrangler.toml d1 execute anipotts-db \
+            --remote \
+            --command "DELETE FROM newsletter_events WHERE id = '$smoke_id';" \
+            --yes
+
+      - name: Prepare deploy secrets
+        run: |
+          echo "WWW_SECRETS_FILE=$RUNNER_TEMP/www-secrets.json" >> "$GITHUB_ENV"
+          echo "NEWSLETTER_SECRETS_FILE=$RUNNER_TEMP/newsletter-secrets.json" >> "$GITHUB_ENV"
+          node <<'NODE'
+          const fs = require("fs");
+          const write = (file, keys) => {
+            const payload = {};
+            for (const key of keys) {
+              const value = process.env[key];
+              if (value) payload[key] = value;
+            }
+            if (Object.keys(payload).length > 0) {
+              fs.writeFileSync(file, JSON.stringify(payload));
+            }
+          };
+          write(`${process.env.RUNNER_TEMP}/www-secrets.json`, [
+            "RESEND_API_KEY",
+            "RESEND_WEBHOOK_SECRET",
+          ]);
+          write(`${process.env.RUNNER_TEMP}/newsletter-secrets.json`, [
+            "RESEND_API_KEY",
+            "NEWSLETTER_MAILING_ADDRESS",
+          ]);
+          NODE
+
+      - name: Deploy www worker
+        if: ${{ inputs.deploy_www == 'true' }}
+        run: |
+          args=(deploy --keep-vars)
+          if [ -s "$WWW_SECRETS_FILE" ]; then
+            args+=(--secrets-file "$WWW_SECRETS_FILE")
+          fi
+          pnpm exec wrangler --cwd apps/www "${args[@]}"
+
+      - name: Deploy newsletter worker
+        if: ${{ inputs.deploy_newsletter == 'true' }}
+        run: |
+          args=(deploy --keep-vars)
+          if [ -s "$NEWSLETTER_SECRETS_FILE" ]; then
+            args+=(--secrets-file "$NEWSLETTER_SECRETS_FILE")
+          fi
+          pnpm exec wrangler --cwd workers/newsletter "${args[@]}"
+
+      - name: Confirm deployed worker secrets
+        run: |
+          newsletter="$RUNNER_TEMP/newsletter-worker-secrets.json"
+          www="$RUNNER_TEMP/www-worker-secrets.json"
+          pnpm exec wrangler -c workers/newsletter/wrangler.toml secret list --format json > "$newsletter"
+          pnpm exec wrangler -c apps/www/wrangler.toml secret list --format json > "$www"
+          NEWSLETTER_SECRETS_RESULT="$newsletter" WWW_SECRETS_RESULT="$www" node <<'NODE'
+          const fs = require("fs");
+          const names = (file) => {
+            const parsed = JSON.parse(fs.readFileSync(file, "utf8"));
+            const list = Array.isArray(parsed) ? parsed : parsed.result ?? [];
+            return new Set(list.map((entry) => entry.name).filter(Boolean));
+          };
+          const newsletter = names(process.env.NEWSLETTER_SECRETS_RESULT);
+          const www = names(process.env.WWW_SECRETS_RESULT);
+          if (!newsletter.has("RESEND_API_KEY")) {
+            console.error("newsletter worker is missing RESEND_API_KEY");
+            process.exit(1);
+          }
+          console.log("newsletter worker has RESEND_API_KEY");
+          if (newsletter.has("NEWSLETTER_MAILING_ADDRESS")) {
+            console.log("newsletter worker has NEWSLETTER_MAILING_ADDRESS");
+          } else {
+            console.warn("NEWSLETTER_MAILING_ADDRESS is not set on the newsletter worker");
+          }
+          if (www.has("RESEND_WEBHOOK_SECRET")) {
+            console.log("www worker has RESEND_WEBHOOK_SECRET");
+          } else {
+            console.warn("RESEND_WEBHOOK_SECRET is not set on the www worker");
+          }
+          NODE
+
+      - name: Smoke live production URLs
+        run: |
+          curl -fsS https://anipotts.com/ > "$RUNNER_TEMP/home.html"
+          curl -fsS https://news.anipotts.com/ > "$RUNNER_TEMP/news.html"
+          curl -fsS https://anipotts-newsletter-worker.anipotts.workers.dev/ > "$RUNNER_TEMP/newsletter-worker.txt"
+          grep -qi "ani potts" "$RUNNER_TEMP/home.html"
+          grep -qi "newsletter" "$RUNNER_TEMP/news.html"
+          grep -qi "newsletter worker ok" "$RUNNER_TEMP/newsletter-worker.txt"


### PR DESCRIPTION
## summary
- wire the newsletter worker into the path-filtered deploy workflow
- add a manual production promotion workflow for ordered queue confirmation, remote D1 migration, D1 smoke, www deploy, newsletter worker deploy, deployed secret-name confirmation, and live URL smoke
- upload the newsletter worker RESEND_API_KEY from GitHub secrets during automated newsletter deploys

## verified
- ruby yaml parse for deploy workflows
- git diff --check
- pnpm --filter @anipotts/newsletter-worker typecheck
- pnpm turbo build --filter=@anipotts/www
- pnpm exec wrangler --cwd workers/newsletter deploy --dry-run
- pnpm exec wrangler --cwd apps/www deploy --dry-run

## notes
- RESEND_API_KEY is present in GitHub secrets
- NEWSLETTER_MAILING_ADDRESS is not present yet, so issue sends will warn and remain blocked until set
- RESEND_WEBHOOK_SECRET is not present yet, so Resend webhook handling will warn until configured
- Deploy workflow remains disabled until the manual promotion workflow succeeds