### PR TITLE
fix agent auto-merge for large prs

### DIFF
--- a/.github/workflows/agent-pr-automerge.yml
+++ b/.github/workflows/agent-pr-automerge.yml
@@ -52,7 +52,10 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: |
           files="$RUNNER_TEMP/pr-files.txt"
-          gh pr diff "$PR_URL" --name-only > "$files"
+          pr_number="${PR_URL##*/}"
+          gh api "repos/${GITHUB_REPOSITORY}/pulls/${pr_number}/files" \
+            --paginate \
+            --jq '.[].filename' > "$files"
 
           www=false
           admin=false


### PR DESCRIPTION
## summary
- make agent auto-merge compute deploy targets from the paginated pull request files API
- avoids GitHub diff-size failures on large consolidation PRs

## verification
- ruby yaml parse for .github/workflows/agent-pr-automerge.yml
- git diff --check

## live impact
- workflow-only change; no app deploy target expected


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal pull request processing workflow to use an alternative method for gathering file information, improving reliability and consistency in deployment target detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->