### PR TITLE
Build admin-solid fleet dashboard MVP

### DIFF
--- a/apps/admin-solid/src/app.css
+++ b/apps/admin-solid/src/app.css
@@ -1,23 +1,16 @@
 :root {
-  --bg: #fbfaf7;
-  --surface: #f3f1ec;
-  --text: #1a1a1a;
-  --muted: #6b6b6b;
-  --accent: #2563eb;
-  --border: rgba(0, 0, 0, 0.08);
+  --bg: #0f1115;
+  --surface: #171a20;
+  --surface-strong: #20242c;
+  --text: #f0f2f5;
+  --muted: #8e97a8;
+  --accent: #5fa8ff;
+  --good: #22c55e;
+  --warn: #eab308;
+  --bad: #ef4444;
+  --border: rgba(255, 255, 255, 0.09);
   --font-sans: "Inter", -apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif;
   --font-mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --bg: #11111b;
-    --surface: #1e1e2e;
-    --text: #cdd6f4;
-    --muted: #7f849c;
-    --accent: #89b4fa;
-    --border: rgba(205, 214, 244, 0.08);
-  }
 }
 
 * {
@@ -46,27 +39,221 @@ a:hover {
 }
 
 main {
-  max-width: 68ch;
+  width: min(1500px, 100%);
   margin: 0 auto;
-  padding: 4rem 1.5rem 6rem;
+  padding: 24px;
 }
 
 h1 {
   font-family: var(--font-mono);
-  font-size: 1.5rem;
+  font-size: clamp(1.6rem, 3vw, 3rem);
   font-weight: 500;
-  letter-spacing: -0.01em;
+  letter-spacing: 0;
   margin: 0 0 0.5rem;
 }
 
 h2 {
   font-family: var(--font-mono);
-  font-size: 0.75rem;
+  font-size: 0.9rem;
   font-weight: 500;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
+  letter-spacing: 0;
+  color: var(--text);
+  margin: 0;
+}
+
+button,
+.hero-actions a {
+  min-height: 36px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--surface-strong);
+  color: var(--text);
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  padding: 0 12px;
+}
+
+.hero-actions a {
+  align-items: center;
+  display: inline-flex;
+}
+
+button:hover,
+.hero-actions a:hover {
+  border-color: color-mix(in srgb, var(--accent), transparent 35%);
+  text-decoration: none;
+}
+
+.dashboard-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.hero-band {
+  align-items: end;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  display: grid;
+  gap: 24px;
+  grid-template-columns: minmax(0, 1fr) auto;
+  padding: 24px;
+}
+
+.hero-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.lede {
   color: var(--muted);
-  margin: 2.5rem 0 1rem;
+  font-size: 0.95rem;
+  line-height: 1.6;
+  margin: 0;
+  max-width: 760px;
+}
+
+.eyebrow {
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  margin: 0 0 8px;
+  text-transform: uppercase;
+}
+
+.section-block {
+  border-top: 1px solid var(--border);
+  padding-top: 16px;
+}
+
+.section-heading {
+  align-items: end;
+  display: flex;
+  gap: 16px;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.metric-grid,
+.source-grid,
+.feed-grid {
+  display: grid;
+  gap: 12px;
+}
+
+.metric-grid {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.source-grid,
+.feed-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.metric-card,
+.source-card,
+.feed-panel {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  min-width: 0;
+  padding: 14px;
+}
+
+.metric-card p,
+.source-card p,
+.panel-note {
+  color: var(--muted);
+  font-size: 0.82rem;
+  line-height: 1.45;
+  margin: 8px 0;
+}
+
+.card-row {
+  align-items: center;
+  display: flex;
+  gap: 10px;
+  justify-content: space-between;
+}
+
+.card-title {
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+}
+
+.status-pill {
+  border-radius: 999px;
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  padding: 3px 7px;
+}
+
+.status-pill[data-status="live"] {
+  background: rgba(34, 197, 94, 0.12);
+  color: #86efac;
+}
+
+.status-pill[data-status="degraded"],
+.status-pill[data-status="planned"] {
+  background: rgba(234, 179, 8, 0.12);
+  color: #fde68a;
+}
+
+.status-pill[data-status="blocked"] {
+  background: rgba(239, 68, 68, 0.12);
+  color: #fca5a5;
+}
+
+.work-list {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.work-item {
+  align-items: center;
+  border-bottom: 1px solid var(--border);
+  color: var(--text);
+  display: grid;
+  gap: 10px;
+  grid-template-columns: 56px minmax(0, 1fr) minmax(160px, 280px);
+  padding: 10px 12px;
+}
+
+.work-item:last-child {
+  border-bottom: 0;
+}
+
+.work-item:hover {
+  background: rgba(95, 168, 255, 0.08);
+  text-decoration: none;
+}
+
+.work-number,
+.work-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.work-number {
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+}
+
+.work-title {
+  font-size: 0.9rem;
+}
+
+.panel-title {
+  align-items: center;
+  display: flex;
+  gap: 8px;
+  margin-bottom: 8px;
 }
 
 .live-dot {
@@ -79,16 +266,16 @@ h2 {
 }
 
 .live-dot[data-state="open"] {
-  background: #4ade80;
-  box-shadow: 0 0 0 4px rgba(74, 222, 128, 0.15);
+  background: var(--good);
+  box-shadow: 0 0 0 4px rgba(34, 197, 94, 0.15);
 }
 
 .live-dot[data-state="connecting"] {
-  background: #fbbf24;
+  background: var(--warn);
 }
 
 .live-dot[data-state="closed"] {
-  background: #ef4444;
+  background: var(--bad);
 }
 
 ul.links {
@@ -122,42 +309,9 @@ ul.links a:hover {
 }
 
 .empty {
-  padding: 2rem 0;
+  padding: 1rem 0;
   color: var(--muted);
   font-size: 0.9rem;
-}
-
-form.add {
-  display: flex;
-  gap: 0.5rem;
-  margin: 1.25rem 0 2rem;
-}
-
-form.add input {
-  flex: 1;
-  padding: 0.5rem 0.75rem;
-  border: 1px solid var(--border);
-  border-radius: 0.375rem;
-  background: var(--surface);
-  color: var(--text);
-  font-family: var(--font-sans);
-  font-size: 0.9rem;
-}
-
-form.add button {
-  padding: 0.5rem 1rem;
-  border: 1px solid var(--accent);
-  border-radius: 0.375rem;
-  background: var(--accent);
-  color: var(--bg);
-  font-family: var(--font-mono);
-  font-size: 0.85rem;
-  cursor: pointer;
-}
-
-form.add button:disabled {
-  opacity: 0.5;
-  cursor: wait;
 }
 
 ul.commits {
@@ -192,4 +346,34 @@ ul.commits li {
   color: var(--text);
   font-weight: 500;
   word-break: break-word;
+}
+
+@media (max-width: 980px) {
+  main {
+    padding: 16px;
+  }
+
+  .hero-band,
+  .metric-grid,
+  .source-grid,
+  .feed-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .hero-band {
+    align-items: start;
+  }
+}
+
+@media (max-width: 680px) {
+  .section-heading,
+  .hero-actions {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .work-item {
+    align-items: start;
+    grid-template-columns: 1fr;
+  }
 }

--- a/apps/admin-solid/src/components/CommitFeed.tsx
+++ b/apps/admin-solid/src/components/CommitFeed.tsx
@@ -1,5 +1,6 @@
 import { createSignal, For, onCleanup, onMount, Show } from "solid-js";
 import { isServer } from "solid-js/web";
+import { getStateWs } from "~/lib/config";
 import { StateClient, type ConnectionState } from "~/lib/state-client";
 
 type Commit = {
@@ -14,10 +15,6 @@ type Commit = {
 type CodeStatsEvent =
   | { type: "snapshot"; commits: Commit[] }
   | { type: "commit.added"; commit: Commit };
-
-const STATE_API =
-  (import.meta.env.VITE_PUBLIC_STATE_API as string | undefined) ??
-  "https://anipotts-state.anipotts.workers.dev";
 
 function formatRelative(iso: string): string {
   const then = new Date(iso).getTime();
@@ -43,7 +40,7 @@ export function CommitFeed() {
   onMount(() => {
     if (isServer) return;
     client = new StateClient<CodeStatsEvent>({
-      url: `${STATE_API.replace(/^http/, "ws")}/api/commits/ws`,
+      url: getStateWs("/api/commits/ws"),
       onState: setConn,
       onEvent: (event) => {
         if (event.type === "snapshot") setCommits(event.commits);
@@ -60,10 +57,10 @@ export function CommitFeed() {
   onCleanup(() => client?.close());
 
   return (
-    <section>
-      <h2>
+    <section class="feed-panel">
+      <h2 class="panel-title">
         <span class="live-dot" data-state={conn()} />
-        CodeStats
+        codestats
       </h2>
 
       <Show

--- a/apps/admin-solid/src/components/FleetDashboard.tsx
+++ b/apps/admin-solid/src/components/FleetDashboard.tsx
@@ -1,0 +1,265 @@
+import { createMemo, createSignal, For, onMount, Show } from "solid-js";
+import { getStateApi } from "~/lib/config";
+
+type FeedStatus = "live" | "degraded" | "blocked" | "planned";
+
+type ServiceCheck = {
+  label: string;
+  target: string;
+  status: FeedStatus;
+  detail: string;
+  checkedAt?: string;
+};
+
+type GitHubPull = {
+  number: number;
+  title: string;
+  html_url: string;
+  head: { ref: string };
+  user: { login: string };
+};
+
+type StateHealth = {
+  ok: boolean;
+  ts: string;
+};
+
+function statusLabel(status: FeedStatus): string {
+  if (status === "live") return "live";
+  if (status === "degraded") return "degraded";
+  if (status === "blocked") return "gated";
+  return "planned";
+}
+
+function formatTime(value?: string): string {
+  if (!value) return "not checked";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleTimeString("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+async function checkJson(url: string): Promise<{
+  ok: boolean;
+  detail: string;
+  checkedAt: string;
+}> {
+  const startedAt = Date.now();
+  try {
+    const res = await fetch(url, {
+      method: "GET",
+      signal: AbortSignal.timeout(5000),
+    });
+    return {
+      ok: res.ok,
+      detail: `${res.status} in ${Date.now() - startedAt}ms`,
+      checkedAt: new Date().toISOString(),
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      detail: error instanceof Error ? error.message : "request failed",
+      checkedAt: new Date().toISOString(),
+    };
+  }
+}
+
+export function FleetDashboard() {
+  const [checks, setChecks] = createSignal<ServiceCheck[]>([]);
+  const [pulls, setPulls] = createSignal<GitHubPull[]>([]);
+  const [githubError, setGithubError] = createSignal<string | null>(null);
+  const stateApi = getStateApi();
+
+  onMount(() => {
+    void refresh();
+  });
+
+  async function refresh(): Promise<void> {
+    setGithubError(null);
+
+    const [stateHealth, stateCommits, stateLinks, miniHealth] =
+      await Promise.all([
+        checkJson(`${stateApi}/health`),
+        checkJson(`${stateApi}/api/commits?limit=1`),
+        checkJson(`${stateApi}/api/links`),
+        checkJson("https://api.mini.anipotts.com/health"),
+      ]);
+
+    setChecks([
+      {
+        label: "state worker",
+        target: `${stateApi}/health`,
+        status: stateHealth.ok ? "live" : "degraded",
+        detail: stateHealth.detail,
+        checkedAt: stateHealth.checkedAt,
+      },
+      {
+        label: "commit feed",
+        target: `${stateApi}/api/commits`,
+        status: stateCommits.ok ? "live" : "degraded",
+        detail: stateCommits.detail,
+        checkedAt: stateCommits.checkedAt,
+      },
+      {
+        label: "link vault",
+        target: `${stateApi}/api/links`,
+        status: stateLinks.ok ? "live" : "degraded",
+        detail: stateLinks.detail,
+        checkedAt: stateLinks.checkedAt,
+      },
+      {
+        label: "mini api",
+        target: "https://api.mini.anipotts.com/health",
+        status: miniHealth.ok ? "live" : "blocked",
+        detail: miniHealth.ok
+          ? miniHealth.detail
+          : `${miniHealth.detail}. route is gated on mini tunnel repair`,
+        checkedAt: miniHealth.checkedAt,
+      },
+    ]);
+
+    try {
+      const res = await fetch(
+        "https://api.github.com/repos/anipotts/anipotts.com/pulls?state=open&per_page=20",
+        { headers: { Accept: "application/vnd.github+json" } },
+      );
+      if (!res.ok) throw new Error(`github returned ${res.status}`);
+      setPulls((await res.json()) as GitHubPull[]);
+    } catch (error) {
+      setGithubError(error instanceof Error ? error.message : "github request failed");
+    }
+  }
+
+  const openDependabotCount = createMemo(
+    () => pulls().filter((pull) => pull.user.login === "dependabot[bot]").length,
+  );
+
+  return (
+    <div class="dashboard-stack">
+      <section class="hero-band">
+        <div>
+          <p class="eyebrow">control plane</p>
+          <h1>anipotts admin</h1>
+          <p class="lede">
+            Live fleet feed for code, machines, business, brand, and open loops.
+            This version starts with safe read-only sources and names the bridges
+            still gated behind server tokens or mini tunnel repair.
+          </p>
+        </div>
+        <div class="hero-actions">
+          <button type="button" onClick={() => void refresh()}>
+            refresh
+          </button>
+          <a href="https://legacy-admin.anipotts.com">legacy admin</a>
+        </div>
+      </section>
+
+      <section class="section-block" aria-labelledby="status-title">
+        <div class="section-heading">
+          <div>
+            <p class="eyebrow">live checks</p>
+            <h2 id="status-title">fleet status</h2>
+          </div>
+          <span class="muted">state api: {stateApi}</span>
+        </div>
+        <div class="metric-grid">
+          <For each={checks()}>
+            {(check) => (
+              <article class="metric-card">
+                <div class="card-row">
+                  <span class="card-title">{check.label}</span>
+                  <span class="status-pill" data-status={check.status}>
+                    {statusLabel(check.status)}
+                  </span>
+                </div>
+                <p>{check.detail}</p>
+                <span class="muted">{formatTime(check.checkedAt)}</span>
+              </article>
+            )}
+          </For>
+        </div>
+      </section>
+
+      <section class="section-block" aria-labelledby="work-title">
+        <div class="section-heading">
+          <div>
+            <p class="eyebrow">github</p>
+            <h2 id="work-title">active work</h2>
+          </div>
+          <span class="muted">
+            {pulls().length} open, {openDependabotCount()} dependabot
+          </span>
+        </div>
+        <Show
+          when={!githubError()}
+          fallback={<p class="empty">GitHub feed degraded: {githubError()}</p>}
+        >
+          <div class="work-list">
+            <For each={pulls().slice(0, 8)}>
+              {(pull) => (
+                <a class="work-item" href={pull.html_url}>
+                  <span class="work-number">#{pull.number}</span>
+                  <span class="work-title">{pull.title}</span>
+                  <span class="muted">{pull.head.ref}</span>
+                </a>
+              )}
+            </For>
+          </div>
+        </Show>
+      </section>
+
+      <section class="section-block" aria-labelledby="sources-title">
+        <div class="section-heading">
+          <div>
+            <p class="eyebrow">source map</p>
+            <h2 id="sources-title">next bridges</h2>
+          </div>
+        </div>
+        <div class="source-grid">
+          <SourceCard
+            title="business"
+            status="planned"
+            body="deals, deadlines, revenue, domains, and compliance should come from D1 through a server-side admin-solid endpoint."
+          />
+          <SourceCard
+            title="brand"
+            status="planned"
+            body="brand content, sponsorships, proof artifacts, and publishing status need a typed read model before write tools move over."
+          />
+          <SourceCard
+            title="responsibilities"
+            status="planned"
+            body="open loops should aggregate Infra bus refs, handoffs, NEEDS-ANI, and active PR blockers without printing private payloads."
+          />
+          <SourceCard
+            title="machines"
+            status="blocked"
+            body="mini live machine data is waiting on the api.mini.anipotts.com tunnel repair gate."
+          />
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function SourceCard(props: {
+  title: string;
+  status: FeedStatus;
+  body: string;
+}) {
+  return (
+    <article class="source-card">
+      <div class="card-row">
+        <span class="card-title">{props.title}</span>
+        <span class="status-pill" data-status={props.status}>
+          {statusLabel(props.status)}
+        </span>
+      </div>
+      <p>{props.body}</p>
+    </article>
+  );
+}
+
+export type { StateHealth };

--- a/apps/admin-solid/src/components/LinkVaultPanel.tsx
+++ b/apps/admin-solid/src/components/LinkVaultPanel.tsx
@@ -1,5 +1,6 @@
 import { createSignal, For, onCleanup, onMount, Show } from "solid-js";
 import { isServer } from "solid-js/web";
+import { getStateWs } from "~/lib/config";
 import { StateClient, type ConnectionState } from "~/lib/state-client";
 
 type Link = {
@@ -16,21 +17,16 @@ type LinkVaultEvent =
   | { type: "link.added"; link: Link }
   | { type: "link.removed"; id: string };
 
-const STATE_API = (import.meta.env.VITE_PUBLIC_STATE_API as string | undefined) ??
-  "https://anipotts-state.anipotts.workers.dev";
-
 export function LinkVaultPanel() {
   const [links, setLinks] = createSignal<Link[]>([]);
   const [conn, setConn] = createSignal<ConnectionState>("connecting");
-  const [submitting, setSubmitting] = createSignal(false);
-  const [draftUrl, setDraftUrl] = createSignal("");
 
   let client: StateClient<LinkVaultEvent> | null = null;
 
   onMount(() => {
     if (isServer) return;
     client = new StateClient<LinkVaultEvent>({
-      url: `${STATE_API.replace(/^http/, "ws")}/api/links/ws`,
+      url: getStateWs("/api/links/ws"),
       onState: setConn,
       onEvent: (event) => {
         if (event.type === "snapshot") setLinks(event.links);
@@ -46,49 +42,22 @@ export function LinkVaultPanel() {
 
   onCleanup(() => client?.close());
 
-  async function submit(e: SubmitEvent) {
-    e.preventDefault();
-    const url = draftUrl().trim();
-    if (!url) return;
-    setSubmitting(true);
-    try {
-      await fetch(`${STATE_API}/api/links`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ url, source: "admin" }),
-      });
-      setDraftUrl("");
-    } finally {
-      setSubmitting(false);
-    }
-  }
-
   return (
-    <section>
-      <h2>
+    <section class="feed-panel">
+      <h2 class="panel-title">
         <span class="live-dot" data-state={conn()} />
-        LinkVault
+        linkvault
       </h2>
-
-      <form class="add" onSubmit={submit}>
-        <input
-          type="url"
-          required
-          placeholder="https://..."
-          value={draftUrl()}
-          onInput={(e) => setDraftUrl(e.currentTarget.value)}
-        />
-        <button type="submit" disabled={submitting()}>
-          save
-        </button>
-      </form>
+      <p class="panel-note">
+        read-only for now. writes move behind an authenticated server action in
+        the next pass.
+      </p>
 
       <Show
         when={links().length > 0}
         fallback={
           <p class="empty">
-            No links yet. Save one above, or text Rudy{" "}
-            <span class="muted">"save https://..."</span>.
+            No links yet. Publisher writes require STATE_PUBLISH_KEY.
           </p>
         }
       >

--- a/apps/admin-solid/src/entry-server.tsx
+++ b/apps/admin-solid/src/entry-server.tsx
@@ -7,9 +7,8 @@ export default createHandler(() => (
         <head>
           <meta charset="utf-8" />
           <meta name="viewport" content="width=device-width, initial-scale=1" />
-          <meta name="theme-color" content="#fbfaf7" media="(prefers-color-scheme: light)" />
-          <meta name="theme-color" content="#11111b" media="(prefers-color-scheme: dark)" />
-          <title>anipotts / admin</title>
+          <meta name="theme-color" content="#0f1115" />
+          <title>anipotts admin</title>
           {assets}
         </head>
         <body>

--- a/apps/admin-solid/src/lib/config.ts
+++ b/apps/admin-solid/src/lib/config.ts
@@ -1,0 +1,19 @@
+export const DEFAULT_STATE_API = "https://api.anipotts.com";
+
+function readEnv(name: string): string | undefined {
+  const value = import.meta.env[name] as string | undefined;
+  return value && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+export function getStateApi(): string {
+  return (
+    readEnv("PUBLIC_STATE_API") ??
+    readEnv("VITE_PUBLIC_STATE_API") ??
+    DEFAULT_STATE_API
+  ).replace(/\/+$/, "");
+}
+
+export function getStateWs(path: string): string {
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  return `${getStateApi().replace(/^http/, "ws")}${normalizedPath}`;
+}

--- a/apps/admin-solid/src/routes/index.tsx
+++ b/apps/admin-solid/src/routes/index.tsx
@@ -1,16 +1,23 @@
 import { CommitFeed } from "~/components/CommitFeed";
+import { FleetDashboard } from "~/components/FleetDashboard";
 import { LinkVaultPanel } from "~/components/LinkVaultPanel";
 
 export default function Home() {
   return (
     <main>
-      <h1>anipotts / admin</h1>
-      <p class="muted">
-        v2 build. SolidStart on Cloudflare Workers, live state via Durable Object WebSockets. No
-        polling.
-      </p>
-      <LinkVaultPanel />
-      <CommitFeed />
+      <FleetDashboard />
+      <section class="section-block" aria-labelledby="feeds-title">
+        <div class="section-heading">
+          <div>
+            <p class="eyebrow">durable objects</p>
+            <h2 id="feeds-title">live feeds</h2>
+          </div>
+        </div>
+        <div class="feed-grid">
+          <CommitFeed />
+          <LinkVaultPanel />
+        </div>
+      </section>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- add a dense admin-solid dashboard shell for fleet status, active GitHub work, source bridges, and Durable Object live feeds
- centralize state API config so PUBLIC_STATE_API and VITE_PUBLIC_STATE_API both work, with https://api.anipotts.com as the default
- remove the unauthenticated LinkVault write form and keep it read-only until writes move behind a server-side authenticated action
- show explicit planned or gated states for business, brand, responsibilities, and mini machine data instead of pretending those feeds are wired

## Verification
- pnpm --filter @anipotts/admin-solid typecheck
- pnpm --filter @anipotts/admin-solid build
- local dev server curl confirmed rendered sections: anipotts admin, fleet status, active work, next bridges, live feeds
- pnpm validate

## Live impact
None. This PR is draft and does not deploy or merge anything.

## Next admin work
- add server-side admin-solid dashboard endpoints for D1 business and brand data
- add a safe responsibilities feed from Infra bus, NEEDS-ANI, handoffs, and PR blockers without private payloads
- repair mini API tunnel behind the infra/live-service gate, then wire machine health and sessions into this shell
