### PR TITLE
fix: render newsletter custom domain root

### DIFF
--- a/apps/www/src/middleware.ts
+++ b/apps/www/src/middleware.ts
@@ -55,10 +55,8 @@ export const onRequest = defineMiddleware(async (context, next) => {
 
   if (host === NEWS_HOST) {
     if (pathname === "/") {
-      const page = await context.locals.runtime.env.ASSETS.fetch(
-        new URL("/newsletter", context.url),
-      );
-      return applyHtmlSecurityHeaders(new Response(page.body, page));
+      const page = await next(new URL("/newsletter", context.url));
+      return applyHtmlSecurityHeaders(page);
     }
 
     if (pathname === "/newsletter") {
@@ -66,10 +64,8 @@ export const onRequest = defineMiddleware(async (context, next) => {
     }
 
     if (pathname === "/archive" || pathname.startsWith("/archive/")) {
-      const page = await context.locals.runtime.env.ASSETS.fetch(
-        new URL("/newsletter/archive", context.url),
-      );
-      return applyHtmlSecurityHeaders(new Response(page.body, page));
+      const page = await next(new URL("/newsletter/archive", context.url));
+      return applyHtmlSecurityHeaders(page);
     }
   }
 


### PR DESCRIPTION
## summary
- fix `news.anipotts.com/` by rewriting through Astro route rendering for `/newsletter`
- fix `news.anipotts.com/archive` the same way for `/newsletter/archive`
- preserve the existing canonical redirect from `/newsletter` to `/` on the news host

## why
The production promotion deployed correctly, but final live smoke exposed that `news.anipotts.com/` returned a Cloudflare 404. The middleware was asking the static assets binding for `/newsletter`, but the newsletter page is served through the Astro worker route rather than a static `/newsletter` asset.

## verified
- pnpm --filter @anipotts/www typecheck
- pnpm turbo build --filter=@anipotts/www
- pnpm exec wrangler --cwd apps/www deploy --dry-run
- git diff --check