### PR TITLE
ci: stabilize release automation

### DIFF
--- a/.github/workflows/agent-pr-automerge.yml
+++ b/.github/workflows/agent-pr-automerge.yml
@@ -129,8 +129,10 @@ jobs:
           steps.targets.outputs.weekly_email == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
         run: |
           gh workflow run deploy.yml \
+            --repo "$GH_REPO" \
             --ref main \
             -f www=${{ steps.targets.outputs.www }} \
             -f admin=${{ steps.targets.outputs.admin }} \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,4 +32,11 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Validate affected packages
-        run: pnpm turbo build lint typecheck test --affected --output-logs=errors-only
+        env:
+          TURBO_SCM_BASE: origin/${{ github.base_ref }}
+          TURBO_SCM_HEAD: HEAD
+        run: |
+          pnpm turbo build --affected --output-logs=errors-only
+          pnpm turbo lint --affected --output-logs=errors-only
+          pnpm turbo typecheck --affected --output-logs=errors-only
+          pnpm turbo test --affected --output-logs=errors-only


### PR DESCRIPTION
## summary
- pass `--repo "$GH_REPO"` when Agent PR Auto-Merge dispatches `deploy.yml`
- set `TURBO_SCM_BASE=origin/${{ github.base_ref }}` and `TURBO_SCM_HEAD=HEAD` in CI
- run turbo build, lint, typecheck, and test sequentially to avoid Astro content-store races
- keep the PR draft until Ani approves release-train promotion

## verification
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/agent-pr-automerge.yml"); YAML.load_file(".github/workflows/ci.yml"); puts "yaml ok"'`\n- `git diff --check`\n- `TURBO_SCM_BASE=origin/main TURBO_SCM_HEAD=HEAD pnpm turbo build --affected --dry=json`\n- root cause checked from failed deploy dispatch run `27802531748` and failed #67 CI run `27803447458`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI and deployment workflow configuration for better reliability and consistency in automated processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->