### PR TITLE
fix(www): square atlantic inline mark

### DIFF
--- a/apps/www/src/components/InlineMention.astro
+++ b/apps/www/src/components/InlineMention.astro
@@ -110,6 +110,7 @@ const logoClass = [
     width: 1.48em;
     flex-basis: 1.48em;
     padding: 0;
+    border-radius: 0;
     background: transparent;
     box-shadow: none;
   }
@@ -126,6 +127,10 @@ const logoClass = [
     height: 100%;
     border-radius: 0.14em;
     object-fit: contain;
+  }
+
+  .brand-mark-wide .logo {
+    border-radius: 0;
   }
 
   .logo-white {


### PR DESCRIPTION
## Summary
- square the wide inline atlantic mark and its image corners
- cosmetic follow-up from the other Codex thread

## Verification
- `pnpm --filter @anipotts/www typecheck`
- `pnpm --filter @anipotts/www build`

## Live impact
No live site change yet. This is a draft PR, so it will not auto-merge or deploy until promoted.
