### PR TITLE
ci: dispatch deploy after agent merges

### DIFF
--- a/.github/workflows/agent-pr-automerge.yml
+++ b/.github/workflows/agent-pr-automerge.yml
@@ -5,8 +5,14 @@ on:
     types: [opened, reopened, synchronize, ready_for_review]
 
 permissions:
+  actions: write
+  checks: read
   contents: write
   pull-requests: write
+
+concurrency:
+  group: agent-pr-automerge-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   automerge:
@@ -20,8 +26,115 @@ jobs:
       )
     runs-on: ubuntu-latest
     steps:
-      - name: Enable auto-merge
+      - name: Wait for required checks
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
-        run: gh pr merge --auto --merge "$PR_URL"
+        run: |
+          count=0
+          for _ in $(seq 1 30); do
+            count="$(gh pr checks "$PR_URL" --required --json name --jq 'length' 2>/dev/null || echo 0)"
+            if [ "$count" -gt 0 ]; then
+              break
+            fi
+            sleep 10
+          done
+          if [ "$count" -eq 0 ]; then
+            echo "required checks were not registered"
+            exit 1
+          fi
+          gh pr checks "$PR_URL" --required --watch --fail-fast --interval 15
+
+      - name: Compute deploy targets
+        id: targets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          files="$RUNNER_TEMP/pr-files.txt"
+          gh pr diff "$PR_URL" --name-only > "$files"
+
+          www=false
+          admin=false
+          labs=false
+          ingest=false
+          newsletter=false
+          weekly_email=false
+
+          while IFS= read -r file; do
+            case "$file" in
+              package.json|pnpm-lock.yaml|pnpm-workspace.yaml|turbo.json)
+                www=true
+                admin=true
+                labs=true
+                ingest=true
+                newsletter=true
+                weekly_email=true
+                ;;
+            esac
+            case "$file" in
+              apps/www/*|packages/lib/*|packages/styles/*|packages/types/*)
+                www=true
+                ;;
+            esac
+            case "$file" in
+              apps/admin/*|packages/config/*|packages/lib/*|packages/services-platform/*|packages/styles/*|packages/types/*|services/*)
+                admin=true
+                ;;
+            esac
+            case "$file" in
+              apps/labs/*|packages/config/*)
+                labs=true
+                ;;
+            esac
+            case "$file" in
+              workers/ingest/*)
+                ingest=true
+                ;;
+            esac
+            case "$file" in
+              workers/newsletter/*)
+                newsletter=true
+                ;;
+            esac
+            case "$file" in
+              workers/weekly-email/*)
+                weekly_email=true
+                ;;
+            esac
+          done < "$files"
+
+          {
+            echo "www=$www"
+            echo "admin=$admin"
+            echo "labs=$labs"
+            echo "ingest=$ingest"
+            echo "newsletter=$newsletter"
+            echo "weekly_email=$weekly_email"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Merge PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr merge --merge --delete-branch "$PR_URL"
+
+      - name: Dispatch deploy
+        if: >
+          steps.targets.outputs.www == 'true' ||
+          steps.targets.outputs.admin == 'true' ||
+          steps.targets.outputs.labs == 'true' ||
+          steps.targets.outputs.ingest == 'true' ||
+          steps.targets.outputs.newsletter == 'true' ||
+          steps.targets.outputs.weekly_email == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run deploy.yml \
+            --ref main \
+            -f www=${{ steps.targets.outputs.www }} \
+            -f admin=${{ steps.targets.outputs.admin }} \
+            -f labs=${{ steps.targets.outputs.labs }} \
+            -f ingest=${{ steps.targets.outputs.ingest }} \
+            -f newsletter=${{ steps.targets.outputs.newsletter }} \
+            -f weekly_email=${{ steps.targets.outputs.weekly_email }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,6 +24,44 @@ on:
       - "docs/**"
       - ".github/ISSUE_TEMPLATE/**"
       - "LICENSE"
+  workflow_dispatch:
+    inputs:
+      www:
+        description: "deploy anipotts.com"
+        required: true
+        default: "false"
+        type: choice
+        options: ["false", "true"]
+      admin:
+        description: "deploy admin.anipotts.com"
+        required: true
+        default: "false"
+        type: choice
+        options: ["false", "true"]
+      labs:
+        description: "deploy labs.anipotts.com"
+        required: true
+        default: "false"
+        type: choice
+        options: ["false", "true"]
+      ingest:
+        description: "deploy ingest worker"
+        required: true
+        default: "false"
+        type: choice
+        options: ["false", "true"]
+      newsletter:
+        description: "deploy newsletter worker"
+        required: true
+        default: "false"
+        type: choice
+        options: ["false", "true"]
+      weekly_email:
+        description: "deploy weekly email worker"
+        required: true
+        default: "false"
+        type: choice
+        options: ["false", "true"]
 
 concurrency:
   group: deploy-${{ github.ref }}
@@ -43,6 +81,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
+        if: github.event_name == 'push'
         id: filter
         with:
           filters: |
@@ -83,7 +122,9 @@ jobs:
   deploy-www:
     name: Deploy www
     needs: [changes]
-    if: needs.changes.outputs.www == 'true'
+    if: >
+      (github.event_name == 'workflow_dispatch' && inputs.www == 'true') ||
+      (github.event_name == 'push' && needs.changes.outputs.www == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -124,7 +165,9 @@ jobs:
   deploy-admin:
     name: Deploy admin
     needs: [changes]
-    if: needs.changes.outputs.admin == 'true'
+    if: >
+      (github.event_name == 'workflow_dispatch' && inputs.admin == 'true') ||
+      (github.event_name == 'push' && needs.changes.outputs.admin == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -167,7 +210,9 @@ jobs:
   deploy-labs:
     name: Deploy labs
     needs: [changes]
-    if: needs.changes.outputs.labs == 'true'
+    if: >
+      (github.event_name == 'workflow_dispatch' && inputs.labs == 'true') ||
+      (github.event_name == 'push' && needs.changes.outputs.labs == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -204,7 +249,9 @@ jobs:
   deploy-ingest:
     name: Deploy ingest worker
     needs: [changes]
-    if: needs.changes.outputs.ingest == 'true'
+    if: >
+      (github.event_name == 'workflow_dispatch' && inputs.ingest == 'true') ||
+      (github.event_name == 'push' && needs.changes.outputs.ingest == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -237,7 +284,9 @@ jobs:
   deploy-weekly-email:
     name: Deploy weekly email worker
     needs: [changes]
-    if: needs.changes.outputs.weekly-email == 'true'
+    if: >
+      (github.event_name == 'workflow_dispatch' && inputs.weekly_email == 'true') ||
+      (github.event_name == 'push' && needs.changes.outputs.weekly-email == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -267,7 +316,9 @@ jobs:
   deploy-newsletter:
     name: Deploy newsletter worker
     needs: [changes]
-    if: needs.changes.outputs.newsletter == 'true'
+    if: >
+      (github.event_name == 'workflow_dispatch' && inputs.newsletter == 'true') ||
+      (github.event_name == 'push' && needs.changes.outputs.newsletter == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,11 +76,11 @@ Wrangler secrets on admin Worker (accessed via `getEnv()` from `@anipotts/lib/en
 ## Agent PR Flow
 
 - Work on `codex/*`, `claude/*`, or `worktree-*` branches.
-- Open same-repo PRs. The agent auto-merge workflow enables merge-commit auto-merge once required checks pass.
+- Open same-repo PRs. The agent auto-merge workflow waits for required checks and dispatches Deploy with touched targets after the merge commit lands.
 - Required PR gates are `Build, lint, typecheck, test` and `security`.
 - CI uses Turbo affected validation, so agents should keep changes scoped and let the package graph decide what to test.
 - Security review is expensive only for infra, admin, worker, package, dependency, and API/middleware changes. Static public-site copy/layout changes get the required `security` check without a Claude review run.
-- Main pushes auto-deploy through the path-filtered Deploy workflow. Deploy jobs build and ship only targets touched by the merge instead of rebuilding the whole monorepo first.
+- Main pushes auto-deploy through the path-filtered Deploy workflow. Agent merges also dispatch Deploy directly because `GITHUB_TOKEN` merges do not reliably create follow-on push workflow runs. Deploy jobs build and ship only targets touched by the merge instead of rebuilding the whole monorepo first.
 
 ## Anti-Corny Guardrails (NON-NEGOTIABLE)
 


### PR DESCRIPTION
## what changed
- rewrite agent PR automerge so future agent PRs wait for required checks, merge, compute deploy targets, and dispatch Deploy explicitly
- add manual Deploy inputs for each target so agent merges do not depend on a push workflow created by GITHUB_TOKEN
- document the reason in CLAUDE.md so future agents do not remove it

## why
GitHub does not reliably create follow-on push workflow runs from merges created by GITHUB_TOKEN. The previous agent automerge path could merge code without starting Deploy. This keeps no-secret automerge while making autodeploy explicit.

## verified
- parsed all GitHub workflow YAML with python/yaml
- git diff --check
- local deploy-target mapping dry run marked packages/lib for both www and admin, and newsletter worker changes only for newsletter