### PR TITLE
ci: speed up agent pr deploy loop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,11 @@ jobs:
   ci:
     name: Build, lint, typecheck, test
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -22,20 +25,11 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "pnpm"
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build
-        run: pnpm turbo build
-
-      - name: Lint
-        run: pnpm turbo lint
-
-      - name: Typecheck
-        run: pnpm turbo typecheck
-
-      - name: Test
-        run: pnpm turbo test
+      - name: Validate affected packages
+        run: pnpm turbo build lint typecheck test --affected --output-logs=errors-only

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,10 +9,10 @@
 #   TYPEFULLY_SOCIAL_SET_ID - Typefully social set ID
 #
 # Path-filtered deploys: each deploy-X job only runs when files relevant to
-# that target actually changed. Lockfile / root package.json changes trigger
-# every deployed target (dep updates can affect any target). Docs-only commits skip the
-# workflow entirely via paths-ignore. No untrusted input is interpolated
-# into run: blocks anywhere in this workflow.
+# that target actually changed. Root dependency changes trigger every deployed
+# target because they can affect any build. Docs-only commits skip the workflow
+# entirely via paths-ignore. Workflow-only changes run detection but deploy
+# nothing. No untrusted input is interpolated into run: blocks anywhere here.
 
 name: Deploy
 
@@ -46,77 +46,46 @@ jobs:
         id: filter
         with:
           filters: |
-            shared: &shared
+            root: &root
               - "package.json"
               - "pnpm-lock.yaml"
               - "pnpm-workspace.yaml"
               - "turbo.json"
-              - "packages/**"
-              - ".github/workflows/deploy.yml"
             www:
-              - *shared
+              - *root
               - "apps/www/**"
+              - "packages/lib/**"
+              - "packages/styles/**"
+              - "packages/types/**"
             admin:
-              - *shared
+              - *root
               - "apps/admin/**"
+              - "packages/config/**"
+              - "packages/lib/**"
+              - "packages/services-platform/**"
+              - "packages/styles/**"
+              - "packages/types/**"
               - "services/**"
             labs:
-              - *shared
+              - *root
               - "apps/labs/**"
+              - "packages/config/**"
             ingest:
+              - *root
               - "workers/ingest/**"
-              - "package.json"
-              - "pnpm-lock.yaml"
-              - ".github/workflows/deploy.yml"
             newsletter:
+              - *root
               - "workers/newsletter/**"
-              - "package.json"
-              - "pnpm-lock.yaml"
-              - "pnpm-workspace.yaml"
-              - ".github/workflows/deploy.yml"
             weekly-email:
+              - *root
               - "workers/weekly-email/**"
-              - "package.json"
-              - "pnpm-lock.yaml"
-              - ".github/workflows/deploy.yml"
-
-  validate:
-    name: Build, lint, typecheck, test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: "10.5.2"
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Build
-        run: pnpm turbo build
-
-      - name: Lint
-        run: pnpm turbo lint
-
-      - name: Typecheck
-        run: pnpm turbo typecheck
-
-      - name: Test
-        run: pnpm turbo test
 
   deploy-www:
     name: Deploy www
-    needs: [changes, validate]
+    needs: [changes]
     if: needs.changes.outputs.www == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 
@@ -154,9 +123,10 @@ jobs:
 
   deploy-admin:
     name: Deploy admin
-    needs: [changes, validate]
+    needs: [changes]
     if: needs.changes.outputs.admin == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
 
@@ -196,9 +166,10 @@ jobs:
 
   deploy-labs:
     name: Deploy labs
-    needs: [changes, validate]
+    needs: [changes]
     if: needs.changes.outputs.labs == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
 
@@ -232,9 +203,10 @@ jobs:
 
   deploy-ingest:
     name: Deploy ingest worker
-    needs: [changes, validate]
+    needs: [changes]
     if: needs.changes.outputs.ingest == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 
@@ -252,6 +224,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Typecheck ingest worker
+        run: pnpm --filter @anipotts/ingest typecheck
+
       - name: Deploy to Cloudflare Workers
         uses: cloudflare/wrangler-action@v3
         with:
@@ -261,9 +236,10 @@ jobs:
 
   deploy-weekly-email:
     name: Deploy weekly email worker
-    needs: [changes, validate]
+    needs: [changes]
     if: needs.changes.outputs.weekly-email == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 
@@ -290,9 +266,10 @@ jobs:
 
   deploy-newsletter:
     name: Deploy newsletter worker
-    needs: [changes, validate]
+    needs: [changes]
     if: needs.changes.outputs.newsletter == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/security-review.yml
+++ b/.github/workflows/security-review.yml
@@ -12,17 +12,34 @@ permissions:
 
 jobs:
   security:
+    name: security
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          fetch-depth: 2
+          fetch-depth: 0
+
+      - name: Decide security review scope
+        id: scope
+        run: |
+          changed="$RUNNER_TEMP/changed-files.txt"
+          git diff --name-only "origin/${{ github.base_ref }}"...HEAD | tee "$changed"
+          if grep -Eq '^(\.github/workflows/|apps/admin/|apps/admin-solid/|apps/labs/|apps/www/src/middleware\.ts|apps/www/src/pages/(api|ingest)/|apps/www/wrangler\.toml|workers/|packages/lib/|packages/services-platform/|drizzle/|scripts/|package\.json|pnpm-lock\.yaml|pnpm-workspace\.yaml|turbo\.json|tsconfig\.json)' "$changed"; then
+            echo "run_review=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_review=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - uses: anthropics/claude-code-security-review@main
+        if: steps.scope.outputs.run_review == 'true'
         with:
           comment-pr: true
           claude-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
           exclude-directories: node_modules,.next,dist
           claude-model: claude-sonnet-4-6
+
+      - name: Skip expensive review for static-site-only changes
+        if: steps.scope.outputs.run_review != 'true'
+        run: echo "static public-site-only change; required security gate passes without claude review"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,15 @@ Wrangler secrets on admin Worker (accessed via `getEnv()` from `@anipotts/lib/en
 - `getEnv(key)` from `@anipotts/lib/env` for all Wrangler secrets (NOT `process.env`).
 - Health endpoints: `/api/health` on www and admin, `/health` on ingest and mini-api.
 
+## Agent PR Flow
+
+- Work on `codex/*`, `claude/*`, or `worktree-*` branches.
+- Open same-repo PRs. The agent auto-merge workflow enables merge-commit auto-merge once required checks pass.
+- Required PR gates are `Build, lint, typecheck, test` and `security`.
+- CI uses Turbo affected validation, so agents should keep changes scoped and let the package graph decide what to test.
+- Security review is expensive only for infra, admin, worker, package, dependency, and API/middleware changes. Static public-site copy/layout changes get the required `security` check without a Claude review run.
+- Main pushes auto-deploy through the path-filtered Deploy workflow. Deploy jobs build and ship only targets touched by the merge instead of rebuilding the whole monorepo first.
+
 ## Anti-Corny Guardrails (NON-NEGOTIABLE)
 
 1. **No fake vulnerability.** Don't perform honesty. Just be honest.


### PR DESCRIPTION
## what changed
- use Turbo affected validation for the required PR CI check
- keep the required security check, but run the expensive Claude security review only for infra, worker, admin, package, dependency, API, and middleware paths
- remove the global deploy validation job so main deploys only build touched targets
- document the agent PR flow in CLAUDE.md

## why
This keeps PR safety on the branch where agents work, then makes production deploys do the smallest useful thing. Public site copy/layout changes should stop dragging admin/labs through deploy unless a real shared dependency changed.

## verified
- parsed all GitHub workflow YAML with python/yaml
- git diff --check
- pnpm exec turbo build lint typecheck test --affected --dry=json