### PR TITLE
Clean public site links and homepage cards

### DIFF
--- a/apps/www/src/content/writing/saturdays-are-for-claude-code.md
+++ b/apps/www/src/content/writing/saturdays-are-for-claude-code.md
@@ -25,7 +25,7 @@ Active tool rate holds steady at about 3.3 calls per minute for any session over
 
 Sessions under 30 minutes are the sweet spot. Past an hour, more than half hit context limits and need compaction. That's when you lose coherence. So the usage limit forcing you to stop isn't just about tokens. It's preventing the session quality degradation that happens naturally anyway.
 
-You can see all of this on [my Claude stats page](/claude). It's live, updated from my actual session logs.
+You can see all of this on [my orchestrating page](/orchestrating). It's live, updated from my actual session logs.
 
 ## Why the limit is a feature
 

--- a/apps/www/src/pages/index.astro
+++ b/apps/www/src/pages/index.astro
@@ -30,10 +30,10 @@ const work = cmsHome.sections.past_work;
 const writing = cmsHome.sections.latest_thoughts;
 const heading = hasCmsHome ? intro.heading : homeContent.heading;
 const homeMakingSlugs = [
+  "quantercise",
   "quantercise-extension",
   "saeshify",
   "nyu-purity-test",
-  "habittracker-obh",
 ] as const;
 const homeMakingOrder = new Map<string, number>(
   homeMakingSlugs.map((slug, index) => [slug, index]),


### PR DESCRIPTION
## Summary
- update the stale `/claude` writing link to `/orchestrating`
- swap the hidden `habittracker-obh` homepage making card for visible `quantercise`
- keep this as a small public-site-only cleanup branch

## Verification
- pnpm --filter @anipotts/www typecheck
- pnpm --filter @anipotts/www build
- pnpm validate

## Live impact
None. This PR is draft and does not deploy or merge anything.
