### PR TITLE
Build admin control-plane shell

### DIFF
--- a/apps/admin-solid/src/app.css
+++ b/apps/admin-solid/src/app.css
@@ -1,23 +1,18 @@
 :root {
-  --bg: #fbfaf7;
-  --surface: #f3f1ec;
-  --text: #1a1a1a;
-  --muted: #6b6b6b;
-  --accent: #2563eb;
-  --border: rgba(0, 0, 0, 0.08);
+  --bg: #111111;
+  --panel: #181818;
+  --panel-strong: #242424;
+  --text: #f4f4f1;
+  --muted: #9a9a92;
+  --border: rgba(255, 255, 255, 0.09);
+  --safe: #22c55e;
+  --approval: #f59e0b;
+  --running: #35c2d1;
+  --blocked: #ef4444;
+  --stale: #a78bfa;
+  --destructive: #fb7185;
   --font-sans: "Inter", -apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif;
   --font-mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --bg: #11111b;
-    --surface: #1e1e2e;
-    --text: #cdd6f4;
-    --muted: #7f849c;
-    --accent: #89b4fa;
-    --border: rgba(205, 214, 244, 0.08);
-  }
 }
 
 * {
@@ -27,169 +22,432 @@
 html,
 body {
   margin: 0;
-  padding: 0;
+  min-height: 100%;
   background: var(--bg);
   color: var(--text);
   font-family: var(--font-sans);
   -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
   text-rendering: optimizeLegibility;
 }
 
 a {
-  color: var(--accent);
+  color: inherit;
   text-decoration: none;
 }
 
-a:hover {
-  text-decoration: underline;
+main {
+  width: min(1560px, 100%);
+  margin: 0 auto;
+  padding: 20px;
 }
 
-main {
-  max-width: 68ch;
-  margin: 0 auto;
-  padding: 4rem 1.5rem 6rem;
+h1,
+h2,
+h3,
+p,
+dl,
+dd {
+  margin: 0;
 }
 
 h1 {
   font-family: var(--font-mono);
-  font-size: 1.5rem;
-  font-weight: 500;
-  letter-spacing: -0.01em;
-  margin: 0 0 0.5rem;
+  font-size: clamp(1.65rem, 3vw, 2.75rem);
+  font-weight: 600;
+  letter-spacing: 0;
 }
 
 h2 {
-  font-family: var(--font-mono);
-  font-size: 0.75rem;
-  font-weight: 500;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
+  font-size: 1rem;
+  font-weight: 650;
+}
+
+h3 {
+  font-size: 0.92rem;
+  font-weight: 620;
+  line-height: 1.35;
+}
+
+.app-header {
+  align-items: end;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  display: grid;
+  gap: 16px;
+  grid-template-columns: minmax(0, 1fr) auto;
+  padding: 18px;
+}
+
+.lede {
   color: var(--muted);
-  margin: 2.5rem 0 1rem;
+  line-height: 1.55;
+  margin-top: 8px;
+  max-width: 880px;
 }
 
-.live-dot {
-  display: inline-block;
-  width: 0.5rem;
-  height: 0.5rem;
-  border-radius: 9999px;
-  margin-right: 0.5rem;
-  vertical-align: middle;
+.eyebrow,
+.muted,
+.model-chip,
+.status-pill,
+.risk-pill,
+dt,
+.strip-label,
+.strip-count {
+  font-family: var(--font-mono);
 }
 
-.live-dot[data-state="open"] {
-  background: #4ade80;
-  box-shadow: 0 0 0 4px rgba(74, 222, 128, 0.15);
-}
-
-.live-dot[data-state="connecting"] {
-  background: #fbbf24;
-}
-
-.live-dot[data-state="closed"] {
-  background: #ef4444;
-}
-
-ul.links {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-}
-
-ul.links li {
-  padding: 0.875rem 0;
-  border-bottom: 1px solid var(--border);
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-}
-
-ul.links a {
-  color: var(--text);
-  font-weight: 500;
-  word-break: break-all;
-}
-
-ul.links a:hover {
-  color: var(--accent);
+.eyebrow {
+  color: var(--muted);
+  font-size: 0.68rem;
+  margin-bottom: 7px;
+  text-transform: uppercase;
 }
 
 .muted {
   color: var(--muted);
-  font-size: 0.8rem;
-  font-family: var(--font-mono);
+  font-size: 0.76rem;
+  line-height: 1.45;
 }
 
-.empty {
-  padding: 2rem 0;
-  color: var(--muted);
-  font-size: 0.9rem;
-}
-
-form.add {
-  display: flex;
-  gap: 0.5rem;
-  margin: 1.25rem 0 2rem;
-}
-
-form.add input {
-  flex: 1;
-  padding: 0.5rem 0.75rem;
+.model-chip {
+  background: var(--panel-strong);
   border: 1px solid var(--border);
-  border-radius: 0.375rem;
-  background: var(--surface);
-  color: var(--text);
-  font-family: var(--font-sans);
-  font-size: 0.9rem;
-}
-
-form.add button {
-  padding: 0.5rem 1rem;
-  border: 1px solid var(--accent);
-  border-radius: 0.375rem;
-  background: var(--accent);
-  color: var(--bg);
-  font-family: var(--font-mono);
-  font-size: 0.85rem;
-  cursor: pointer;
-}
-
-form.add button:disabled {
-  opacity: 0.5;
-  cursor: wait;
-}
-
-ul.commits {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-}
-
-ul.commits li {
-  padding: 0.875rem 0;
-  border-bottom: 1px solid var(--border);
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-}
-
-.commit-line {
-  display: flex;
-  gap: 0.625rem;
-  align-items: baseline;
-  font-size: 0.95rem;
-}
-
-.commit-sha {
-  font-family: var(--font-mono);
+  border-radius: 999px;
   color: var(--muted);
-  font-size: 0.8rem;
-  flex-shrink: 0;
+  font-size: 0.72rem;
+  padding: 8px 10px;
+  white-space: nowrap;
 }
 
-.commit-subject {
+.nav-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 14px 0;
+}
+
+.nav-row a {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  padding: 9px 11px;
+}
+
+.nav-row a[aria-current="page"],
+.nav-row a:hover {
+  border-color: rgba(56, 189, 248, 0.4);
   color: var(--text);
-  font-weight: 500;
-  word-break: break-word;
+}
+
+.top-strip {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  margin-bottom: 20px;
+}
+
+.strip-card,
+.panel-card,
+.action-card,
+.table-card {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+
+.strip-card {
+  min-height: 120px;
+  padding: 12px;
+}
+
+.strip-count {
+  display: block;
+  font-size: 1rem;
+  font-weight: 650;
+  line-height: 1.2;
+}
+
+.strip-label {
+  display: block;
+  font-size: 0.72rem;
+  margin: 9px 0 7px;
+  text-transform: uppercase;
+}
+
+.strip-card[data-state="safe"] {
+  border-color: rgba(34, 197, 94, 0.28);
+}
+
+.strip-card[data-state="needs-approval"] {
+  border-color: rgba(245, 158, 11, 0.28);
+}
+
+.strip-card[data-state="running"] {
+  border-color: rgba(56, 189, 248, 0.28);
+}
+
+.strip-card[data-state="blocked"] {
+  border-color: rgba(239, 68, 68, 0.28);
+}
+
+.strip-card[data-state="stale"] {
+  border-color: rgba(167, 139, 250, 0.28);
+}
+
+.strip-card[data-state="destructive"] {
+  border-color: rgba(251, 113, 133, 0.28);
+}
+
+.page-stack {
+  display: grid;
+  gap: 18px;
+}
+
+.section-header {
+  align-items: end;
+  border-top: 1px solid var(--border);
+  display: flex;
+  gap: 16px;
+  justify-content: space-between;
+  margin-bottom: 12px;
+  padding-top: 14px;
+}
+
+.grid {
+  display: grid;
+  gap: 12px;
+}
+
+.actions-grid,
+.destructive-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.grid.two {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.action-card,
+.panel-card {
+  padding: 14px;
+}
+
+.card-top {
+  align-items: start;
+  display: flex;
+  gap: 12px;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.pill-row {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.align-end {
+  justify-content: end;
+}
+
+.status-pill,
+.risk-pill {
+  border-radius: 999px;
+  display: inline-flex;
+  font-size: 0.68rem;
+  line-height: 1;
+  padding: 5px 7px;
+  white-space: nowrap;
+}
+
+.status-pill[data-state="safe"],
+.status-pill[data-state="verified"],
+.status-pill[data-state="valid"],
+.status-pill[data-state="active"],
+.status-pill[data-state="absorbed"],
+.status-pill[data-state="current"] {
+  background: rgba(34, 197, 94, 0.12);
+  color: #86efac;
+}
+
+.status-pill[data-state="needs-approval"],
+.status-pill[data-state="approved"],
+.status-pill[data-state="proposed"] {
+  background: rgba(245, 158, 11, 0.12);
+  color: #fcd34d;
+}
+
+.status-pill[data-state="running"],
+.status-pill[data-state="queued"],
+.status-pill[data-state="partially_absorbed"] {
+  background: rgba(53, 194, 209, 0.12);
+  color: #9be8ef;
+}
+
+.status-pill[data-state="blocked"],
+.status-pill[data-state="waiting_on_agent"],
+.status-pill[data-state="open"] {
+  background: rgba(239, 68, 68, 0.12);
+  color: #fca5a5;
+}
+
+.status-pill[data-state="stale"] {
+  background: rgba(167, 139, 250, 0.12);
+  color: #c4b5fd;
+}
+
+.status-pill[data-state="destructive"] {
+  background: rgba(251, 113, 133, 0.12);
+  color: #fda4af;
+}
+
+.risk-pill[data-risk="low"] {
+  background: rgba(34, 197, 94, 0.1);
+  color: #bbf7d0;
+}
+
+.risk-pill[data-risk="medium"] {
+  background: rgba(245, 158, 11, 0.1);
+  color: #fde68a;
+}
+
+.risk-pill[data-risk="high"],
+.risk-pill[data-risk="critical"] {
+  background: rgba(239, 68, 68, 0.1);
+  color: #fecaca;
+}
+
+.flow-grid {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+}
+
+.flow-grid div,
+.fact {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 6px;
+  min-width: 0;
+  padding: 9px;
+}
+
+dt,
+.fact span {
+  color: var(--muted);
+  display: block;
+  font-size: 0.64rem;
+  margin-bottom: 6px;
+  text-transform: uppercase;
+}
+
+dd,
+.fact strong {
+  color: var(--text);
+  display: block;
+  font-size: 0.78rem;
+  font-weight: 520;
+  line-height: 1.35;
+}
+
+.table-card {
+  overflow: hidden;
+}
+
+.table-row {
+  border-bottom: 1px solid var(--border);
+  display: grid;
+  gap: 12px;
+  padding: 12px;
+}
+
+.table-row:last-child {
+  border-bottom: 0;
+}
+
+.mutation-row {
+  grid-template-columns: minmax(180px, 0.75fr) minmax(460px, 2.5fr) minmax(120px, 0.4fr);
+}
+
+.authority-row {
+  grid-template-columns: minmax(220px, 0.8fr) repeat(3, minmax(180px, 1fr)) minmax(120px, 0.4fr);
+}
+
+.proof-row {
+  grid-template-columns: minmax(240px, 1fr) repeat(3, minmax(180px, 1fr)) minmax(90px, 0.35fr);
+}
+
+.repo-row {
+  grid-template-columns: minmax(160px, 0.8fr) repeat(5, minmax(120px, 1fr));
+}
+
+.handoff-row {
+  align-items: start;
+  grid-template-columns: minmax(220px, 1fr) 120px repeat(4, minmax(140px, 1fr));
+}
+
+.repo-row .proof-line,
+.handoff-row .proof-line {
+  grid-column: 1 / -1;
+}
+
+.fact-grid {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.proof-line {
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  line-height: 1.45;
+  margin-top: 10px;
+}
+
+@media (max-width: 1200px) {
+  .top-strip,
+  .actions-grid,
+  .destructive-grid,
+  .grid.two {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .flow-grid,
+  .mutation-row,
+  .authority-row,
+  .proof-row,
+  .repo-row,
+  .handoff-row {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 720px) {
+  main {
+    padding: 14px;
+  }
+
+  .app-header,
+  .top-strip,
+  .actions-grid,
+  .destructive-grid,
+  .grid.two,
+  .fact-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .section-header,
+  .card-top {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .model-chip {
+    white-space: normal;
+  }
 }

--- a/apps/admin-solid/src/app.css
+++ b/apps/admin-solid/src/app.css
@@ -283,6 +283,7 @@ dt,
 
 .status-pill[data-state="running"],
 .status-pill[data-state="queued"],
+.status-pill[data-state="waiting"],
 .status-pill[data-state="partially_absorbed"] {
   background: rgba(53, 194, 209, 0.12);
   color: #9be8ef;
@@ -290,6 +291,7 @@ dt,
 
 .status-pill[data-state="blocked"],
 .status-pill[data-state="waiting_on_agent"],
+.status-pill[data-state="waiting_on_ani"],
 .status-pill[data-state="open"] {
   background: rgba(239, 68, 68, 0.12);
   color: #fca5a5;

--- a/apps/admin-solid/src/app.css
+++ b/apps/admin-solid/src/app.css
@@ -387,14 +387,34 @@ dd,
   grid-template-columns: minmax(160px, 0.8fr) repeat(5, minmax(120px, 1fr));
 }
 
+.runtime-row {
+  grid-template-columns: minmax(180px, 0.9fr) repeat(7, minmax(112px, 1fr));
+}
+
 .handoff-row {
   align-items: start;
   grid-template-columns: minmax(220px, 1fr) 120px repeat(4, minmax(140px, 1fr));
 }
 
 .repo-row .proof-line,
+.runtime-row .proof-line,
 .handoff-row .proof-line {
   grid-column: 1 / -1;
+}
+
+.runtime-panel {
+  display: grid;
+  gap: 12px;
+}
+
+.section-header.compact {
+  margin-bottom: 0;
+}
+
+.runtime-safety {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
 .fact-grid {
@@ -424,6 +444,7 @@ dd,
   .authority-row,
   .proof-row,
   .repo-row,
+  .runtime-row,
   .handoff-row {
     grid-template-columns: 1fr;
   }
@@ -439,7 +460,8 @@ dd,
   .actions-grid,
   .destructive-grid,
   .grid.two,
-  .fact-grid {
+  .fact-grid,
+  .runtime-safety {
     grid-template-columns: 1fr;
   }
 

--- a/apps/admin-solid/src/components/ControlPlane.tsx
+++ b/apps/admin-solid/src/components/ControlPlane.tsx
@@ -1,0 +1,351 @@
+import { A } from "@solidjs/router";
+import { For, Show } from "solid-js";
+import type { JSX } from "solid-js";
+import type {
+  AuthorityCard,
+  ControlState,
+  DestructiveGate,
+  HandoffCard,
+  OperationCard,
+  ProofCard,
+  RepoCard,
+  RiskLevel,
+  WorkCard,
+} from "~/data/control-plane";
+import { topStrip } from "~/data/control-plane";
+
+const navItems = [
+  { href: "/", label: "overview" },
+  { href: "/mutations", label: "mutations" },
+  { href: "/fleet", label: "fleet" },
+  { href: "/repos", label: "repos" },
+  { href: "/handoffs", label: "handoffs" },
+  { href: "/ops/destructive", label: "destructive ops" },
+];
+
+export function ControlPlaneLayout(props: {
+  title: string;
+  deck: string;
+  children: JSX.Element;
+}) {
+  return (
+    <main>
+      <header class="app-header">
+        <div>
+          <p class="eyebrow">admin.anipotts.com</p>
+          <h1>{props.title}</h1>
+          <p class="lede">{props.deck}</p>
+        </div>
+        <div class="model-chip">intent / authority / operation / proof / state</div>
+      </header>
+
+      <nav class="nav-row" aria-label="admin control-plane sections">
+        <For each={navItems}>
+          {(item) => (
+            <A href={item.href} end={item.href === "/"}>
+              {item.label}
+            </A>
+          )}
+        </For>
+      </nav>
+
+      <TopStrip />
+
+      <div class="page-stack">{props.children}</div>
+    </main>
+  );
+}
+
+export function TopStrip() {
+  return (
+    <section class="top-strip" aria-label="fleet control states">
+      <For each={topStrip}>
+        {(item) => (
+          <article class="strip-card" data-state={stateKey(item.status)}>
+            <span class="strip-count">{item.title}</span>
+            <span class="strip-label">{item.status}</span>
+            <span class="muted">{item.next_safe_action}</span>
+          </article>
+        )}
+      </For>
+    </section>
+  );
+}
+
+export function StatusPill(props: { state: ControlState }) {
+  return (
+    <span class="status-pill" data-state={stateKey(props.state)}>
+      {props.state}
+    </span>
+  );
+}
+
+export function RiskPill(props: { risk: RiskLevel }) {
+  return (
+    <span class="risk-pill" data-risk={props.risk}>
+      {props.risk}
+    </span>
+  );
+}
+
+export function SectionHeader(props: {
+  eyebrow: string;
+  title: string;
+  detail?: string;
+}) {
+  return (
+    <div class="section-header">
+      <div>
+        <p class="eyebrow">{props.eyebrow}</p>
+        <h2>{props.title}</h2>
+      </div>
+      <Show when={props.detail}>
+        <span class="muted">{props.detail}</span>
+      </Show>
+    </div>
+  );
+}
+
+export function WorkCardView(props: { card: WorkCard }) {
+  return (
+    <article class="action-card">
+      <div class="card-top">
+        <div>
+          <h3>{props.card.title}</h3>
+          <p class="muted">{props.card.next_safe_action}</p>
+        </div>
+        <div class="pill-row">
+          <StatusPill state={props.card.status} />
+          <RiskPill risk={props.card.risk_level} />
+        </div>
+      </div>
+      <FlowGrid
+        intent={props.card.intent}
+        authority={props.card.authority_state}
+        operation={props.card.operation_summary}
+        proof={props.card.proof_ids.join(", ")}
+        state={props.card.status}
+      />
+    </article>
+  );
+}
+
+export function FlowGrid(props: {
+  intent: string;
+  authority: string;
+  operation: string;
+  proof: string;
+  state: ControlState | string;
+}) {
+  return (
+    <dl class="flow-grid">
+      <FlowTerm label="intent" value={props.intent} />
+      <FlowTerm label="authority" value={props.authority} />
+      <FlowTerm label="operation" value={props.operation} />
+      <FlowTerm label="proof" value={props.proof} />
+      <FlowTerm label="state" value={props.state} />
+    </dl>
+  );
+}
+
+function FlowTerm(props: { label: string; value: string }) {
+  return (
+    <div>
+      <dt>{props.label}</dt>
+      <dd>{props.value}</dd>
+    </div>
+  );
+}
+
+export function MutationTable(props: {
+  rows: WorkCard[];
+  authorities: AuthorityCard[];
+  proofs: ProofCard[];
+}) {
+  return (
+    <div class="table-card">
+      <For each={props.rows}>
+        {(row) => (
+          <article class="table-row mutation-row">
+            <div>
+              <h3>{row.title}</h3>
+              <p class="muted">{row.next_safe_action}</p>
+            </div>
+            <FlowGrid
+              intent={row.intent}
+              authority={row.authority_state}
+              operation={row.operation_summary}
+              proof={row.proof_ids.join(", ")}
+              state={row.status}
+            />
+            <div class="pill-row align-end">
+              <StatusPill state={row.status} />
+              <RiskPill risk={row.risk_level} />
+            </div>
+          </article>
+        )}
+      </For>
+
+      <For each={props.authorities}>
+        {(row) => (
+          <article class="table-row authority-row">
+            <div>
+              <h3>{row.title}</h3>
+              <p class="muted">authority_state: {row.authority_state}</p>
+            </div>
+            <Fact label="required_approval_ids" value={row.required_approval_ids.join(", ")} />
+            <Fact label="allowed_actions" value={row.allowed_actions.join(", ")} />
+            <Fact label="forbidden_actions" value={row.forbidden_actions.join(", ")} />
+            <div class="pill-row align-end">
+              <StatusPill state={row.status} />
+              <RiskPill risk={row.risk_level} />
+            </div>
+          </article>
+        )}
+      </For>
+
+      <For each={props.proofs}>
+        {(proof) => (
+          <article class="table-row proof-row">
+            <div>
+              <h3>{proof.title}</h3>
+              <p class="muted">{proof.summary}</p>
+            </div>
+            <Fact label="proof_ids" value={proof.proof_ids.join(", ")} />
+            <Fact label="evidence_uri" value={proof.evidence_uri} />
+            <Fact label="redaction" value={proof.redaction} />
+            <StatusPill state={proof.status} />
+          </article>
+        )}
+      </For>
+    </div>
+  );
+}
+
+export function FleetGrid(props: { operations: OperationCard[] }) {
+  return (
+    <div class="grid two">
+      <For each={props.operations}>
+        {(operation) => (
+          <article class="panel-card">
+            <div class="card-top">
+              <div>
+                <p class="eyebrow">{operation.machine}</p>
+                <h3>{operation.title}</h3>
+              </div>
+              <StatusPill state={operation.status} />
+            </div>
+            <div class="fact-grid">
+              <Fact label="agent" value={operation.agent} />
+              <Fact label="phase" value={operation.phase} />
+              <Fact label="heartbeat_at" value={operation.heartbeat_at} />
+              <Fact label="stop_path" value={operation.stop_path} />
+            </div>
+            <p class="proof-line">next_safe_action: {operation.next_safe_action}</p>
+          </article>
+        )}
+      </For>
+    </div>
+  );
+}
+
+export function RepoTable(props: { repos: RepoCard[] }) {
+  return (
+    <div class="table-card">
+      <For each={props.repos}>
+        {(repo) => (
+          <article class="table-row repo-row">
+            <div>
+              <h3>{repo.repo}</h3>
+              <p class="muted">{repo.path}</p>
+            </div>
+            <Fact label="branch" value={repo.branch} />
+            <Fact label="dirty_tracked" value={formatList(repo.dirty_tracked)} />
+            <Fact label="untracked_count" value={String(repo.untracked_count)} />
+            <Fact label="deploy_impact" value={repo.deploy_impact} />
+            <Fact label="proof_ids" value={repo.proof_ids.join(", ")} />
+            <p class="proof-line">next_safe_action: {repo.next_safe_action}</p>
+          </article>
+        )}
+      </For>
+    </div>
+  );
+}
+
+export function HandoffTable(props: { handoffs: HandoffCard[] }) {
+  return (
+    <div class="table-card">
+      <For each={props.handoffs}>
+        {(handoff) => (
+          <article class="table-row handoff-row">
+            <div>
+              <h3>{handoff.title}</h3>
+              <p class="muted">{handoff.path}</p>
+            </div>
+            <StatusPill state={handoff.status} />
+            <Fact label="freshness" value={handoff.freshness} />
+            <Fact label="absorbed_at" value={handoff.absorbed_at ?? "not absorbed"} />
+            <Fact label="target_owner" value={handoff.target_owner} />
+            <Fact label="proof_ids" value={handoff.proof_ids.join(", ")} />
+            <p class="proof-line">next_safe_action: {handoff.next_safe_action}</p>
+          </article>
+        )}
+      </For>
+    </div>
+  );
+}
+
+export function DestructiveGrid(props: { gates: DestructiveGate[] }) {
+  return (
+    <div class="grid destructive-grid">
+      <For each={props.gates}>
+        {(gate) => (
+          <article class="panel-card destructive-card">
+            <div class="card-top">
+              <div>
+                <p class="eyebrow">{gate.area}</p>
+                <h3>{gate.title}</h3>
+              </div>
+              <div class="pill-row">
+                <StatusPill state={gate.status} />
+                <RiskPill risk={gate.risk_level} />
+              </div>
+            </div>
+            <FlowGrid
+              intent={gate.intent}
+              authority={gate.authority_state}
+              operation={gate.operation_summary}
+              proof={gate.proof_ids.join(", ")}
+              state={gate.status}
+            />
+            <div class="fact-grid">
+              <Fact label="required_approval_ids" value={gate.required_approval_ids.join(", ")} />
+              <Fact label="allowed_actions" value={gate.allowed_actions.join(", ")} />
+              <Fact label="forbidden_actions" value={gate.forbidden_actions.join(", ")} />
+              <Fact label="evidence_uri" value={gate.evidence_uri} />
+              <Fact label="redaction" value={gate.redaction} />
+            </div>
+            <p class="proof-line">next_safe_action: {gate.next_safe_action}</p>
+          </article>
+        )}
+      </For>
+    </div>
+  );
+}
+
+export function Fact(props: { label: string; value: string }) {
+  return (
+    <div class="fact">
+      <span>{props.label}</span>
+      <strong>{props.value}</strong>
+    </div>
+  );
+}
+
+function formatList(values: string[]): string {
+  return values.length > 0 ? values.join(", ") : "none";
+}
+
+function stateKey(state: ControlState): string {
+  return state.replaceAll(" ", "-");
+}

--- a/apps/admin-solid/src/components/ControlPlane.tsx
+++ b/apps/admin-solid/src/components/ControlPlane.tsx
@@ -1,5 +1,5 @@
 import { A } from "@solidjs/router";
-import { For, Show } from "solid-js";
+import { createSignal, For, onMount, Show } from "solid-js";
 import type { JSX } from "solid-js";
 import type {
   AuthorityCard,
@@ -10,6 +10,8 @@ import type {
   ProofCard,
   RepoCard,
   RiskLevel,
+  RuntimeOverlayResponse,
+  RuntimeRepoOverlay,
   WorkCard,
 } from "~/data/control-plane";
 import { topStrip } from "~/data/control-plane";
@@ -269,6 +271,97 @@ export function RepoTable(props: { repos: RepoCard[] }) {
         )}
       </For>
     </div>
+  );
+}
+
+export function RuntimeRepoOverlayPanel() {
+  const [runtime, setRuntime] = createSignal<RuntimeOverlayResponse | null>(null);
+
+  onMount(async () => {
+    try {
+      const response = await fetch("/api/admin/runtime-feed");
+      setRuntime((await response.json()) as RuntimeOverlayResponse);
+    } catch (error) {
+      setRuntime({
+        available: false,
+        mode: "error",
+        generated_at: null,
+        machine: null,
+        source_path: "/Users/anipotts/Infra/state/runtime/admin/admin-feed.current.json",
+        safety: null,
+        overlays: [],
+        error: error instanceof Error ? error.message : "runtime overlay fetch failed",
+      });
+    }
+  });
+
+  return (
+    <div class="runtime-panel">
+      <div class="section-header compact">
+        <div>
+          <p class="eyebrow">local-dev runtime</p>
+          <h2>repo overlays</h2>
+        </div>
+        <Show when={runtime()} fallback={<span class="muted">loading local runtime feed</span>}>
+          {(data) => (
+            <span class="muted">
+              {data().available ? `${data().overlays.length} overlays / ${data().machine ?? "unknown machine"}` : data().mode}
+            </span>
+          )}
+        </Show>
+      </div>
+
+      <Show when={runtime()} fallback={<p class="proof-line">runtime loader is local-dev only</p>}>
+        {(data) => (
+          <>
+            <Show
+              when={data().available}
+              fallback={
+                <p class="proof-line">
+                  runtime overlay unavailable: {data().error ?? data().mode}. source_path: {data().source_path}
+                </p>
+              }
+            >
+              <div class="table-card">
+                <For each={data().overlays}>
+                  {(overlay) => <RuntimeOverlayRow overlay={overlay} />}
+                </For>
+              </div>
+            </Show>
+
+            <div class="runtime-safety">
+              <Fact label="generated_at" value={data().generated_at ?? "not available"} />
+              <Fact label="source_path" value={data().source_path} />
+              <Fact label="safety_mode" value={data().safety?.mode ?? "not available"} />
+              <Fact label="secret_values" value={String(data().safety?.secret_values_included ?? false)} />
+              <Fact label="file_contents" value={String(data().safety?.file_contents_included ?? false)} />
+              <Fact label="health_payloads" value={String(data().safety?.health_payloads_included ?? false)} />
+            </div>
+          </>
+        )}
+      </Show>
+    </div>
+  );
+}
+
+function RuntimeOverlayRow(props: { overlay: RuntimeRepoOverlay }) {
+  return (
+    <article class="table-row runtime-row">
+      <div>
+        <h3>{props.overlay.repo}</h3>
+        <p class="muted">{props.overlay.repo_root_label}</p>
+      </div>
+      <Fact label="git" value={props.overlay.git_available ? "available" : "unavailable"} />
+      <Fact label="branch" value={props.overlay.branch ?? "not a git tree"} />
+      <Fact label="head_sha" value={props.overlay.head_sha ?? "none"} />
+      <Fact label="ahead/behind" value={`${props.overlay.ahead ?? "n/a"} / ${props.overlay.behind ?? "n/a"}`} />
+      <Fact label="dirty_tracked_count" value={String(props.overlay.dirty_tracked_count ?? "n/a")} />
+      <Fact label="untracked_count" value={String(props.overlay.untracked_count ?? "n/a")} />
+      <Fact label="deploy_impact" value={props.overlay.deploy_impact} />
+      <p class="proof-line">
+        {props.overlay.live_runtime_role}. {props.overlay.notes}
+      </p>
+    </article>
   );
 }
 

--- a/apps/admin-solid/src/data/control-plane.ts
+++ b/apps/admin-solid/src/data/control-plane.ts
@@ -1,3 +1,5 @@
+import feedJson from "./static/admin-feed.sample.json";
+
 export type ControlState =
   | "safe"
   | "needs approval"
@@ -11,13 +13,138 @@ export type ControlState =
   | "queued"
   | "active"
   | "valid"
+  | "waiting"
   | "waiting_on_agent"
+  | "waiting_on_ani"
   | "open"
   | "partially_absorbed"
   | "absorbed"
   | "current";
 
 export type RiskLevel = "low" | "medium" | "high" | "critical";
+
+type SourceRef = {
+  kind: string;
+  path: string;
+  ref?: string;
+  summary: string;
+};
+
+type ApprovalRow = {
+  approval_id: string;
+  title: string;
+  status: string;
+  risk_level: string;
+  allowed: string[];
+  forbidden: string[];
+  proof_required: string[];
+  mutation_ids: string[];
+  source_refs: SourceRef[];
+};
+
+type BlockerRow = {
+  blocker_id: string;
+  title: string;
+  status: string;
+  severity: string;
+  owner: string;
+  domain: string;
+  requires_ani: boolean;
+  next_action: string;
+  related_ids: string[];
+};
+
+type HandoffRow = {
+  handoff_id: string;
+  title: string;
+  path: string;
+  freshness: string;
+  absorbed_at: string | null;
+  target_owner: string;
+  status: string;
+  next_action: string;
+  proof_ids: string[];
+};
+
+type MutationRow = {
+  mutation_id: string;
+  title: string;
+  status: string;
+  risk_level: string;
+  intent: string;
+  authority_state: string;
+  allowed_actions: string[];
+  forbidden_actions: string[];
+  required_approval_ids: string[];
+  next_safe_action: string;
+  target_surface: string;
+  proof_ids: string[];
+  blocker_ids: string[];
+  domain: string;
+  repo: string;
+};
+
+type OperationRow = {
+  operation_id: string;
+  title: string;
+  status: string;
+  machine: string;
+  agent: string;
+  phase: string;
+  heartbeat_at: string;
+  stop_path: string;
+  next_safe_action: string;
+  proof_ids: string[];
+  repo: string;
+};
+
+type ProofRow = {
+  proof_id: string;
+  title: string;
+  status: string;
+  evidence_uri: string;
+  redaction: "none" | "metadata_only" | "secret_value_omitted" | "private_payload_omitted";
+  summary: string;
+};
+
+type RepoStateRow = {
+  repo_state_id: string;
+  repo: string;
+  path: string;
+  branch: string;
+  dirty_tracked: string[];
+  untracked_count: number;
+  deploy_impact: "none" | "local_only" | "preview" | "production" | "unknown";
+  status?: string;
+  worktree_state: string;
+  next_safe_action: string;
+  proof_ids: string[];
+  blocker_ids: string[];
+  canonical_role: string;
+};
+
+type AdminFeed = {
+  counts: Record<string, number>;
+  model: string;
+  question: string;
+  snapshot_type: string;
+  source: {
+    generated_by: string;
+    mode: string;
+    path: string;
+    repo: string;
+  };
+  version: number;
+  objects: {
+    approvals: ApprovalRow[];
+    blockers: BlockerRow[];
+    handoffs: HandoffRow[];
+    mutations: MutationRow[];
+    operations: OperationRow[];
+    proofs: ProofRow[];
+    repo_states: RepoStateRow[];
+  };
+};
 
 export type WorkCard = {
   title: string;
@@ -86,393 +213,335 @@ export type HandoffCard = {
 export type DestructiveGate = WorkCard &
   AuthorityCard &
   ProofCard & {
-    area: "delete" | "auth" | "secrets" | "dns" | "deploy" | "payment" | "account";
+    area: string;
   };
 
-export const topStrip: WorkCard[] = [
-  {
-    title: "safe",
-    status: "safe",
-    risk_level: "low",
-    next_safe_action: "continue read-only checks and draft PR work",
-    intent: "show work that can proceed without live mutation",
-    authority_state: "not_required",
-    operation_summary: "local validation and draft review",
-    proof_ids: ["proof.validator.admin-contract.samples"],
-  },
-  {
-    title: "needs approval",
-    status: "needs approval",
-    risk_level: "medium",
-    next_safe_action: "ask for exact approval before merge, deploy, tunnel, env, or account changes",
-    intent: "separate safe preparation from live authority",
-    authority_state: "required",
-    operation_summary: "approval-gated queue",
-    proof_ids: ["appr.admin.readonly-build-slices.2026-06-23"],
-  },
-  {
-    title: "running",
-    status: "running",
-    risk_level: "low",
-    next_safe_action: "watch local validation and draft PR checks",
-    intent: "track active non-live work",
-    authority_state: "approved",
-    operation_summary: "admin shell build and schema validation",
-    proof_ids: ["op.site.admin-shell.local-build"],
-  },
-  {
-    title: "blocked",
-    status: "blocked",
-    risk_level: "high",
-    next_safe_action: "route mini tunnel and live collectors to gated Infra approval",
-    intent: "stop work that needs live service authority",
-    authority_state: "not_granted",
-    operation_summary: "collector and tunnel checks paused",
-    proof_ids: ["block.admin.live-collectors-not-yet-approved"],
-  },
-  {
-    title: "stale",
-    status: "stale",
-    risk_level: "medium",
-    next_safe_action: "refresh handoff absorption and repo snapshots before acting",
-    intent: "keep old thread state visible",
-    authority_state: "refresh_required",
-    operation_summary: "handoff and repo-state freshness",
-    proof_ids: ["handoff.admin-control-plane-build-map"],
-  },
-  {
-    title: "destructive",
-    status: "destructive",
-    risk_level: "critical",
-    next_safe_action: "show proof requirements only, no live controls",
-    intent: "make dangerous operations inspectable without enabling execution",
-    authority_state: "explicit_approval_required",
-    operation_summary: "delete, auth, secrets, dns, deploy, payment, account",
-    proof_ids: ["proof.handoff.admin-build-map"],
-  },
-];
+export const adminFeed = feedJson as AdminFeed;
+
+export const feedSource = {
+  infra_commit: "8fa3c32",
+  copied_from: "/Users/anipotts/Infra/coord/admin/static/admin-feed.sample.json",
+  generated_by: adminFeed.source.generated_by,
+  snapshot_type: adminFeed.snapshot_type,
+  version: adminFeed.version,
+};
+
+const {
+  approvals,
+  blockers,
+  handoffs: handoffRows,
+  mutations,
+  operations: operationRows,
+  proofs: proofRows,
+  repo_states: repoStateRows,
+} = adminFeed.objects;
 
 export const workCards: WorkCard[] = [
-  {
-    title: "Build read-only admin control-plane shell",
-    status: "approved",
-    risk_level: "low",
-    next_safe_action: "Use coord/admin/samples as mocked read model and render route skeletons.",
-    intent: "Make admin.anipotts.com answer what is safe to do next using mocked control-plane data.",
-    authority_state: "approved",
-    operation_summary: "add read-only admin-solid routes on an agent branch",
-    proof_ids: ["proof.handoff.admin-build-map"],
-  },
-  {
-    title: "Claude review bot gate",
-    status: "verified",
-    risk_level: "medium",
-    next_safe_action: "Rerun or update admin PR checks so Claude review can pass with the token-factory bot.",
-    intent: "remove false review failure on agent PRs",
-    authority_state: "approved_by_ani",
-    operation_summary: "PR #74 merged before continuing admin shell",
-    proof_ids: ["ac41a92da49c70fbecff799b47aca0ebec242980"],
-  },
-  {
-    title: "Live collectors are intentionally out of scope",
-    status: "blocked",
-    risk_level: "high",
-    next_safe_action: "After the read-only UI feels right, request separate approval for low-latency collectors.",
-    intent: "protect live machine, auth, and service state while the UI model settles",
-    authority_state: "not_approved",
-    operation_summary: "collector wiring stopped before worker or service mutation",
-    proof_ids: ["block.admin.live-collectors-not-yet-approved"],
-  },
-  {
-    title: "Small public cleanup PR",
-    status: "needs approval",
-    risk_level: "medium",
-    next_safe_action: "Keep PR #73 unmerged unless Ani explicitly wants that public cleanup deployed.",
-    intent: "avoid bundling public-site deploy risk into admin shell work",
-    authority_state: "approval_required",
-    operation_summary: "draft public-site-only PR remains separate",
-    proof_ids: ["pr-73-draft"],
-  },
+  ...mutations.map(toMutationWorkCard),
+  ...blockers.map(toBlockerWorkCard),
+];
+
+export const coverageCards: WorkCard[] = [
+  coverageCard("site/admin shell state", hasDomain("site"), "mut.site.admin-shell.readonly.slice1"),
+  coverageCard("health rename blocker", hasDomain("health"), "block.health.rename.execution-approval"),
+  coverageCard("jobs feed state", hasDomain("jobs"), "missing.jobs.feed.static-sample"),
+  coverageCard("brand/business operating layers", hasDomain("brand") || hasDomain("business"), "missing.brand-business.static-sample"),
+  coverageCard("repo states", repoStateRows.length > 0, "repo.anipotts-com.admin-solid"),
 ];
 
 export const authorityCards: AuthorityCard[] = [
-  {
-    title: "Read-only admin control-plane build slices",
-    status: "active",
-    risk_level: "low",
-    authority_state: "approved",
-    required_approval_ids: ["appr.admin.readonly-build-slices.2026-06-23"],
-    allowed_actions: ["read-only design", "sample data", "schemas", "local validation", "scoped agent branch"],
-    forbidden_actions: ["deploy", "DNS", "env or secret mutation", "live worker mutation", "Cloudflare mutation"],
-  },
-  {
-    title: "Admin live deployment",
-    status: "needs approval",
-    risk_level: "high",
-    authority_state: "not_approved",
-    required_approval_ids: ["approval.admin.live-deploy.required"],
-    allowed_actions: ["draft PR prep", "local smoke tests", "static mock data"],
-    forbidden_actions: ["merge admin PR to main", "deploy admin worker", "change auth", "wire destructive controls"],
-  },
+  ...approvals.map(toApprovalAuthorityCard),
+  ...mutations.map(toMutationAuthorityCard),
 ];
 
-export const operations: OperationCard[] = [
-  {
-    title: "Build mocked admin shell in apps/admin-solid",
-    status: "running",
-    machine: "ap-mini",
-    agent: "chief/site",
-    phase: "local-ui-build",
-    heartbeat_at: "2026-06-24T03:45:00Z",
-    stop_path: "stop before deploy, DNS, env, worker, or production mutation",
-    next_safe_action: "Run admin-solid typecheck, build, and local route smoke.",
-  },
-  {
-    title: "Write admin contract schemas and samples",
-    status: "verified",
-    machine: "ap-mini",
-    agent: "chief/infra",
-    phase: "schema-and-sample-committed",
-    heartbeat_at: "2026-06-24T03:40:00Z",
-    stop_path: "no further Infra mutation needed for site slice",
-    next_safe_action: "Consume coord/admin fields in the admin shell mock data.",
-  },
-  {
-    title: "ap-pro review surface",
-    status: "queued",
-    machine: "ap-pro",
-    agent: "Codex and Claude placeholders",
-    phase: "browser-auth-and-final-review",
-    heartbeat_at: "not wired in slice 1",
-    stop_path: "stay read-only until browser auth and collector approvals exist",
-    next_safe_action: "Show as placeholder until workers/state or an approved collector emits live proof.",
-  },
-];
+export const operations: OperationCard[] = operationRows.map((operation) => ({
+  title: operation.title,
+  status: normalizeStatus(operation.status),
+  machine: operation.machine,
+  agent: operation.agent,
+  phase: operation.phase,
+  heartbeat_at: operation.heartbeat_at,
+  stop_path: operation.stop_path,
+  next_safe_action: operation.next_safe_action,
+}));
 
-export const proofs: ProofCard[] = [
-  {
-    title: "Admin control-plane build map exists",
-    status: "valid",
-    proof_ids: ["proof.handoff.admin-build-map"],
-    evidence_uri: "/Users/anipotts/Infra/handoffs/2026-06-23-admin-control-plane-build-map.md",
-    redaction: "none",
-    summary: "Handoff defines product thesis, core objects, site slice, infra contract slice, and non-goals.",
-  },
-  {
-    title: "Admin contract schemas and samples validate",
-    status: "valid",
-    proof_ids: ["proof.validator.admin-contract.samples"],
-    evidence_uri: "python3 coord/admin/validate_admin_contract.py",
-    redaction: "none",
-    summary: "Validation parses schemas and samples, rejects undeclared fields, checks enums, and checks duplicate ids.",
-  },
-  {
-    title: "Review automation gate merged",
-    status: "valid",
-    proof_ids: ["ac41a92da49c70fbecff799b47aca0ebec242980"],
-    evidence_uri: "https://github.com/anipotts/anipotts.com/pull/74",
-    redaction: "none",
-    summary: "PR #74 merged after CI, security, Claude review, and CodeRabbit were green.",
-  },
-];
+export const proofs: ProofCard[] = proofRows.map((proof) => ({
+  title: proof.title,
+  status: normalizeStatus(proof.status),
+  proof_ids: [proof.proof_id],
+  evidence_uri: proof.evidence_uri,
+  redaction: proof.redaction,
+  summary: proof.summary,
+}));
 
-export const repos: RepoCard[] = [
-  {
-    repo: "anipotts-com",
-    path: "/Users/anipotts/Code/projects/anipotts-com",
-    branch: "codex/admin-control-plane-shell-2026-06-23",
-    dirty_tracked: ["apps/admin-solid"],
-    untracked_count: 7,
-    deploy_impact: "none",
-    status: "running",
-    next_safe_action: "Finish local validation, commit the admin-only branch, and open a draft PR.",
-    proof_ids: ["op.site.admin-shell.local-build"],
-  },
-  {
-    repo: "Infra",
-    path: "/Users/anipotts/Infra",
-    branch: "main",
-    dirty_tracked: [],
-    untracked_count: 1,
-    deploy_impact: "none",
-    status: "verified",
-    next_safe_action: "Use coord/admin samples as the local mock source for site slice 1.",
-    proof_ids: ["b5fcc37"],
-  },
-  {
-    repo: "vitals/health",
-    path: "/Users/anipotts/Code/projects/vitals",
-    branch: "runtime tree",
-    dirty_tracked: [],
-    untracked_count: 0,
-    deploy_impact: "unknown",
-    status: "blocked",
-    next_safe_action: "Do not use for live admin heartbeat until chief/infra approves collector work.",
-    proof_ids: ["block.admin.live-collectors-not-yet-approved"],
-  },
-];
+export const repos: RepoCard[] = repoStateRows.map((repo) => ({
+  repo: repo.repo,
+  path: repo.path,
+  branch: repo.branch,
+  dirty_tracked: repo.dirty_tracked,
+  untracked_count: repo.untracked_count,
+  deploy_impact: repo.deploy_impact,
+  status: repoStatus(repo),
+  next_safe_action: repo.next_safe_action,
+  proof_ids: repo.proof_ids,
+}));
 
-export const handoffs: HandoffCard[] = [
-  {
-    title: "admin control plane build map",
-    path: "/Users/anipotts/Infra/handoffs/2026-06-23-admin-control-plane-build-map.md",
-    freshness: "current",
-    absorbed_at: null,
-    target_owner: "chief/site and chief/infra",
-    status: "partially_absorbed",
-    next_safe_action: "chief/site binds UI shell to matching sample ids, then reports exact checks.",
-    proof_ids: ["proof.handoff.admin-build-map"],
-  },
-  {
-    title: "fleet control plane goal",
-    path: "/Users/anipotts/Infra/handoffs/2026-06-23-fleet-control-plane-goal.md",
-    freshness: "current",
-    absorbed_at: "2026-06-23T23:40:00Z",
-    target_owner: "chief/site",
-    status: "absorbed",
-    next_safe_action: "Keep the product question visible on every route.",
-    proof_ids: ["fleet-control-plane-goal-absorbed-2026-06-23"],
-  },
-  {
-    title: "Rudy and kpanil account deletion closeout",
-    path: "/Users/anipotts/Infra/handoffs/2026-06-23-rudy-kpanil-account-deletion-closeout.md",
-    freshness: "current",
-    absorbed_at: "2026-06-24T02:43:15Z",
-    target_owner: "chief/infra",
-    status: "verified",
-    next_safe_action: "Display as completed destructive proof, with no new cleanup action unless fresh proof appears.",
-    proof_ids: ["rudy-kpanil-account-deletion-closeout-2026-06-23"],
-  },
-  {
-    title: "Live collector approval",
-    path: "/Users/anipotts/Infra/coord/admin/source-map.md",
-    freshness: "stale",
-    absorbed_at: null,
-    target_owner: "chief/infra",
-    status: "blocked",
-    next_safe_action: "Request separate approval before adding collectors or worker live feeds.",
-    proof_ids: ["block.admin.live-collectors-not-yet-approved"],
-  },
-];
+export const handoffs: HandoffCard[] = handoffRows.map((handoff) => ({
+  title: handoff.title,
+  path: handoff.path,
+  freshness: normalizeFreshness(handoff.freshness),
+  absorbed_at: handoff.absorbed_at,
+  target_owner: handoff.target_owner,
+  status: normalizeStatus(handoff.status),
+  next_safe_action: handoff.next_action,
+  proof_ids: handoff.proof_ids,
+}));
 
 export const destructiveGates: DestructiveGate[] = [
-  {
-    area: "delete",
-    title: "Delete source or local state",
-    status: "destructive",
-    risk_level: "critical",
-    next_safe_action: "Require item-level approval, archive proof, checksum proof, and rollback note.",
-    intent: "remove stale source or local state",
-    authority_state: "explicit_approval_required",
-    operation_summary: "archive, checksum, then delete",
-    proof_ids: ["proof.delete.required"],
-    required_approval_ids: ["approval.delete.item.required"],
-    allowed_actions: ["read manifests", "prepare rollback packet"],
-    forbidden_actions: ["delete files", "archive worktrees", "hide source"],
-    evidence_uri: "pending approved cleanup packet",
-    redaction: "metadata_only",
-    summary: "No delete operation may run from this UI slice.",
-  },
-  {
-    area: "auth",
-    title: "Change access or account connection",
-    status: "destructive",
-    risk_level: "critical",
-    next_safe_action: "Require exact auth approval and before/after policy proof.",
-    intent: "change access or account connection",
-    authority_state: "explicit_approval_required",
-    operation_summary: "modify auth provider, session, or access policy",
-    proof_ids: ["proof.auth.required"],
-    required_approval_ids: ["approval.auth.required"],
-    allowed_actions: ["read approved policy names", "prepare diff summary"],
-    forbidden_actions: ["connect accounts", "change access policies", "rotate sessions"],
-    evidence_uri: "pending approved auth packet",
-    redaction: "metadata_only",
-    summary: "Auth changes stay outside the read-only admin shell.",
-  },
-  {
-    area: "secrets",
-    title: "Change tokens or env values",
-    status: "destructive",
-    risk_level: "critical",
-    next_safe_action: "Show secret names only and require separate env or secret approval.",
-    intent: "change tokens or env values",
-    authority_state: "explicit_approval_required",
-    operation_summary: "rotate, set, or copy secret material",
-    proof_ids: ["proof.secrets.required"],
-    required_approval_ids: ["approval.secrets.required"],
-    allowed_actions: ["verify secret presence without values"],
-    forbidden_actions: ["print values", "copy values", "mutate env"],
-    evidence_uri: "pending approved secret packet",
-    redaction: "secret_value_omitted",
-    summary: "Secret values are never part of admin feed samples.",
-  },
-  {
-    area: "dns",
-    title: "Change live route ownership",
-    status: "destructive",
-    risk_level: "critical",
-    next_safe_action: "Require DNS approval, propagation plan, and rollback record.",
-    intent: "change live route ownership",
-    authority_state: "explicit_approval_required",
-    operation_summary: "edit record, route, custom domain, or tunnel hostname",
-    proof_ids: ["proof.dns.required"],
-    required_approval_ids: ["approval.dns.required"],
-    allowed_actions: ["read DNS target metadata"],
-    forbidden_actions: ["edit DNS", "change tunnel hostname", "mutate custom domains"],
-    evidence_uri: "pending approved DNS packet",
-    redaction: "metadata_only",
-    summary: "DNS is visible as a gate, not as a control.",
-  },
-  {
-    area: "deploy",
-    title: "Publish admin or public site",
-    status: "destructive",
-    risk_level: "high",
-    next_safe_action: "Keep admin PR draft until Ani approves admin live deployment.",
-    intent: "publish admin or public site",
-    authority_state: "explicit_approval_required",
-    operation_summary: "merge branch or dispatch deployment",
-    proof_ids: ["proof.deploy.required"],
-    required_approval_ids: ["approval.deploy.required"],
-    allowed_actions: ["draft PR prep", "local build", "preview planning"],
-    forbidden_actions: ["merge admin PR", "deploy worker", "dispatch production deploy"],
-    evidence_uri: "pending approved deploy packet",
-    redaction: "none",
-    summary: "Deploy impact is none until merge or deploy is explicitly approved.",
-  },
-  {
-    area: "payment",
-    title: "Pay, invoice, or file revenue state",
-    status: "destructive",
-    risk_level: "critical",
-    next_safe_action: "Route to Business with private-payload proof rules.",
-    intent: "pay, invoice, or file revenue state",
-    authority_state: "explicit_approval_required",
-    operation_summary: "submit payment, mark paid, or file external state",
-    proof_ids: ["proof.payment.required"],
-    required_approval_ids: ["approval.payment.required"],
-    allowed_actions: ["show metadata-only blockers"],
-    forbidden_actions: ["pay", "invoice", "file", "print private payloads"],
-    evidence_uri: "pending approved Business packet",
-    redaction: "private_payload_omitted",
-    summary: "Finance and filing actions remain display-only in admin.",
-  },
-  {
-    area: "account",
-    title: "Change user, machine, or external account state",
-    status: "destructive",
-    risk_level: "critical",
-    next_safe_action: "Require account-specific approval and closeout proof.",
-    intent: "change user, machine, or external account state",
-    authority_state: "explicit_approval_required",
-    operation_summary: "create, hide, delete, connect, or disconnect account",
-    proof_ids: ["proof.account.required"],
-    required_approval_ids: ["approval.account.required"],
-    allowed_actions: ["read closeout handoff metadata"],
-    forbidden_actions: ["create accounts", "delete accounts", "connect accounts"],
-    evidence_uri: "pending approved account packet",
-    redaction: "metadata_only",
-    summary: "Account mutation requires its own approval and proof packet.",
-  },
+  "delete",
+  "auth",
+  "secrets",
+  "dns",
+  "deploy",
+  "payment",
+  "account",
+].map(toDestructiveGate);
+
+export const topStrip: WorkCard[] = [
+  stateSummary("safe", "safe", safeCount(), "read-only work and no-deploy repo rows"),
+  stateSummary("needs approval", "needs approval", needsApprovalCount(), "approval-linked mutations and Ani-gated blockers"),
+  stateSummary("running", "running", runningCount(), "running, queued, or waiting operations"),
+  stateSummary("blocked", "blocked", blockedCount(), "blockers and blocked mutations"),
+  stateSummary("stale", "stale", staleCount(), "missing static feed coverage or stale handoffs"),
+  stateSummary("destructive", "destructive", destructiveGates.length, "gated operation classes with proof requirements"),
 ];
+
+function toMutationWorkCard(mutation: MutationRow): WorkCard {
+  return {
+    title: mutation.title,
+    status: normalizeStatus(mutation.status),
+    risk_level: normalizeRisk(mutation.risk_level),
+    next_safe_action: mutation.next_safe_action,
+    intent: mutation.intent,
+    authority_state: mutation.authority_state,
+    operation_summary: mutation.target_surface,
+    proof_ids: mutation.proof_ids,
+  };
+}
+
+function toBlockerWorkCard(blocker: BlockerRow): WorkCard {
+  return {
+    title: blocker.title,
+    status: normalizeStatus(blocker.status),
+    risk_level: normalizeRisk(blocker.severity),
+    next_safe_action: blocker.next_action,
+    intent: blocker.title,
+    authority_state: blocker.requires_ani ? "requires_ani" : "agent_can_continue",
+    operation_summary: `${blocker.owner} / ${blocker.domain}`,
+    proof_ids: blocker.related_ids,
+  };
+}
+
+function toApprovalAuthorityCard(approval: ApprovalRow): AuthorityCard {
+  return {
+    title: approval.title,
+    status: normalizeStatus(approval.status),
+    risk_level: normalizeRisk(approval.risk_level),
+    authority_state: approval.status,
+    required_approval_ids: [approval.approval_id],
+    allowed_actions: approval.allowed,
+    forbidden_actions: approval.forbidden,
+  };
+}
+
+function toMutationAuthorityCard(mutation: MutationRow): AuthorityCard {
+  return {
+    title: mutation.title,
+    status: normalizeStatus(mutation.status),
+    risk_level: normalizeRisk(mutation.risk_level),
+    authority_state: mutation.authority_state,
+    required_approval_ids: mutation.required_approval_ids,
+    allowed_actions: mutation.allowed_actions,
+    forbidden_actions: mutation.forbidden_actions,
+  };
+}
+
+function coverageCard(title: string, present: boolean, proofId: string): WorkCard {
+  return {
+    title,
+    status: present ? "verified" : "stale",
+    risk_level: present ? "low" : "medium",
+    next_safe_action: present
+      ? "Render from the static feed bundle copied from Infra 8fa3c32."
+      : "No object for this layer exists in the 8fa3c32 static feed; add a repo exporter or sample row before live collector work.",
+    intent: present ? "confirm static feed coverage" : "show missing static feed coverage without inventing state",
+    authority_state: "static_sample_only",
+    operation_summary: `${adminFeed.snapshot_type} / ${feedSource.infra_commit}`,
+    proof_ids: [proofId],
+  };
+}
+
+function stateSummary(
+  title: string,
+  status: ControlState,
+  count: number,
+  detail: string,
+): WorkCard {
+  return {
+    title,
+    status,
+    risk_level: status === "destructive" ? "critical" : status === "blocked" ? "high" : "low",
+    next_safe_action: `${count} ${detail}`,
+    intent: adminFeed.question,
+    authority_state: "static_sample_only",
+    operation_summary: `${adminFeed.model} / ${feedSource.infra_commit}`,
+    proof_ids: ["admin-feed.sample.json"],
+  };
+}
+
+function toDestructiveGate(area: string): DestructiveGate {
+  const matchingForbidden = allForbiddenActions().filter((action) => matchesArea(area, action));
+  const relatedMutation = mutations.find((mutation) =>
+    mutation.forbidden_actions.some((action) => matchesArea(area, action)),
+  );
+  const relatedBlocker = blockers.find((blocker) =>
+    blocker.next_action.toLowerCase().includes(area),
+  );
+  const proof = proofRows.find((row) => row.proof_id === relatedMutation?.proof_ids[0]) ?? proofRows[0];
+  const sourceAuthority = relatedMutation
+    ? toMutationAuthorityCard(relatedMutation)
+    : approvals[0]
+      ? toApprovalAuthorityCard(approvals[0])
+      : fallbackAuthorityCard();
+
+  return {
+    area,
+    title: `${area} gate`,
+    status: "destructive",
+    risk_level: area === "deploy" || area === "dns" || area === "secrets" ? "critical" : "high",
+    next_safe_action:
+      relatedMutation?.next_safe_action ??
+      relatedBlocker?.next_action ??
+      "Use the static feed to inspect proof requirements only; do not execute.",
+    intent: relatedMutation?.intent ?? `Keep ${area} operations gated in the read-only admin shell.`,
+    authority_state: sourceAuthority.authority_state,
+    operation_summary: matchingForbidden.join(", ") || `${area} operation class is hard-gated`,
+    proof_ids: relatedMutation?.proof_ids ?? [proof?.proof_id ?? "admin-feed.sample.json"],
+    required_approval_ids: sourceAuthority.required_approval_ids,
+    allowed_actions: sourceAuthority.allowed_actions,
+    forbidden_actions: matchingForbidden.length > 0 ? matchingForbidden : sourceAuthority.forbidden_actions,
+    evidence_uri: proof?.evidence_uri ?? feedSource.copied_from,
+    redaction: proof?.redaction ?? "metadata_only",
+    summary: proof?.summary ?? "Static feed copied from Infra without secret or private payload values.",
+  };
+}
+
+function allForbiddenActions(): string[] {
+  return [
+    ...approvals.flatMap((approval) => approval.forbidden),
+    ...mutations.flatMap((mutation) => mutation.forbidden_actions),
+  ];
+}
+
+function fallbackAuthorityCard(): AuthorityCard {
+  return {
+    title: "Static feed authority missing",
+    status: "blocked",
+    risk_level: "high",
+    authority_state: "missing_static_authority",
+    required_approval_ids: ["admin-feed.authority.missing"],
+    allowed_actions: ["inspect static feed metadata"],
+    forbidden_actions: ["execute destructive operations", "deploy", "mutate live state"],
+  };
+}
+
+function matchesArea(area: string, action: string): boolean {
+  const haystack = action.toLowerCase();
+  const matchers: Record<string, RegExp> = {
+    delete: /delete|cleanup|source\/personal/,
+    auth: /auth|access/,
+    secrets: /secret|env/,
+    dns: /dns|endpoint|port|tailscale|firewall/,
+    deploy: /deploy|worker|service|launchd|restart|rename/,
+    payment: /payment|filing|invoice|revenue/,
+    account: /account|user/,
+  };
+  return matchers[area]?.test(haystack) ?? false;
+}
+
+function hasDomain(domain: string): boolean {
+  return (
+    mutations.some((row) => row.domain === domain || row.repo === domain) ||
+    blockers.some((row) => row.domain === domain) ||
+    repoStateRows.some((row) => row.repo === domain || row.canonical_role === domain)
+  );
+}
+
+function safeCount(): number {
+  return approvals.filter((row) => row.status === "active").length +
+    repoStateRows.filter((row) => row.deploy_impact === "none").length;
+}
+
+function needsApprovalCount(): number {
+  return mutations.filter((row) => row.required_approval_ids.length > 0).length +
+    blockers.filter((row) => row.requires_ani).length;
+}
+
+function runningCount(): number {
+  return operationRows.filter((row) => ["running", "queued", "waiting"].includes(row.status)).length;
+}
+
+function blockedCount(): number {
+  return blockers.length + mutations.filter((row) => row.status === "blocked").length;
+}
+
+function staleCount(): number {
+  return coverageCards.filter((row) => row.status === "stale").length +
+    handoffRows.filter((row) => row.freshness === "stale").length;
+}
+
+function repoStatus(repo: RepoStateRow): ControlState {
+  if (repo.blocker_ids.length > 0) return "blocked";
+  if (repo.deploy_impact === "none") return "safe";
+  if (repo.deploy_impact === "local_only") return "needs approval";
+  return "stale";
+}
+
+function normalizeRisk(value: string): RiskLevel {
+  if (value === "critical" || value === "high" || value === "medium" || value === "low") {
+    return value;
+  }
+  return "medium";
+}
+
+function normalizeStatus(value: string): ControlState {
+  if (
+    value === "safe" ||
+    value === "needs approval" ||
+    value === "running" ||
+    value === "blocked" ||
+    value === "stale" ||
+    value === "destructive" ||
+    value === "proposed" ||
+    value === "approved" ||
+    value === "verified" ||
+    value === "queued" ||
+    value === "active" ||
+    value === "valid" ||
+    value === "waiting" ||
+    value === "waiting_on_agent" ||
+    value === "waiting_on_ani" ||
+    value === "open" ||
+    value === "partially_absorbed" ||
+    value === "absorbed" ||
+    value === "current"
+  ) {
+    return value;
+  }
+  return "stale";
+}
+
+function normalizeFreshness(value: string): "current" | "stale" | "unknown" {
+  if (value === "current" || value === "stale") return value;
+  return "unknown";
+}

--- a/apps/admin-solid/src/data/control-plane.ts
+++ b/apps/admin-solid/src/data/control-plane.ts
@@ -199,6 +199,42 @@ export type RepoCard = {
   proof_ids: string[];
 };
 
+export type RuntimeRepoOverlay = {
+  repo_state_id: string;
+  repo: string;
+  repo_root_label: string;
+  machine: string;
+  git_available: boolean;
+  branch: string | null;
+  head_sha: string | null;
+  upstream: string | null;
+  upstream_sha: string | null;
+  ahead: number | null;
+  behind: number | null;
+  dirty_tracked_count: number | null;
+  untracked_count: number | null;
+  deploy_impact: "none" | "local_only" | "preview" | "production" | "unknown";
+  live_runtime_role: string;
+  notes: string;
+};
+
+export type RuntimeOverlayResponse = {
+  available: boolean;
+  mode: "local_dev" | "disabled" | "missing" | "error";
+  generated_at: string | null;
+  machine: string | null;
+  source_path: string;
+  safety: {
+    dirty_filenames_included: boolean;
+    file_contents_included: boolean;
+    health_payloads_included: boolean;
+    mode: string;
+    secret_values_included: boolean;
+  } | null;
+  overlays: RuntimeRepoOverlay[];
+  error?: string;
+};
+
 export type HandoffCard = {
   title: string;
   path: string;

--- a/apps/admin-solid/src/data/control-plane.ts
+++ b/apps/admin-solid/src/data/control-plane.ts
@@ -219,7 +219,7 @@ export type DestructiveGate = WorkCard &
 export const adminFeed = feedJson as AdminFeed;
 
 export const feedSource = {
-  infra_commit: "8fa3c32",
+  infra_commit: "c26959c",
   copied_from: "/Users/anipotts/Infra/coord/admin/static/admin-feed.sample.json",
   generated_by: adminFeed.source.generated_by,
   snapshot_type: adminFeed.snapshot_type,
@@ -244,8 +244,8 @@ export const workCards: WorkCard[] = [
 export const coverageCards: WorkCard[] = [
   coverageCard("site/admin shell state", hasDomain("site"), "mut.site.admin-shell.readonly.slice1"),
   coverageCard("health rename blocker", hasDomain("health"), "block.health.rename.execution-approval"),
-  coverageCard("jobs feed state", hasDomain("jobs"), "missing.jobs.feed.static-sample"),
-  coverageCard("brand/business operating layers", hasDomain("brand") || hasDomain("business"), "missing.brand-business.static-sample"),
+  coverageCard("jobs feed state", hasDomain("jobs"), "proof.jobs.admin-feed.commit"),
+  coverageCard("brand/business operating layers", hasDomain("brand") && hasDomain("business"), "proof.brand.phase1.commit, proof.business.secretary-layer.commit"),
   coverageCard("repo states", repoStateRows.length > 0, "repo.anipotts-com.admin-solid"),
 ];
 
@@ -372,8 +372,8 @@ function coverageCard(title: string, present: boolean, proofId: string): WorkCar
     status: present ? "verified" : "stale",
     risk_level: present ? "low" : "medium",
     next_safe_action: present
-      ? "Render from the static feed bundle copied from Infra 8fa3c32."
-      : "No object for this layer exists in the 8fa3c32 static feed; add a repo exporter or sample row before live collector work.",
+      ? `Render from the static feed bundle copied from Infra ${feedSource.infra_commit}.`
+      : `No object for this layer exists in the ${feedSource.infra_commit} static feed; add a repo exporter or sample row before live collector work.`,
     intent: present ? "confirm static feed coverage" : "show missing static feed coverage without inventing state",
     authority_state: "static_sample_only",
     operation_summary: `${adminFeed.snapshot_type} / ${feedSource.infra_commit}`,
@@ -470,10 +470,11 @@ function matchesArea(area: string, action: string): boolean {
 }
 
 function hasDomain(domain: string): boolean {
+  const needle = domain.toLowerCase();
   return (
-    mutations.some((row) => row.domain === domain || row.repo === domain) ||
-    blockers.some((row) => row.domain === domain) ||
-    repoStateRows.some((row) => row.repo === domain || row.canonical_role === domain)
+    mutations.some((row) => row.domain.toLowerCase() === needle || row.repo.toLowerCase() === needle) ||
+    blockers.some((row) => row.domain.toLowerCase() === needle) ||
+    repoStateRows.some((row) => row.repo.toLowerCase() === needle || row.canonical_role.toLowerCase() === needle)
   );
 }
 

--- a/apps/admin-solid/src/data/control-plane.ts
+++ b/apps/admin-solid/src/data/control-plane.ts
@@ -1,0 +1,478 @@
+export type ControlState =
+  | "safe"
+  | "needs approval"
+  | "running"
+  | "blocked"
+  | "stale"
+  | "destructive"
+  | "proposed"
+  | "approved"
+  | "verified"
+  | "queued"
+  | "active"
+  | "valid"
+  | "waiting_on_agent"
+  | "open"
+  | "partially_absorbed"
+  | "absorbed"
+  | "current";
+
+export type RiskLevel = "low" | "medium" | "high" | "critical";
+
+export type WorkCard = {
+  title: string;
+  status: ControlState;
+  risk_level: RiskLevel;
+  next_safe_action: string;
+  intent: string;
+  authority_state: string;
+  operation_summary: string;
+  proof_ids: string[];
+};
+
+export type AuthorityCard = {
+  title: string;
+  status: ControlState;
+  risk_level: RiskLevel;
+  authority_state: string;
+  required_approval_ids: string[];
+  allowed_actions: string[];
+  forbidden_actions: string[];
+};
+
+export type OperationCard = {
+  title: string;
+  status: ControlState;
+  machine: string;
+  agent: string;
+  phase: string;
+  heartbeat_at: string;
+  stop_path: string;
+  next_safe_action: string;
+};
+
+export type ProofCard = {
+  title: string;
+  status: ControlState;
+  proof_ids: string[];
+  evidence_uri: string;
+  redaction: "none" | "metadata_only" | "secret_value_omitted" | "private_payload_omitted";
+  summary: string;
+};
+
+export type RepoCard = {
+  repo: string;
+  path: string;
+  branch: string;
+  dirty_tracked: string[];
+  untracked_count: number;
+  deploy_impact: "none" | "local_only" | "preview" | "production" | "unknown";
+  status: ControlState;
+  next_safe_action: string;
+  proof_ids: string[];
+};
+
+export type HandoffCard = {
+  title: string;
+  path: string;
+  freshness: "current" | "stale" | "unknown";
+  absorbed_at: string | null;
+  target_owner: string;
+  status: ControlState;
+  next_safe_action: string;
+  proof_ids: string[];
+};
+
+export type DestructiveGate = WorkCard &
+  AuthorityCard &
+  ProofCard & {
+    area: "delete" | "auth" | "secrets" | "dns" | "deploy" | "payment" | "account";
+  };
+
+export const topStrip: WorkCard[] = [
+  {
+    title: "safe",
+    status: "safe",
+    risk_level: "low",
+    next_safe_action: "continue read-only checks and draft PR work",
+    intent: "show work that can proceed without live mutation",
+    authority_state: "not_required",
+    operation_summary: "local validation and draft review",
+    proof_ids: ["proof.validator.admin-contract.samples"],
+  },
+  {
+    title: "needs approval",
+    status: "needs approval",
+    risk_level: "medium",
+    next_safe_action: "ask for exact approval before merge, deploy, tunnel, env, or account changes",
+    intent: "separate safe preparation from live authority",
+    authority_state: "required",
+    operation_summary: "approval-gated queue",
+    proof_ids: ["appr.admin.readonly-build-slices.2026-06-23"],
+  },
+  {
+    title: "running",
+    status: "running",
+    risk_level: "low",
+    next_safe_action: "watch local validation and draft PR checks",
+    intent: "track active non-live work",
+    authority_state: "approved",
+    operation_summary: "admin shell build and schema validation",
+    proof_ids: ["op.site.admin-shell.local-build"],
+  },
+  {
+    title: "blocked",
+    status: "blocked",
+    risk_level: "high",
+    next_safe_action: "route mini tunnel and live collectors to gated Infra approval",
+    intent: "stop work that needs live service authority",
+    authority_state: "not_granted",
+    operation_summary: "collector and tunnel checks paused",
+    proof_ids: ["block.admin.live-collectors-not-yet-approved"],
+  },
+  {
+    title: "stale",
+    status: "stale",
+    risk_level: "medium",
+    next_safe_action: "refresh handoff absorption and repo snapshots before acting",
+    intent: "keep old thread state visible",
+    authority_state: "refresh_required",
+    operation_summary: "handoff and repo-state freshness",
+    proof_ids: ["handoff.admin-control-plane-build-map"],
+  },
+  {
+    title: "destructive",
+    status: "destructive",
+    risk_level: "critical",
+    next_safe_action: "show proof requirements only, no live controls",
+    intent: "make dangerous operations inspectable without enabling execution",
+    authority_state: "explicit_approval_required",
+    operation_summary: "delete, auth, secrets, dns, deploy, payment, account",
+    proof_ids: ["proof.handoff.admin-build-map"],
+  },
+];
+
+export const workCards: WorkCard[] = [
+  {
+    title: "Build read-only admin control-plane shell",
+    status: "approved",
+    risk_level: "low",
+    next_safe_action: "Use coord/admin/samples as mocked read model and render route skeletons.",
+    intent: "Make admin.anipotts.com answer what is safe to do next using mocked control-plane data.",
+    authority_state: "approved",
+    operation_summary: "add read-only admin-solid routes on an agent branch",
+    proof_ids: ["proof.handoff.admin-build-map"],
+  },
+  {
+    title: "Claude review bot gate",
+    status: "verified",
+    risk_level: "medium",
+    next_safe_action: "Rerun or update admin PR checks so Claude review can pass with the token-factory bot.",
+    intent: "remove false review failure on agent PRs",
+    authority_state: "approved_by_ani",
+    operation_summary: "PR #74 merged before continuing admin shell",
+    proof_ids: ["ac41a92da49c70fbecff799b47aca0ebec242980"],
+  },
+  {
+    title: "Live collectors are intentionally out of scope",
+    status: "blocked",
+    risk_level: "high",
+    next_safe_action: "After the read-only UI feels right, request separate approval for low-latency collectors.",
+    intent: "protect live machine, auth, and service state while the UI model settles",
+    authority_state: "not_approved",
+    operation_summary: "collector wiring stopped before worker or service mutation",
+    proof_ids: ["block.admin.live-collectors-not-yet-approved"],
+  },
+  {
+    title: "Small public cleanup PR",
+    status: "needs approval",
+    risk_level: "medium",
+    next_safe_action: "Keep PR #73 unmerged unless Ani explicitly wants that public cleanup deployed.",
+    intent: "avoid bundling public-site deploy risk into admin shell work",
+    authority_state: "approval_required",
+    operation_summary: "draft public-site-only PR remains separate",
+    proof_ids: ["pr-73-draft"],
+  },
+];
+
+export const authorityCards: AuthorityCard[] = [
+  {
+    title: "Read-only admin control-plane build slices",
+    status: "active",
+    risk_level: "low",
+    authority_state: "approved",
+    required_approval_ids: ["appr.admin.readonly-build-slices.2026-06-23"],
+    allowed_actions: ["read-only design", "sample data", "schemas", "local validation", "scoped agent branch"],
+    forbidden_actions: ["deploy", "DNS", "env or secret mutation", "live worker mutation", "Cloudflare mutation"],
+  },
+  {
+    title: "Admin live deployment",
+    status: "needs approval",
+    risk_level: "high",
+    authority_state: "not_approved",
+    required_approval_ids: ["approval.admin.live-deploy.required"],
+    allowed_actions: ["draft PR prep", "local smoke tests", "static mock data"],
+    forbidden_actions: ["merge admin PR to main", "deploy admin worker", "change auth", "wire destructive controls"],
+  },
+];
+
+export const operations: OperationCard[] = [
+  {
+    title: "Build mocked admin shell in apps/admin-solid",
+    status: "running",
+    machine: "ap-mini",
+    agent: "chief/site",
+    phase: "local-ui-build",
+    heartbeat_at: "2026-06-24T03:45:00Z",
+    stop_path: "stop before deploy, DNS, env, worker, or production mutation",
+    next_safe_action: "Run admin-solid typecheck, build, and local route smoke.",
+  },
+  {
+    title: "Write admin contract schemas and samples",
+    status: "verified",
+    machine: "ap-mini",
+    agent: "chief/infra",
+    phase: "schema-and-sample-committed",
+    heartbeat_at: "2026-06-24T03:40:00Z",
+    stop_path: "no further Infra mutation needed for site slice",
+    next_safe_action: "Consume coord/admin fields in the admin shell mock data.",
+  },
+  {
+    title: "ap-pro review surface",
+    status: "queued",
+    machine: "ap-pro",
+    agent: "Codex and Claude placeholders",
+    phase: "browser-auth-and-final-review",
+    heartbeat_at: "not wired in slice 1",
+    stop_path: "stay read-only until browser auth and collector approvals exist",
+    next_safe_action: "Show as placeholder until workers/state or an approved collector emits live proof.",
+  },
+];
+
+export const proofs: ProofCard[] = [
+  {
+    title: "Admin control-plane build map exists",
+    status: "valid",
+    proof_ids: ["proof.handoff.admin-build-map"],
+    evidence_uri: "/Users/anipotts/Infra/handoffs/2026-06-23-admin-control-plane-build-map.md",
+    redaction: "none",
+    summary: "Handoff defines product thesis, core objects, site slice, infra contract slice, and non-goals.",
+  },
+  {
+    title: "Admin contract schemas and samples validate",
+    status: "valid",
+    proof_ids: ["proof.validator.admin-contract.samples"],
+    evidence_uri: "python3 coord/admin/validate_admin_contract.py",
+    redaction: "none",
+    summary: "Validation parses schemas and samples, rejects undeclared fields, checks enums, and checks duplicate ids.",
+  },
+  {
+    title: "Review automation gate merged",
+    status: "valid",
+    proof_ids: ["ac41a92da49c70fbecff799b47aca0ebec242980"],
+    evidence_uri: "https://github.com/anipotts/anipotts.com/pull/74",
+    redaction: "none",
+    summary: "PR #74 merged after CI, security, Claude review, and CodeRabbit were green.",
+  },
+];
+
+export const repos: RepoCard[] = [
+  {
+    repo: "anipotts-com",
+    path: "/Users/anipotts/Code/projects/anipotts-com",
+    branch: "codex/admin-control-plane-shell-2026-06-23",
+    dirty_tracked: ["apps/admin-solid"],
+    untracked_count: 7,
+    deploy_impact: "none",
+    status: "running",
+    next_safe_action: "Finish local validation, commit the admin-only branch, and open a draft PR.",
+    proof_ids: ["op.site.admin-shell.local-build"],
+  },
+  {
+    repo: "Infra",
+    path: "/Users/anipotts/Infra",
+    branch: "main",
+    dirty_tracked: [],
+    untracked_count: 1,
+    deploy_impact: "none",
+    status: "verified",
+    next_safe_action: "Use coord/admin samples as the local mock source for site slice 1.",
+    proof_ids: ["b5fcc37"],
+  },
+  {
+    repo: "vitals/health",
+    path: "/Users/anipotts/Code/projects/vitals",
+    branch: "runtime tree",
+    dirty_tracked: [],
+    untracked_count: 0,
+    deploy_impact: "unknown",
+    status: "blocked",
+    next_safe_action: "Do not use for live admin heartbeat until chief/infra approves collector work.",
+    proof_ids: ["block.admin.live-collectors-not-yet-approved"],
+  },
+];
+
+export const handoffs: HandoffCard[] = [
+  {
+    title: "admin control plane build map",
+    path: "/Users/anipotts/Infra/handoffs/2026-06-23-admin-control-plane-build-map.md",
+    freshness: "current",
+    absorbed_at: null,
+    target_owner: "chief/site and chief/infra",
+    status: "partially_absorbed",
+    next_safe_action: "chief/site binds UI shell to matching sample ids, then reports exact checks.",
+    proof_ids: ["proof.handoff.admin-build-map"],
+  },
+  {
+    title: "fleet control plane goal",
+    path: "/Users/anipotts/Infra/handoffs/2026-06-23-fleet-control-plane-goal.md",
+    freshness: "current",
+    absorbed_at: "2026-06-23T23:40:00Z",
+    target_owner: "chief/site",
+    status: "absorbed",
+    next_safe_action: "Keep the product question visible on every route.",
+    proof_ids: ["fleet-control-plane-goal-absorbed-2026-06-23"],
+  },
+  {
+    title: "Rudy and kpanil account deletion closeout",
+    path: "/Users/anipotts/Infra/handoffs/2026-06-23-rudy-kpanil-account-deletion-closeout.md",
+    freshness: "current",
+    absorbed_at: "2026-06-24T02:43:15Z",
+    target_owner: "chief/infra",
+    status: "verified",
+    next_safe_action: "Display as completed destructive proof, with no new cleanup action unless fresh proof appears.",
+    proof_ids: ["rudy-kpanil-account-deletion-closeout-2026-06-23"],
+  },
+  {
+    title: "Live collector approval",
+    path: "/Users/anipotts/Infra/coord/admin/source-map.md",
+    freshness: "stale",
+    absorbed_at: null,
+    target_owner: "chief/infra",
+    status: "blocked",
+    next_safe_action: "Request separate approval before adding collectors or worker live feeds.",
+    proof_ids: ["block.admin.live-collectors-not-yet-approved"],
+  },
+];
+
+export const destructiveGates: DestructiveGate[] = [
+  {
+    area: "delete",
+    title: "Delete source or local state",
+    status: "destructive",
+    risk_level: "critical",
+    next_safe_action: "Require item-level approval, archive proof, checksum proof, and rollback note.",
+    intent: "remove stale source or local state",
+    authority_state: "explicit_approval_required",
+    operation_summary: "archive, checksum, then delete",
+    proof_ids: ["proof.delete.required"],
+    required_approval_ids: ["approval.delete.item.required"],
+    allowed_actions: ["read manifests", "prepare rollback packet"],
+    forbidden_actions: ["delete files", "archive worktrees", "hide source"],
+    evidence_uri: "pending approved cleanup packet",
+    redaction: "metadata_only",
+    summary: "No delete operation may run from this UI slice.",
+  },
+  {
+    area: "auth",
+    title: "Change access or account connection",
+    status: "destructive",
+    risk_level: "critical",
+    next_safe_action: "Require exact auth approval and before/after policy proof.",
+    intent: "change access or account connection",
+    authority_state: "explicit_approval_required",
+    operation_summary: "modify auth provider, session, or access policy",
+    proof_ids: ["proof.auth.required"],
+    required_approval_ids: ["approval.auth.required"],
+    allowed_actions: ["read approved policy names", "prepare diff summary"],
+    forbidden_actions: ["connect accounts", "change access policies", "rotate sessions"],
+    evidence_uri: "pending approved auth packet",
+    redaction: "metadata_only",
+    summary: "Auth changes stay outside the read-only admin shell.",
+  },
+  {
+    area: "secrets",
+    title: "Change tokens or env values",
+    status: "destructive",
+    risk_level: "critical",
+    next_safe_action: "Show secret names only and require separate env or secret approval.",
+    intent: "change tokens or env values",
+    authority_state: "explicit_approval_required",
+    operation_summary: "rotate, set, or copy secret material",
+    proof_ids: ["proof.secrets.required"],
+    required_approval_ids: ["approval.secrets.required"],
+    allowed_actions: ["verify secret presence without values"],
+    forbidden_actions: ["print values", "copy values", "mutate env"],
+    evidence_uri: "pending approved secret packet",
+    redaction: "secret_value_omitted",
+    summary: "Secret values are never part of admin feed samples.",
+  },
+  {
+    area: "dns",
+    title: "Change live route ownership",
+    status: "destructive",
+    risk_level: "critical",
+    next_safe_action: "Require DNS approval, propagation plan, and rollback record.",
+    intent: "change live route ownership",
+    authority_state: "explicit_approval_required",
+    operation_summary: "edit record, route, custom domain, or tunnel hostname",
+    proof_ids: ["proof.dns.required"],
+    required_approval_ids: ["approval.dns.required"],
+    allowed_actions: ["read DNS target metadata"],
+    forbidden_actions: ["edit DNS", "change tunnel hostname", "mutate custom domains"],
+    evidence_uri: "pending approved DNS packet",
+    redaction: "metadata_only",
+    summary: "DNS is visible as a gate, not as a control.",
+  },
+  {
+    area: "deploy",
+    title: "Publish admin or public site",
+    status: "destructive",
+    risk_level: "high",
+    next_safe_action: "Keep admin PR draft until Ani approves admin live deployment.",
+    intent: "publish admin or public site",
+    authority_state: "explicit_approval_required",
+    operation_summary: "merge branch or dispatch deployment",
+    proof_ids: ["proof.deploy.required"],
+    required_approval_ids: ["approval.deploy.required"],
+    allowed_actions: ["draft PR prep", "local build", "preview planning"],
+    forbidden_actions: ["merge admin PR", "deploy worker", "dispatch production deploy"],
+    evidence_uri: "pending approved deploy packet",
+    redaction: "none",
+    summary: "Deploy impact is none until merge or deploy is explicitly approved.",
+  },
+  {
+    area: "payment",
+    title: "Pay, invoice, or file revenue state",
+    status: "destructive",
+    risk_level: "critical",
+    next_safe_action: "Route to Business with private-payload proof rules.",
+    intent: "pay, invoice, or file revenue state",
+    authority_state: "explicit_approval_required",
+    operation_summary: "submit payment, mark paid, or file external state",
+    proof_ids: ["proof.payment.required"],
+    required_approval_ids: ["approval.payment.required"],
+    allowed_actions: ["show metadata-only blockers"],
+    forbidden_actions: ["pay", "invoice", "file", "print private payloads"],
+    evidence_uri: "pending approved Business packet",
+    redaction: "private_payload_omitted",
+    summary: "Finance and filing actions remain display-only in admin.",
+  },
+  {
+    area: "account",
+    title: "Change user, machine, or external account state",
+    status: "destructive",
+    risk_level: "critical",
+    next_safe_action: "Require account-specific approval and closeout proof.",
+    intent: "change user, machine, or external account state",
+    authority_state: "explicit_approval_required",
+    operation_summary: "create, hide, delete, connect, or disconnect account",
+    proof_ids: ["proof.account.required"],
+    required_approval_ids: ["approval.account.required"],
+    allowed_actions: ["read closeout handoff metadata"],
+    forbidden_actions: ["create accounts", "delete accounts", "connect accounts"],
+    evidence_uri: "pending approved account packet",
+    redaction: "metadata_only",
+    summary: "Account mutation requires its own approval and proof packet.",
+  },
+];

--- a/apps/admin-solid/src/data/static/README.md
+++ b/apps/admin-solid/src/data/static/README.md
@@ -3,7 +3,7 @@
 `admin-feed.sample.json` is a tracked static copy of the Infra admin feed bundle.
 
 - Source repo: `/Users/anipotts/Infra`
-- Source commit: `8fa3c32`
+- Source commit: `c26959c`
 - Source path: `coord/admin/static/admin-feed.sample.json`
 - Builder: `coord/admin/build_static_snapshot.py`
 

--- a/apps/admin-solid/src/data/static/README.md
+++ b/apps/admin-solid/src/data/static/README.md
@@ -1,0 +1,12 @@
+# admin static feed sample
+
+`admin-feed.sample.json` is a tracked static copy of the Infra admin feed bundle.
+
+- Source repo: `/Users/anipotts/Infra`
+- Source commit: `8fa3c32`
+- Source path: `coord/admin/static/admin-feed.sample.json`
+- Builder: `coord/admin/build_static_snapshot.py`
+
+This file is build-time sample data only. It must not become a live collector,
+write path, deploy trigger, env reader, secret reader, or cross-repo runtime
+dependency.

--- a/apps/admin-solid/src/data/static/admin-feed.sample.json
+++ b/apps/admin-solid/src/data/static/admin-feed.sample.json
@@ -1,0 +1,671 @@
+{
+  "counts": {
+    "approvals": 1,
+    "blockers": 3,
+    "handoffs": 2,
+    "mutations": 3,
+    "operations": 3,
+    "proofs": 3,
+    "repo_states": 3
+  },
+  "model": "intent -> authority -> operation -> proof -> state",
+  "objects": {
+    "approvals": [
+      {
+        "allowed": [
+          "read-only design",
+          "sample data",
+          "schemas",
+          "local validation",
+          "validated Infra docs/schema/sample commit and push"
+        ],
+        "approval_id": "appr.admin.readonly-build-slices.2026-06-23",
+        "approved_at": "2026-06-23T23:40:00Z",
+        "approved_by": "Ani",
+        "authority_ref": "fleet/boss build slice 2 delegation",
+        "expires_at": null,
+        "forbidden": [
+          "launchd/root/auth/secrets/env/firewall/tailscale/service mutation",
+          "user-account cleanup",
+          "source/personal delete",
+          "deploy",
+          "DNS",
+          "payment",
+          "filing",
+          "outbound",
+          "Gmail/Calendar mutation",
+          "health rename execution"
+        ],
+        "mutation_ids": [
+          "mut.site.admin-shell.readonly.slice1",
+          "mut.infra.admin-contract.schema-samples"
+        ],
+        "notes": "Sample rows are non-secret and not live execution authority.",
+        "object_type": "approval",
+        "proof_required": [
+          "schema JSON parses",
+          "sample JSONL parses",
+          "samples validate against schemas"
+        ],
+        "risk_level": "low",
+        "source_refs": [
+          {
+            "kind": "delegation",
+            "path": "current Codex thread",
+            "ref": "fleet/boss build slice 2",
+            "summary": "Ani routed slice 2 to chief/infra with docs/schema/sample push allowed after validation."
+          }
+        ],
+        "source_thread_id": "019ed10b-518a-7d80-814b-cb52f7453646",
+        "status": "active",
+        "title": "Read-only admin control-plane build slices",
+        "updated_at": "2026-06-23T23:40:00Z"
+      }
+    ],
+    "blockers": [
+      {
+        "blocked_since": "2026-06-23T23:40:00Z",
+        "blocker_id": "block.site.consume-contract-fields",
+        "domain": "site",
+        "next_action": "Bind route cards to sample fields from coord/admin/README.md and samples/*.jsonl.",
+        "object_type": "blocker",
+        "owner": "chief/site",
+        "owner_thread": "chief/site",
+        "related_ids": [
+          "mut.site.admin-shell.readonly.slice1",
+          "op.site.admin-shell.local-build"
+        ],
+        "requires_ani": false,
+        "severity": "medium",
+        "source_refs": [
+          {
+            "kind": "handoff",
+            "path": "/Users/anipotts/Infra/handoffs/2026-06-23-admin-control-plane-build-map.md",
+            "ref": "todo queue",
+            "summary": "chief/site and chief/infra need matching object names and sample ids."
+          }
+        ],
+        "stale_after": "2026-06-25T23:40:00Z",
+        "status": "waiting_on_agent",
+        "title": "chief/site needs stable field names for first admin UI slice",
+        "unblock_conditions": [
+          "UI can render mutation, approval, operation, proof, blocker, repo_state, and handoff cards from sample rows",
+          "No deploy or live worker mutation required"
+        ],
+        "updated_at": "2026-06-23T23:40:00Z"
+      },
+      {
+        "blocked_since": "2026-06-23T23:40:00Z",
+        "blocker_id": "block.admin.live-collectors-not-yet-approved",
+        "domain": "infra",
+        "next_action": "After the read-only UI feels right, request separate approval for low-latency collectors.",
+        "object_type": "blocker",
+        "owner": "chief/infra",
+        "owner_thread": "chief/infra",
+        "related_ids": ["mut.infra.admin-contract.schema-samples"],
+        "requires_ani": true,
+        "severity": "low",
+        "source_refs": [
+          {
+            "kind": "handoff",
+            "path": "/Users/anipotts/Infra/handoffs/2026-06-23-admin-control-plane-build-map.md",
+            "ref": "todo queue",
+            "summary": "Collectors come after read-only UI and before any write paths."
+          }
+        ],
+        "stale_after": "2026-07-01T23:40:00Z",
+        "status": "open",
+        "title": "Live collectors are intentionally out of scope for first pass",
+        "unblock_conditions": [
+          "UI field model is accepted",
+          "Collector paths are reviewed",
+          "No secret values or protected payloads enter admin feeds"
+        ],
+        "updated_at": "2026-06-23T23:40:00Z"
+      },
+      {
+        "blocked_since": "2026-06-22T09:24:10Z",
+        "blocker_id": "block.health.rename.execution-approval",
+        "domain": "health",
+        "next_action": "Review and approve or revise the prepared backup/hash and rollback packet before any path rename, restart, env-ref migration, or launchd label change.",
+        "object_type": "blocker",
+        "owner": "chief/health",
+        "owner_thread": "chief/health",
+        "related_ids": [
+          "mut.health.rename.execution-gate",
+          "op.health.rename.execution-waiting",
+          "proof.health.ingest-and-ready-packet",
+          "repo.health.vitals-live-tree.ap-mini"
+        ],
+        "requires_ani": true,
+        "severity": "high",
+        "source_refs": [
+          {
+            "kind": "needs-ani",
+            "path": "/Users/anipotts/Infra/coord/NEEDS-ANI.md",
+            "ref": "blocker-health-rename-execution",
+            "summary": "Fresh ingest proof is sufficient; approval is now needed for execution packet."
+          },
+          {
+            "kind": "handoff",
+            "path": "/Users/anipotts/Infra/handoffs/2026-06-22-health-rename-ready-packet.md",
+            "ref": "health-rename-ready-packet-2026-06-22",
+            "summary": "Prepared packet with commands only."
+          }
+        ],
+        "stale_after": "2026-06-26T03:55:32Z",
+        "status": "waiting_on_ani",
+        "title": "Health rename execution awaits packet approval",
+        "unblock_conditions": [
+          "Ani approves the prepared packet or supplies revisions",
+          "No endpoint, port, auth, env, secret, launchd, or GitHub repo rename changes are bundled into approval",
+          "Backup/hash commands remain local-only and value-safe",
+          "Post-rename proof remains required before launchd label rename"
+        ],
+        "updated_at": "2026-06-24T03:55:32Z"
+      }
+    ],
+    "handoffs": [
+      {
+        "absorbed_at": null,
+        "created_at": "2026-06-23T23:40:00Z",
+        "freshness": "current",
+        "handoff_id": "handoff.admin-control-plane-build-map",
+        "next_action": "chief/infra publishes contract and chief/site binds the UI shell to matching sample ids.",
+        "object_type": "handoff",
+        "owner": "fleet/boss",
+        "path": "/Users/anipotts/Infra/handoffs/2026-06-23-admin-control-plane-build-map.md",
+        "proof_ids": ["proof.handoff.admin-build-map"],
+        "related_ids": [
+          "mut.site.admin-shell.readonly.slice1",
+          "mut.infra.admin-contract.schema-samples"
+        ],
+        "source_refs": [
+          {
+            "kind": "git",
+            "path": "/Users/anipotts/Infra",
+            "ref": "a4a09c5",
+            "summary": "Build map is tracked in Infra origin/main."
+          }
+        ],
+        "source_thread_id": "019ef754-39df-7ae3-a4bb-d15cc9e2a70b",
+        "status": "partially_absorbed",
+        "summary": "Defines admin as a read-only control plane for intent, authority, operation, proof, and state.",
+        "target_owner": "chief/site and chief/infra",
+        "title": "admin control plane build map",
+        "updated_at": "2026-06-23T23:40:00Z"
+      },
+      {
+        "absorbed_at": "2026-06-24T02:43:15Z",
+        "created_at": "2026-06-24T02:43:15Z",
+        "freshness": "current",
+        "handoff_id": "handoff.rudy-account-deletion-closeout",
+        "next_action": "Display as verified destructive work with rollback limits and no remaining account-cleanup action unless new proof says otherwise.",
+        "object_type": "handoff",
+        "owner": "fleet/boss",
+        "path": "/Users/anipotts/Infra/handoffs/2026-06-23-rudy-kpanil-account-deletion-closeout.md",
+        "proof_ids": [],
+        "related_ids": ["block.admin.live-collectors-not-yet-approved"],
+        "source_refs": [
+          {
+            "kind": "bus_ref",
+            "path": "/Users/anipotts/Infra/coord/bus.jsonl",
+            "ref": "rudy-kpanil-account-deletion-closeout-2026-06-23",
+            "summary": "Representative completed destructive operation for admin mock data."
+          }
+        ],
+        "source_thread_id": "019ed10b-518a-7d80-814b-cb52f7453646",
+        "status": "absorbed",
+        "summary": "Example high-risk handoff where admin must show destructive cleanup only after approval, archive proof, process proof, and closeout proof exist.",
+        "target_owner": "chief/infra",
+        "title": "Rudy and kpanil account deletion closeout",
+        "updated_at": "2026-06-24T03:40:00Z"
+      }
+    ],
+    "mutations": [
+      {
+        "allowed_actions": [
+          "local app code edits",
+          "local verification",
+          "agent branch or scoped commit plan"
+        ],
+        "authority_state": "approved",
+        "blocker_ids": ["block.site.consume-contract-fields"],
+        "domain": "site",
+        "forbidden_actions": [
+          "deploy",
+          "DNS change",
+          "env or secret mutation",
+          "live worker mutation"
+        ],
+        "intent": "Make admin.anipotts.com answer what is safe to do next using mocked control-plane data.",
+        "mutation_class": "read_only",
+        "mutation_id": "mut.site.admin-shell.readonly.slice1",
+        "next_safe_action": "Use coord/admin/samples as mocked read model and render read-only route skeletons.",
+        "object_type": "mutation",
+        "operation_ids": ["op.site.admin-shell.local-build"],
+        "proof_ids": ["proof.handoff.admin-build-map"],
+        "proposed_by": "chief/site",
+        "repo": "anipotts-com",
+        "requested_at": "2026-06-23T23:40:00Z",
+        "required_approval_ids": [
+          "appr.admin.readonly-build-slices.2026-06-23"
+        ],
+        "risk_level": "low",
+        "source_refs": [
+          {
+            "kind": "handoff",
+            "path": "/Users/anipotts/Infra/handoffs/2026-06-23-admin-control-plane-build-map.md",
+            "ref": "build slice 1",
+            "summary": "chief/site owns the first read-only UI shell."
+          }
+        ],
+        "status": "approved",
+        "target_surface": "apps/admin-solid",
+        "title": "Build read-only admin control-plane shell",
+        "updated_at": "2026-06-23T23:40:00Z"
+      },
+      {
+        "allowed_actions": [
+          "schema files",
+          "sample jsonl",
+          "validation script",
+          "private Infra commit and push after validation"
+        ],
+        "authority_state": "approved",
+        "blocker_ids": [],
+        "domain": "infra",
+        "forbidden_actions": [
+          "launchd mutation",
+          "auth mutation",
+          "service mutation",
+          "deploy",
+          "user account cleanup"
+        ],
+        "intent": "Make authority, operation, proof, blocker, repo, and handoff state consumable by the admin UI.",
+        "mutation_class": "docs_schema",
+        "mutation_id": "mut.infra.admin-contract.schema-samples",
+        "next_safe_action": "Validate samples against schemas, commit tracked docs, and push Infra main.",
+        "object_type": "mutation",
+        "operation_ids": ["op.infra.admin-contract.schema-samples"],
+        "proof_ids": ["proof.validator.admin-contract.samples"],
+        "proposed_by": "chief/infra",
+        "repo": "Infra",
+        "requested_at": "2026-06-23T23:40:00Z",
+        "required_approval_ids": [
+          "appr.admin.readonly-build-slices.2026-06-23"
+        ],
+        "risk_level": "low",
+        "source_refs": [
+          {
+            "kind": "authority",
+            "path": "/Users/anipotts/Infra/coord/authority.jsonl",
+            "ref": "approval-infra-major-vision-continuation-2026-06-22",
+            "summary": "Infra coordination-only docs and validation are approved."
+          },
+          {
+            "kind": "handoff",
+            "path": "/Users/anipotts/Infra/handoffs/2026-06-23-admin-control-plane-build-map.md",
+            "ref": "build slice 2",
+            "summary": "chief/infra owns the read-only data contract."
+          }
+        ],
+        "status": "running",
+        "target_surface": "coord/admin",
+        "title": "Create admin read-only data contract",
+        "updated_at": "2026-06-23T23:40:00Z"
+      },
+      {
+        "allowed_actions": [
+          "read-only review of prepared packet",
+          "approval or revision of backup/hash and rollback plan",
+          "metadata-only freshness verification"
+        ],
+        "authority_state": "requested",
+        "blocker_ids": ["block.health.rename.execution-approval"],
+        "domain": "health",
+        "forbidden_actions": [
+          "path rename before approval",
+          "service restart before approval",
+          "endpoint or port change",
+          "auth/env/secret mutation",
+          "launchd label change",
+          "health data mutation",
+          "DuckDB row reads",
+          "pro-to-mini overwrite",
+          "GitHub repo rename"
+        ],
+        "intent": "Rename the mini live vitals service tree to health only after the prepared backup/hash and rollback packet is approved.",
+        "mutation_class": "service",
+        "mutation_id": "mut.health.rename.execution-gate",
+        "next_safe_action": "Review and approve or revise /Users/anipotts/Infra/handoffs/2026-06-22-health-rename-ready-packet.md before any execution.",
+        "object_type": "mutation",
+        "operation_ids": ["op.health.rename.execution-waiting"],
+        "proof_ids": ["proof.health.ingest-and-ready-packet"],
+        "proposed_by": "chief/health",
+        "repo": "vitals",
+        "requested_at": "2026-06-22T09:24:10Z",
+        "required_approval_ids": ["appr.health.rename.execution.required"],
+        "risk_level": "high",
+        "source_refs": [
+          {
+            "kind": "handoff",
+            "path": "/Users/anipotts/Infra/handoffs/2026-06-22-health-rename-ready-packet.md",
+            "ref": "health-rename-ready-packet-2026-06-22",
+            "summary": "Prepared backup/hash commands and rollback plan only; commands were not executed."
+          },
+          {
+            "kind": "needs-ani",
+            "path": "/Users/anipotts/Infra/coord/NEEDS-ANI.md",
+            "ref": "blocker-health-rename-execution",
+            "summary": "Current blocker is execution approval, not phone ingest proof."
+          }
+        ],
+        "status": "blocked",
+        "target_surface": "/Users/anipotts/Code/projects/vitals -> /Users/anipotts/Code/projects/health",
+        "title": "Health vitals to health rename execution gate",
+        "updated_at": "2026-06-24T03:55:32Z"
+      }
+    ],
+    "operations": [
+      {
+        "agent": "codex chief/infra",
+        "allowed_by_approval_ids": [
+          "appr.admin.readonly-build-slices.2026-06-23"
+        ],
+        "blocker_ids": [],
+        "branch": "main",
+        "command_class": "docs_schema_commit",
+        "heartbeat_at": "2026-06-23T23:40:00Z",
+        "machine": "ap-mini",
+        "mutation_ids": ["mut.infra.admin-contract.schema-samples"],
+        "next_safe_action": "Run coord/admin/validate_admin_contract.py and loop-runner validate before commit.",
+        "object_type": "operation",
+        "operation_id": "op.infra.admin-contract.schema-samples",
+        "phase": "schema-and-sample-authoring",
+        "proof_ids": ["proof.validator.admin-contract.samples"],
+        "repo": "Infra",
+        "source_refs": [
+          {
+            "kind": "git",
+            "path": "/Users/anipotts/Infra",
+            "ref": "main",
+            "summary": "Private Infra repo may receive validated coordination docs/schema commits."
+          }
+        ],
+        "started_at": "2026-06-23T23:40:00Z",
+        "status": "running",
+        "stop_path": "stop by not committing, then revert working tree changes by exact file path if requested",
+        "thread_id": "current",
+        "title": "Write admin contract schemas and samples",
+        "updated_at": "2026-06-23T23:40:00Z"
+      },
+      {
+        "agent": "chief/site",
+        "allowed_by_approval_ids": [
+          "appr.admin.readonly-build-slices.2026-06-23"
+        ],
+        "blocker_ids": ["block.site.consume-contract-fields"],
+        "branch": "codex/admin-control-plane-readonly-slice",
+        "command_class": "ui_local_build",
+        "heartbeat_at": "2026-06-23T23:40:00Z",
+        "machine": "ap-pro or ap-mini",
+        "mutation_ids": ["mut.site.admin-shell.readonly.slice1"],
+        "next_safe_action": "Render route skeletons using coord/admin/samples JSONL as mocked data.",
+        "object_type": "operation",
+        "operation_id": "op.site.admin-shell.local-build",
+        "phase": "waiting-for-contract",
+        "proof_ids": ["proof.handoff.admin-build-map"],
+        "repo": "anipotts-com",
+        "source_refs": [
+          {
+            "kind": "handoff",
+            "path": "/Users/anipotts/Infra/handoffs/2026-06-23-admin-control-plane-build-map.md",
+            "ref": "build slice 1",
+            "summary": "Site owns the read-only admin UI shell."
+          }
+        ],
+        "started_at": "2026-06-23T23:40:00Z",
+        "status": "queued",
+        "stop_path": "stop before deploy, DNS, env, worker, or production mutation",
+        "thread_id": "chief/site",
+        "title": "Build mocked admin shell in apps/admin-solid",
+        "updated_at": "2026-06-23T23:40:00Z"
+      },
+      {
+        "agent": "codex chief/health",
+        "allowed_by_approval_ids": [],
+        "blocker_ids": ["block.health.rename.execution-approval"],
+        "branch": "not-a-git-checkout",
+        "command_class": "read_only_validation",
+        "heartbeat_at": "2026-06-24T03:55:32Z",
+        "machine": "ap-mini",
+        "mutation_ids": ["mut.health.rename.execution-gate"],
+        "next_safe_action": "Wait for approval or revisions to /Users/anipotts/Infra/handoffs/2026-06-22-health-rename-ready-packet.md.",
+        "object_type": "operation",
+        "operation_id": "op.health.rename.execution-waiting",
+        "phase": "approval-gate",
+        "proof_ids": ["proof.health.ingest-and-ready-packet"],
+        "repo": "vitals",
+        "source_refs": [
+          {
+            "kind": "handoff",
+            "path": "/Users/anipotts/Infra/handoffs/2026-06-22-health-rename-ready-packet.md",
+            "ref": "health-rename-ready-packet-2026-06-22",
+            "summary": "Execution commands are prepared but not run."
+          }
+        ],
+        "started_at": "2026-06-22T09:24:10Z",
+        "status": "waiting",
+        "stop_path": "Do not run rename-ready packet commands; leave /Users/anipotts/Code/projects/vitals, port 8080, env refs, endpoint shape, and launchd label unchanged.",
+        "thread_id": "019eebf1-bbd7-7f53-95d5-6dc05d48732c",
+        "title": "Health rename waiting on execution approval",
+        "updated_at": "2026-06-24T03:55:32Z"
+      }
+    ],
+    "proofs": [
+      {
+        "collected_at": "2026-06-23T23:40:00Z",
+        "collected_by": "fleet/boss",
+        "evidence_uri": "/Users/anipotts/Infra/handoffs/2026-06-23-admin-control-plane-build-map.md",
+        "machine": "ap-mini",
+        "object_type": "proof",
+        "proof_id": "proof.handoff.admin-build-map",
+        "proof_type": "handoff",
+        "redaction": "none",
+        "related_ids": ["handoff.admin-control-plane-build-map"],
+        "repo": "Infra",
+        "source_refs": [
+          {
+            "kind": "git",
+            "path": "/Users/anipotts/Infra",
+            "ref": "a4a09c5",
+            "summary": "Build map was present at a4a09c5 or newer."
+          }
+        ],
+        "status": "valid",
+        "summary": "Handoff defines product thesis, core objects, site slice, infra contract slice, and non-goals.",
+        "title": "Admin control-plane build map exists",
+        "updated_at": "2026-06-23T23:40:00Z",
+        "verifies": [
+          "mut.site.admin-shell.readonly.slice1",
+          "mut.infra.admin-contract.schema-samples"
+        ]
+      },
+      {
+        "collected_at": "2026-06-23T23:40:00Z",
+        "collected_by": "chief/infra",
+        "evidence_uri": "python3 coord/admin/validate_admin_contract.py",
+        "machine": "ap-mini",
+        "object_type": "proof",
+        "proof_id": "proof.validator.admin-contract.samples",
+        "proof_type": "validator",
+        "redaction": "none",
+        "related_ids": ["op.infra.admin-contract.schema-samples"],
+        "repo": "Infra",
+        "source_refs": [
+          {
+            "kind": "file",
+            "path": "/Users/anipotts/Infra/coord/admin/validate_admin_contract.py",
+            "summary": "Local stdlib validator for the contract."
+          }
+        ],
+        "status": "valid",
+        "summary": "Validation command parses schemas, parses JSONL samples, checks required fields, rejects extra fields, validates primitive types and enum values, and checks duplicate ids per file.",
+        "title": "Admin contract schemas and samples validate",
+        "updated_at": "2026-06-23T23:40:00Z",
+        "verifies": ["mut.infra.admin-contract.schema-samples"]
+      },
+      {
+        "collected_at": "2026-06-22T09:24:10Z",
+        "collected_by": "chief/health",
+        "evidence_uri": "/Users/anipotts/Infra/handoffs/2026-06-22-health-rename-ready-packet.md",
+        "machine": "ap-mini",
+        "object_type": "proof",
+        "proof_id": "proof.health.ingest-and-ready-packet",
+        "proof_type": "handoff",
+        "redaction": "private_payload_omitted",
+        "related_ids": ["op.health.rename.execution-waiting"],
+        "repo": "vitals",
+        "source_refs": [
+          {
+            "kind": "handoff",
+            "path": "/Users/anipotts/Infra/handoffs/2026-06-22-health-rename-ready-packet.md",
+            "ref": "health-rename-ready-packet-2026-06-22",
+            "summary": "Prepared gated rename packet."
+          },
+          {
+            "kind": "bus_ref",
+            "path": "/Users/anipotts/Infra/coord/bus.jsonl",
+            "ref": "health-phone-ingest-proof-sufficient-2026-06-22",
+            "summary": "Proof classified sufficient without printing rows or payload bodies."
+          }
+        ],
+        "status": "valid",
+        "summary": "Fresh Health Auto Export proof is metadata-only: raw HAE count 59, newest archive filename 2026-06-22T09-12-08-114Z.json, latest.json and DuckDB WAL refreshed at 2026-06-22T05:12:18-0400, unauthenticated /api/health returns 401, and the live Bun process is unchanged. Ready packet contains backup/hash and rollback commands only; commands were not executed.",
+        "title": "Fresh health ingest proof and ready packet exist",
+        "updated_at": "2026-06-24T03:55:32Z",
+        "verifies": [
+          "mut.health.rename.execution-gate",
+          "block.health.rename.execution-approval",
+          "repo.health.vitals-live-tree.ap-mini"
+        ]
+      }
+    ],
+    "repo_states": [
+      {
+        "active_threads": ["chief/infra"],
+        "ahead": 0,
+        "behind": 0,
+        "blocker_ids": [],
+        "branch": "main",
+        "canonical_role": "source",
+        "deploy_impact": "none",
+        "dirty_tracked": [],
+        "head_sha": "a4a09c5-or-newer",
+        "last_verified_at": "2026-06-23T23:40:00Z",
+        "live_runtime_role": "coordination source and private remote backup",
+        "machine": "ap-mini",
+        "next_safe_action": "Commit and push validated coord/admin contract files only.",
+        "object_type": "repo_state",
+        "path": "/Users/anipotts/Infra",
+        "proof_ids": ["proof.handoff.admin-build-map"],
+        "repo": "Infra",
+        "repo_state_id": "repo.infra.ap-mini.main",
+        "source_refs": [
+          {
+            "kind": "git-status",
+            "path": "/Users/anipotts/Infra",
+            "summary": "Infra source moves by git; untracked local audits are not auto-staged."
+          }
+        ],
+        "untracked_count": 1,
+        "untracked_policy": "ignore unrelated local audit files unless explicitly routed",
+        "updated_at": "2026-06-23T23:40:00Z",
+        "upstream": "origin/main",
+        "worktree_state": "clean"
+      },
+      {
+        "active_threads": ["chief/site"],
+        "ahead": 0,
+        "behind": 0,
+        "blocker_ids": ["block.site.consume-contract-fields"],
+        "branch": "codex/admin-control-plane-readonly-slice",
+        "canonical_role": "source",
+        "deploy_impact": "none",
+        "dirty_tracked": [],
+        "head_sha": "unknown-until-chief-site-starts",
+        "last_verified_at": "2026-06-23T23:40:00Z",
+        "live_runtime_role": "renderer for admin.anipotts.com, no deploy in slice 1",
+        "machine": "ap-pro or ap-mini",
+        "next_safe_action": "Build local mocked UI against coord/admin sample rows without deploy.",
+        "object_type": "repo_state",
+        "path": "/Users/anipotts/Code/projects/anipotts-com",
+        "proof_ids": ["proof.handoff.admin-build-map"],
+        "repo": "anipotts-com",
+        "repo_state_id": "repo.anipotts-com.admin-solid",
+        "source_refs": [
+          {
+            "kind": "handoff",
+            "path": "/Users/anipotts/Infra/handoffs/2026-06-23-admin-control-plane-build-map.md",
+            "ref": "existing site planning facts",
+            "summary": "apps/admin-solid is the correct target for admin.anipotts.com."
+          }
+        ],
+        "untracked_count": 0,
+        "untracked_policy": "chief/site should inspect before editing and avoid env or generated churn",
+        "updated_at": "2026-06-23T23:40:00Z",
+        "upstream": "origin/main",
+        "worktree_state": "unknown"
+      },
+      {
+        "active_threads": ["chief/health"],
+        "ahead": 0,
+        "behind": 0,
+        "blocker_ids": ["block.health.rename.execution-approval"],
+        "branch": "not-a-git-checkout",
+        "canonical_role": "runtime",
+        "deploy_impact": "local_only",
+        "dirty_tracked": [],
+        "head_sha": "none",
+        "last_verified_at": "2026-06-22T09:24:10Z",
+        "live_runtime_role": "live health/vitals API tree on port 8080 with local-only health data; admin must show metadata only",
+        "machine": "ap-mini",
+        "next_safe_action": "Review the gated ready packet; do not rename, restart, edit env/secrets, change endpoint, or copy from pro.",
+        "object_type": "repo_state",
+        "path": "/Users/anipotts/Code/projects/vitals",
+        "proof_ids": ["proof.health.ingest-and-ready-packet"],
+        "repo": "vitals",
+        "repo_state_id": "repo.health.vitals-live-tree.ap-mini",
+        "source_refs": [
+          {
+            "kind": "handoff",
+            "path": "/Users/anipotts/Infra/handoffs/2026-06-21-health-rename-phone-ingest-gate.md",
+            "ref": "live tree and data classification",
+            "summary": "Mini vitals path is runtime-authoritative and not a Git checkout."
+          },
+          {
+            "kind": "handoff",
+            "path": "/Users/anipotts/Infra/handoffs/2026-06-22-health-rename-ready-packet.md",
+            "ref": "classification",
+            "summary": "Fresh ingest proof is sufficient and execution packet is prepared."
+          }
+        ],
+        "untracked_count": 0,
+        "untracked_policy": "not applicable because this is a live non-git service tree; do not overwrite from pro",
+        "updated_at": "2026-06-24T03:55:32Z",
+        "upstream": "none",
+        "worktree_state": "unknown"
+      }
+    ]
+  },
+  "question": "what is safe to do next?",
+  "snapshot_type": "admin-control-plane-static-sample",
+  "source": {
+    "generated_by": "coord/admin/build_static_snapshot.py",
+    "mode": "tracked-static-sample",
+    "path": "coord/admin/samples",
+    "repo": "Infra"
+  },
+  "version": 1
+}

--- a/apps/admin-solid/src/data/static/admin-feed.sample.json
+++ b/apps/admin-solid/src/data/static/admin-feed.sample.json
@@ -1,12 +1,12 @@
 {
   "counts": {
     "approvals": 1,
-    "blockers": 3,
+    "blockers": 6,
     "handoffs": 2,
-    "mutations": 3,
-    "operations": 3,
-    "proofs": 3,
-    "repo_states": 3
+    "mutations": 7,
+    "operations": 7,
+    "proofs": 7,
+    "repo_states": 6
   },
   "model": "intent -> authority -> operation -> proof -> state",
   "objects": {
@@ -163,6 +163,104 @@
           "Post-rename proof remains required before launchd label rename"
         ],
         "updated_at": "2026-06-24T03:55:32Z"
+      },
+      {
+        "blocked_since": "2026-06-24T04:05:00Z",
+        "blocker_id": "block.site.static-feed-consumption",
+        "domain": "site",
+        "next_action": "Replace ad hoc admin-solid mocks with a static copy or imported equivalent of coord/admin/static/admin-feed.sample.json.",
+        "object_type": "blocker",
+        "owner": "chief/site",
+        "owner_thread": "chief/site",
+        "related_ids": [
+          "mut.site.admin-static-feed.consume",
+          "op.site.admin-static-feed.consume",
+          "proof.admin.static-feed.bundle"
+        ],
+        "requires_ani": false,
+        "severity": "medium",
+        "source_refs": [
+          {
+            "kind": "bus_ref",
+            "path": "/Users/anipotts/Infra/coord/bus.jsonl",
+            "ref": "site-admin-static-feed-consumption-dispatched-2026-06-23",
+            "summary": "fleet/boss routed the static feed consumption task to chief/site."
+          }
+        ],
+        "stale_after": "2026-06-25T04:05:00Z",
+        "status": "waiting_on_agent",
+        "title": "Admin UI must consume the unified static feed",
+        "unblock_conditions": [
+          "All six admin routes render from the bundled feed",
+          "No runtime dependency on /Users/anipotts/Infra",
+          "No deploy or live collector"
+        ],
+        "updated_at": "2026-06-24T04:05:00Z"
+      },
+      {
+        "blocked_since": "2026-06-23T15:05:00Z",
+        "blocker_id": "block.jobs.gmail-empty-label-ui-cleanup",
+        "domain": "jobs",
+        "next_action": "Use a thread with in-app Browser access to remove empty old Gmail label objects after count proof; do not delete messages or filters.",
+        "object_type": "blocker",
+        "owner": "chief/jobs",
+        "owner_thread": "chief/jobs",
+        "related_ids": [
+          "mut.jobs.admin-feed-operating-layer.complete",
+          "proof.jobs.admin-feed.commit"
+        ],
+        "requires_ani": false,
+        "severity": "low",
+        "source_refs": [
+          {
+            "kind": "bus_ref",
+            "path": "/Users/anipotts/Infra/coord/bus.jsonl",
+            "ref": "jobs-admin-feed-operating-layer-complete-2026-06-23",
+            "summary": "Jobs message-label migration is complete; label-object cleanup is browser/UI-only."
+          }
+        ],
+        "stale_after": "2026-06-27T04:05:00Z",
+        "status": "open",
+        "title": "Empty Gmail label objects need Browser/UI cleanup",
+        "unblock_conditions": [
+          "Browser/UI runtime is available",
+          "Before counts still show old labels at 0 messages and 0 threads",
+          "After proof records no message delete, archive, send, or filter mutation"
+        ],
+        "updated_at": "2026-06-24T04:05:00Z"
+      },
+      {
+        "blocked_since": "2026-06-23T03:57:00Z",
+        "blocker_id": "block.brand.rayban-analytics-due",
+        "domain": "brand",
+        "next_action": "Prepare Ray-Ban 30-day analytics proof by 2026-07-05 without posting, sending, invoicing, or changing deal/payment status.",
+        "object_type": "blocker",
+        "owner": "chief/brand",
+        "owner_thread": "chief/brand",
+        "related_ids": [
+          "mut.brand.phase1-operating-skeleton.complete",
+          "proof.brand.phase1.commit",
+          "repo.brand.ap-mini.main"
+        ],
+        "requires_ani": false,
+        "severity": "medium",
+        "source_refs": [
+          {
+            "kind": "bus_ref",
+            "path": "/Users/anipotts/Infra/coord/bus.jsonl",
+            "ref": "brand-phase-1-operating-skeleton-complete-2026-06-23",
+            "summary": "Brand Phase 1 preserved Ray-Ban due date and deal-first priority."
+          }
+        ],
+        "stale_after": "2026-07-05T12:00:00Z",
+        "status": "open",
+        "title": "Ray-Ban 30-day analytics proof is the next Brand deal checkpoint",
+        "unblock_conditions": [
+          "Analytics proof is collected from approved source surfaces",
+          "Business remains payment truth source",
+          "No platform mutation or outbound message occurs without approval"
+        ],
+        "updated_at": "2026-06-24T04:05:00Z"
       }
     ],
     "handoffs": [
@@ -365,6 +463,193 @@
         "target_surface": "/Users/anipotts/Code/projects/vitals -> /Users/anipotts/Code/projects/health",
         "title": "Health vitals to health rename execution gate",
         "updated_at": "2026-06-24T03:55:32Z"
+      },
+      {
+        "allowed_actions": [
+          "static JSON copy",
+          "typed adapter",
+          "local route rendering",
+          "branch push after verification"
+        ],
+        "authority_state": "approved",
+        "blocker_ids": ["block.site.static-feed-consumption"],
+        "domain": "site",
+        "forbidden_actions": [
+          "deploy",
+          "DNS change",
+          "env or secret mutation",
+          "live collector",
+          "admin write path",
+          "PR merge without Ani approval"
+        ],
+        "intent": "Make the read-only admin shell render the same bundled feed that Infra validates.",
+        "mutation_class": "read_only",
+        "mutation_id": "mut.site.admin-static-feed.consume",
+        "next_safe_action": "chief/site should render approvals, blockers, handoffs, mutations, operations, proofs, and repo_states from the static bundle.",
+        "object_type": "mutation",
+        "operation_ids": ["op.site.admin-static-feed.consume"],
+        "proof_ids": ["proof.admin.static-feed.bundle"],
+        "proposed_by": "fleet/boss",
+        "repo": "anipotts-com",
+        "requested_at": "2026-06-24T04:05:00Z",
+        "required_approval_ids": [
+          "appr.admin.readonly-build-slices.2026-06-23"
+        ],
+        "risk_level": "low",
+        "source_refs": [
+          {
+            "kind": "bus_ref",
+            "path": "/Users/anipotts/Infra/coord/bus.jsonl",
+            "ref": "site-admin-static-feed-consumption-dispatched-2026-06-23",
+            "summary": "Static feed consumption was routed after Infra 8fa3c32."
+          }
+        ],
+        "status": "running",
+        "target_surface": "apps/admin-solid",
+        "title": "Consume unified static admin feed in admin-solid",
+        "updated_at": "2026-06-24T04:05:00Z"
+      },
+      {
+        "allowed_actions": [
+          "tracked docs",
+          "safe metadata ledgers",
+          "source registries",
+          "agent rules"
+        ],
+        "authority_state": "approved",
+        "blocker_ids": [],
+        "domain": "business",
+        "forbidden_actions": [
+          "filings",
+          "payments",
+          "account connections",
+          "Gmail/Calendar/Drive mutation",
+          "Mercury/Wave/Fidelity/NJ/IRS portal mutation",
+          "outbound messages",
+          "secrets or env edits"
+        ],
+        "intent": "Make Business agent-native with a control center, safe data ledgers, and agent ops docs.",
+        "mutation_class": "docs_schema",
+        "mutation_id": "mut.business.secretary-operating-layer.complete",
+        "next_safe_action": "Use the committed Business control center as the source for future read-only admin exports.",
+        "object_type": "mutation",
+        "operation_ids": ["op.business.secretary-operating-layer.complete"],
+        "proof_ids": ["proof.business.secretary-layer.commit"],
+        "proposed_by": "chief/business",
+        "repo": "Business",
+        "requested_at": "2026-06-24T03:52:00Z",
+        "required_approval_ids": [
+          "appr.admin.readonly-build-slices.2026-06-23"
+        ],
+        "risk_level": "low",
+        "source_refs": [
+          {
+            "kind": "bus_ref",
+            "path": "/Users/anipotts/Infra/coord/bus.jsonl",
+            "ref": "business-secretary-operating-layer-complete-2026-06-23",
+            "summary": "Business first operating layer completed at fd00777."
+          }
+        ],
+        "status": "verified",
+        "target_surface": "docs/00-control-center, docs/09-agent-ops, data",
+        "title": "Business secretary operating layer",
+        "updated_at": "2026-06-24T04:05:00Z"
+      },
+      {
+        "allowed_actions": [
+          "tracked docs",
+          "top-level data YAML",
+          "source registries",
+          "approval gates"
+        ],
+        "authority_state": "approved",
+        "blocker_ids": ["block.brand.rayban-analytics-due"],
+        "domain": "brand",
+        "forbidden_actions": [
+          "folder moves",
+          "private payload reads",
+          "platform mutation",
+          "Gmail/Calendar/Drive/Apps Script mutation",
+          "posting",
+          "scheduling",
+          "sending",
+          "invoicing",
+          "payment mutation",
+          "deal-status mutation",
+          "source delete"
+        ],
+        "intent": "Make Brand agent-native without displacing deal closeout work.",
+        "mutation_class": "docs_schema",
+        "mutation_id": "mut.brand.phase1-operating-skeleton.complete",
+        "next_safe_action": "Keep Ray-Ban analytics and Higgsfield proof gaps visible while using Brand data ledgers for future admin exports.",
+        "object_type": "mutation",
+        "operation_ids": ["op.brand.phase1-operating-skeleton.complete"],
+        "proof_ids": ["proof.brand.phase1.commit"],
+        "proposed_by": "chief/brand",
+        "repo": "Brand",
+        "requested_at": "2026-06-24T03:52:00Z",
+        "required_approval_ids": [
+          "appr.admin.readonly-build-slices.2026-06-23"
+        ],
+        "risk_level": "low",
+        "source_refs": [
+          {
+            "kind": "bus_ref",
+            "path": "/Users/anipotts/Infra/coord/bus.jsonl",
+            "ref": "brand-phase-1-operating-skeleton-complete-2026-06-23",
+            "summary": "Brand Phase 1 completed at 0266970."
+          }
+        ],
+        "status": "verified",
+        "target_surface": "README.md, docs/00-control-center, docs/09-agent-ops, data",
+        "title": "Brand phase 1 operating skeleton",
+        "updated_at": "2026-06-24T04:05:00Z"
+      },
+      {
+        "allowed_actions": [
+          "tracked docs",
+          "sample admin-feed rows",
+          "branch push after validation"
+        ],
+        "authority_state": "approved",
+        "blocker_ids": ["block.jobs.gmail-empty-label-ui-cleanup"],
+        "domain": "jobs",
+        "forbidden_actions": [
+          "Gmail mutation",
+          "Calendar mutation",
+          "Sheets mutation",
+          "Workspace Studio mutation",
+          "applications",
+          "message delete/archive/send",
+          "filter mutation",
+          "outbound action"
+        ],
+        "intent": "Expose jobs tracker, Gmail proof, application gates, and repo state as static admin-feed rows.",
+        "mutation_class": "docs_schema",
+        "mutation_id": "mut.jobs.admin-feed-operating-layer.complete",
+        "next_safe_action": "Use Jobs ops/admin-feed rows as a source for the next static feed import; keep empty Gmail label-object cleanup separate.",
+        "object_type": "mutation",
+        "operation_ids": ["op.jobs.admin-feed-operating-layer.complete"],
+        "proof_ids": ["proof.jobs.admin-feed.commit"],
+        "proposed_by": "chief/jobs",
+        "repo": "jobs",
+        "requested_at": "2026-06-24T03:58:00Z",
+        "required_approval_ids": [
+          "appr.admin.readonly-build-slices.2026-06-23"
+        ],
+        "risk_level": "low",
+        "source_refs": [
+          {
+            "kind": "bus_ref",
+            "path": "/Users/anipotts/Infra/coord/bus.jsonl",
+            "ref": "jobs-admin-feed-operating-layer-complete-2026-06-23",
+            "summary": "Jobs admin-feed layer completed at 6b4768e."
+          }
+        ],
+        "status": "verified",
+        "target_surface": "docs/00-control-center, docs/09-agent-ops, ops/admin-feed",
+        "title": "Jobs admin feed operating layer",
+        "updated_at": "2026-06-24T04:05:00Z"
       }
     ],
     "operations": [
@@ -461,6 +746,134 @@
         "thread_id": "019eebf1-bbd7-7f53-95d5-6dc05d48732c",
         "title": "Health rename waiting on execution approval",
         "updated_at": "2026-06-24T03:55:32Z"
+      },
+      {
+        "agent": "chief/site",
+        "allowed_by_approval_ids": [
+          "appr.admin.readonly-build-slices.2026-06-23"
+        ],
+        "blocker_ids": ["block.site.static-feed-consumption"],
+        "branch": "codex/admin-control-plane-shell-2026-06-23",
+        "command_class": "ui_local_build",
+        "heartbeat_at": "2026-06-24T04:05:00Z",
+        "machine": "ap-mini",
+        "mutation_ids": ["mut.site.admin-static-feed.consume"],
+        "next_safe_action": "Finish typed adapter and local route smoke against the static bundle.",
+        "object_type": "operation",
+        "operation_id": "op.site.admin-static-feed.consume",
+        "phase": "static-feed-adapter",
+        "proof_ids": ["proof.admin.static-feed.bundle"],
+        "repo": "anipotts-com",
+        "source_refs": [
+          {
+            "kind": "codex_thread",
+            "path": "codex-thread:019eebe2-e344-7213-810b-9469b8fe4d1e",
+            "ref": "site static feed prompt",
+            "summary": "chief/site is currently implementing static feed consumption."
+          }
+        ],
+        "started_at": "2026-06-24T04:05:00Z",
+        "status": "running",
+        "stop_path": "Stop before deploy, DNS, env, secrets, Cloudflare, production, live collector, admin write path, or PR merge.",
+        "thread_id": "019eebe2-e344-7213-810b-9469b8fe4d1e",
+        "title": "Wire admin-solid to the static feed bundle",
+        "updated_at": "2026-06-24T04:05:00Z"
+      },
+      {
+        "agent": "chief/business",
+        "allowed_by_approval_ids": [
+          "appr.admin.readonly-build-slices.2026-06-23"
+        ],
+        "blocker_ids": [],
+        "branch": "main",
+        "command_class": "docs_schema_commit",
+        "heartbeat_at": "2026-06-24T03:56:00Z",
+        "machine": "ap-mini",
+        "mutation_ids": ["mut.business.secretary-operating-layer.complete"],
+        "next_safe_action": "Keep exporting safe metadata from the Business control center; do not infer payment or filing truth without exact source proof.",
+        "object_type": "operation",
+        "operation_id": "op.business.secretary-operating-layer.complete",
+        "phase": "verified-pushed",
+        "proof_ids": ["proof.business.secretary-layer.commit"],
+        "repo": "Business",
+        "source_refs": [
+          {
+            "kind": "git",
+            "path": "/Users/anipotts/Business",
+            "ref": "fd00777",
+            "summary": "Business main contains the first operating layer."
+          }
+        ],
+        "started_at": "2026-06-24T03:52:00Z",
+        "status": "succeeded",
+        "stop_path": "No external business systems were mutated; future changes stop at gates for filings, payments, accounts, portals, and outbound messages.",
+        "thread_id": "019eebe2-6147-70b0-b0fc-4a1a4ebaed2e",
+        "title": "Business operating layer committed",
+        "updated_at": "2026-06-24T04:05:00Z"
+      },
+      {
+        "agent": "chief/brand",
+        "allowed_by_approval_ids": [
+          "appr.admin.readonly-build-slices.2026-06-23"
+        ],
+        "blocker_ids": ["block.brand.rayban-analytics-due"],
+        "branch": "main",
+        "command_class": "docs_schema_commit",
+        "heartbeat_at": "2026-06-24T03:57:00Z",
+        "machine": "ap-mini",
+        "mutation_ids": ["mut.brand.phase1-operating-skeleton.complete"],
+        "next_safe_action": "Keep Ray-Ban due date and Higgsfield proof state prominent in the Brand control center.",
+        "object_type": "operation",
+        "operation_id": "op.brand.phase1-operating-skeleton.complete",
+        "phase": "verified-pushed",
+        "proof_ids": ["proof.brand.phase1.commit"],
+        "repo": "Brand",
+        "source_refs": [
+          {
+            "kind": "git",
+            "path": "/Users/anipotts/Brand",
+            "ref": "0266970",
+            "summary": "Brand main contains the first operating skeleton."
+          }
+        ],
+        "started_at": "2026-06-24T03:52:00Z",
+        "status": "succeeded",
+        "stop_path": "No platform, media, posting, scheduling, payment, deal-status, or source-delete mutation occurred.",
+        "thread_id": "019eebe2-c72e-73d1-a945-c1a446d3b155",
+        "title": "Brand phase 1 skeleton committed",
+        "updated_at": "2026-06-24T04:05:00Z"
+      },
+      {
+        "agent": "chief/jobs",
+        "allowed_by_approval_ids": [
+          "appr.admin.readonly-build-slices.2026-06-23"
+        ],
+        "blocker_ids": ["block.jobs.gmail-empty-label-ui-cleanup"],
+        "branch": "codex/yc-2025-job-recs-refresh-2026-06-15",
+        "command_class": "docs_schema_commit",
+        "heartbeat_at": "2026-06-24T04:01:00Z",
+        "machine": "ap-mini",
+        "mutation_ids": ["mut.jobs.admin-feed-operating-layer.complete"],
+        "next_safe_action": "Keep Jobs admin-feed rows as static source data until a safe read-only exporter exists.",
+        "object_type": "operation",
+        "operation_id": "op.jobs.admin-feed-operating-layer.complete",
+        "phase": "verified-pushed",
+        "proof_ids": ["proof.jobs.admin-feed.commit"],
+        "repo": "jobs",
+        "source_refs": [
+          {
+            "kind": "git",
+            "path": "/Users/anipotts/Personal/jobs",
+            "ref": "6b4768e",
+            "summary": "Jobs branch contains the first admin-feed operating layer."
+          }
+        ],
+        "started_at": "2026-06-24T03:58:00Z",
+        "status": "succeeded",
+        "stop_path": "No Gmail, Calendar, Sheets, Workspace Studio, application, message archive/send/delete, filter, or outbound mutation occurred.",
+        "thread_id": "019eebe2-d537-76e2-bbfe-32a04ac63458",
+        "title": "Jobs admin feed layer committed",
+        "updated_at": "2026-06-24T04:05:00Z"
       }
     ],
     "proofs": [
@@ -549,6 +962,120 @@
           "mut.health.rename.execution-gate",
           "block.health.rename.execution-approval",
           "repo.health.vitals-live-tree.ap-mini"
+        ]
+      },
+      {
+        "collected_at": "2026-06-24T04:04:00Z",
+        "collected_by": "fleet/boss",
+        "evidence_uri": "python3 coord/admin/validate_admin_contract.py",
+        "machine": "ap-mini",
+        "object_type": "proof",
+        "proof_id": "proof.admin.static-feed.bundle",
+        "proof_type": "validator",
+        "redaction": "none",
+        "related_ids": ["op.site.admin-static-feed.consume"],
+        "repo": "Infra",
+        "source_refs": [
+          {
+            "kind": "git",
+            "path": "/Users/anipotts/Infra",
+            "ref": "8fa3c32",
+            "summary": "Infra commit created the deterministic bundled feed."
+          }
+        ],
+        "status": "valid",
+        "summary": "Static bundle was generated from tracked sample JSONL rows and validator confirms snapshot counts match source samples.",
+        "title": "Static admin feed bundle validates",
+        "updated_at": "2026-06-24T04:05:00Z",
+        "verifies": [
+          "mut.site.admin-static-feed.consume",
+          "block.site.static-feed-consumption"
+        ]
+      },
+      {
+        "collected_at": "2026-06-24T03:56:00Z",
+        "collected_by": "chief/business",
+        "evidence_uri": "git commit fd00777",
+        "machine": "ap-mini",
+        "object_type": "proof",
+        "proof_id": "proof.business.secretary-layer.commit",
+        "proof_type": "git_commit",
+        "redaction": "metadata_only",
+        "related_ids": ["op.business.secretary-operating-layer.complete"],
+        "repo": "Business",
+        "source_refs": [
+          {
+            "kind": "bus_ref",
+            "path": "/Users/anipotts/Infra/coord/bus.jsonl",
+            "ref": "business-secretary-operating-layer-complete-2026-06-23",
+            "summary": "Business completion was absorbed by fleet/boss."
+          }
+        ],
+        "status": "valid",
+        "summary": "Business main contains docs/00-control-center, docs/09-agent-ops, safe data ledgers/source registries, and agent-rule pointers. Validation reported YAML parse, compliance-state summary, AGENTS/CLAUDE match, diff check, and no tracked private artifacts.",
+        "title": "Business operating layer commit verified",
+        "updated_at": "2026-06-24T04:05:00Z",
+        "verifies": [
+          "mut.business.secretary-operating-layer.complete",
+          "repo.business.ap-mini.main"
+        ]
+      },
+      {
+        "collected_at": "2026-06-24T03:57:00Z",
+        "collected_by": "chief/brand",
+        "evidence_uri": "git commit 0266970",
+        "machine": "ap-mini",
+        "object_type": "proof",
+        "proof_id": "proof.brand.phase1.commit",
+        "proof_type": "git_commit",
+        "redaction": "metadata_only",
+        "related_ids": ["op.brand.phase1-operating-skeleton.complete"],
+        "repo": "Brand",
+        "source_refs": [
+          {
+            "kind": "bus_ref",
+            "path": "/Users/anipotts/Infra/coord/bus.jsonl",
+            "ref": "brand-phase-1-operating-skeleton-complete-2026-06-23",
+            "summary": "Brand completion was absorbed by fleet/boss."
+          }
+        ],
+        "status": "valid",
+        "summary": "Brand main contains README, docs/00-control-center, docs/09-agent-ops, data ledgers/source registries, and .gitignore changes while private exports remain ignored. Validation reported diff check, YAML parse, no staged private artifact formats, no folder moves, no private payload reads, and no external mutations.",
+        "title": "Brand phase 1 operating skeleton commit verified",
+        "updated_at": "2026-06-24T04:05:00Z",
+        "verifies": [
+          "mut.brand.phase1-operating-skeleton.complete",
+          "repo.brand.ap-mini.main",
+          "block.brand.rayban-analytics-due"
+        ]
+      },
+      {
+        "collected_at": "2026-06-24T04:01:00Z",
+        "collected_by": "chief/jobs",
+        "evidence_uri": "git commit 6b4768e",
+        "machine": "ap-mini",
+        "object_type": "proof",
+        "proof_id": "proof.jobs.admin-feed.commit",
+        "proof_type": "git_commit",
+        "redaction": "metadata_only",
+        "related_ids": ["op.jobs.admin-feed-operating-layer.complete"],
+        "repo": "jobs",
+        "source_refs": [
+          {
+            "kind": "bus_ref",
+            "path": "/Users/anipotts/Infra/coord/bus.jsonl",
+            "ref": "jobs-admin-feed-operating-layer-complete-2026-06-23",
+            "summary": "Jobs completion was absorbed by fleet/boss."
+          }
+        ],
+        "status": "valid",
+        "summary": "Jobs branch contains docs/00-control-center, docs/09-agent-ops, ops/admin-feed README, and schema-compatible sample rows. Validation reported 12 Jobs feed rows against Infra schemas and upstream Infra samples with 0 failures and 13 sample rows.",
+        "title": "Jobs admin-feed layer commit verified",
+        "updated_at": "2026-06-24T04:05:00Z",
+        "verifies": [
+          "mut.jobs.admin-feed-operating-layer.complete",
+          "repo.jobs.ap-mini.branch",
+          "block.jobs.gmail-empty-label-ui-cleanup"
         ]
       }
     ],
@@ -656,6 +1183,105 @@
         "updated_at": "2026-06-24T03:55:32Z",
         "upstream": "none",
         "worktree_state": "unknown"
+      },
+      {
+        "active_threads": ["chief/business"],
+        "ahead": 0,
+        "behind": 0,
+        "blocker_ids": [],
+        "branch": "main",
+        "canonical_role": "source",
+        "deploy_impact": "none",
+        "dirty_tracked": [],
+        "head_sha": "fd00777",
+        "last_verified_at": "2026-06-24T03:56:00Z",
+        "live_runtime_role": "business operating repo and metadata source for compliance/revenue/evidence gates",
+        "machine": "ap-mini",
+        "next_safe_action": "Use the control center and safe ledgers as metadata-only inputs for admin; keep payments, filings, portals, and outbound actions gated.",
+        "object_type": "repo_state",
+        "path": "/Users/anipotts/Business",
+        "proof_ids": ["proof.business.secretary-layer.commit"],
+        "repo": "Business",
+        "repo_state_id": "repo.business.ap-mini.main",
+        "source_refs": [
+          {
+            "kind": "git",
+            "path": "/Users/anipotts/Business",
+            "ref": "fd00777",
+            "summary": "Business operating layer is pushed and aligned."
+          }
+        ],
+        "untracked_count": 0,
+        "untracked_policy": "do not stage private artifacts; source truth stays in tracked operating docs plus explicit evidence refs",
+        "updated_at": "2026-06-24T04:05:00Z",
+        "upstream": "origin/main",
+        "worktree_state": "clean"
+      },
+      {
+        "active_threads": ["chief/brand"],
+        "ahead": 0,
+        "behind": 0,
+        "blocker_ids": ["block.brand.rayban-analytics-due"],
+        "branch": "main",
+        "canonical_role": "source",
+        "deploy_impact": "none",
+        "dirty_tracked": [],
+        "head_sha": "0266970",
+        "last_verified_at": "2026-06-24T03:57:00Z",
+        "live_runtime_role": "brand operating repo and metadata source for deal, content, and platform gates",
+        "machine": "ap-mini",
+        "next_safe_action": "Keep Ray-Ban analytics due date and Higgsfield proof status visible while preserving Business as payment truth source.",
+        "object_type": "repo_state",
+        "path": "/Users/anipotts/Brand",
+        "proof_ids": ["proof.brand.phase1.commit"],
+        "repo": "Brand",
+        "repo_state_id": "repo.brand.ap-mini.main",
+        "source_refs": [
+          {
+            "kind": "git",
+            "path": "/Users/anipotts/Brand",
+            "ref": "0266970",
+            "summary": "Brand Phase 1 operating skeleton is pushed and aligned."
+          }
+        ],
+        "untracked_count": 0,
+        "untracked_policy": "private exports and ops/crew/data remain ignored; do not stage media, PDFs, videos, envs, or private payloads",
+        "updated_at": "2026-06-24T04:05:00Z",
+        "upstream": "origin/main",
+        "worktree_state": "clean"
+      },
+      {
+        "active_threads": ["chief/jobs"],
+        "ahead": 0,
+        "behind": 0,
+        "blocker_ids": ["block.jobs.gmail-empty-label-ui-cleanup"],
+        "branch": "codex/yc-2025-job-recs-refresh-2026-06-15",
+        "canonical_role": "source",
+        "deploy_impact": "none",
+        "dirty_tracked": [],
+        "head_sha": "6b4768e",
+        "last_verified_at": "2026-06-24T04:01:00Z",
+        "live_runtime_role": "jobs tracker and proof repo; outbound/application/Gmail mutations remain gated",
+        "machine": "ap-mini",
+        "next_safe_action": "Use ops/admin-feed as static metadata source; keep Gmail label-object cleanup browser/UI-only and non-destructive.",
+        "object_type": "repo_state",
+        "path": "/Users/anipotts/Personal/jobs",
+        "proof_ids": ["proof.jobs.admin-feed.commit"],
+        "repo": "jobs",
+        "repo_state_id": "repo.jobs.ap-mini.branch",
+        "source_refs": [
+          {
+            "kind": "git",
+            "path": "/Users/anipotts/Personal/jobs",
+            "ref": "6b4768e",
+            "summary": "Jobs admin-feed branch is pushed and aligned."
+          }
+        ],
+        "untracked_count": 0,
+        "untracked_policy": "do not stage private Gmail, tracker, or application artifacts unless explicitly routed and redacted",
+        "updated_at": "2026-06-24T04:05:00Z",
+        "upstream": "origin/codex/yc-2025-job-recs-refresh-2026-06-15",
+        "worktree_state": "clean"
       }
     ]
   },

--- a/apps/admin-solid/src/entry-server.tsx
+++ b/apps/admin-solid/src/entry-server.tsx
@@ -7,9 +7,8 @@ export default createHandler(() => (
         <head>
           <meta charset="utf-8" />
           <meta name="viewport" content="width=device-width, initial-scale=1" />
-          <meta name="theme-color" content="#fbfaf7" media="(prefers-color-scheme: light)" />
-          <meta name="theme-color" content="#11111b" media="(prefers-color-scheme: dark)" />
-          <title>anipotts / admin</title>
+          <meta name="theme-color" content="#111111" />
+          <title>anipotts admin</title>
           {assets}
         </head>
         <body>

--- a/apps/admin-solid/src/routes/api/admin/runtime-feed.ts
+++ b/apps/admin-solid/src/routes/api/admin/runtime-feed.ts
@@ -1,0 +1,53 @@
+import type { RuntimeOverlayResponse, RuntimeRepoOverlay } from "~/data/control-plane";
+
+const RUNTIME_FEED_PATH = "/Users/anipotts/Infra/state/runtime/admin/admin-feed.current.json";
+
+type RuntimeFeedFile = {
+  generated_at?: string;
+  machine?: string;
+  runtime?: {
+    repo_state_overlays?: RuntimeRepoOverlay[];
+    safety?: RuntimeOverlayResponse["safety"];
+  };
+};
+
+export async function GET() {
+  if (!import.meta.env.DEV) {
+    return Response.json(disabledResponse());
+  }
+
+  try {
+    const { readFile } = await import("node:fs/promises");
+    const raw = await readFile(RUNTIME_FEED_PATH, "utf8");
+    const feed = JSON.parse(raw) as RuntimeFeedFile;
+
+    return Response.json({
+      available: true,
+      mode: "local_dev",
+      generated_at: feed.generated_at ?? null,
+      machine: feed.machine ?? null,
+      source_path: RUNTIME_FEED_PATH,
+      safety: feed.runtime?.safety ?? null,
+      overlays: feed.runtime?.repo_state_overlays ?? [],
+    } satisfies RuntimeOverlayResponse);
+  } catch (error) {
+    const code = typeof error === "object" && error && "code" in error ? String(error.code) : "";
+    return Response.json({
+      ...disabledResponse(),
+      mode: code === "ENOENT" ? "missing" : "error",
+      error: error instanceof Error ? error.message : "unknown runtime feed read failure",
+    } satisfies RuntimeOverlayResponse);
+  }
+}
+
+function disabledResponse(): RuntimeOverlayResponse {
+  return {
+    available: false,
+    mode: "disabled",
+    generated_at: null,
+    machine: null,
+    source_path: RUNTIME_FEED_PATH,
+    safety: null,
+    overlays: [],
+  };
+}

--- a/apps/admin-solid/src/routes/fleet.tsx
+++ b/apps/admin-solid/src/routes/fleet.tsx
@@ -1,0 +1,24 @@
+import {
+  ControlPlaneLayout,
+  FleetGrid,
+  SectionHeader,
+} from "~/components/ControlPlane";
+import { operations } from "~/data/control-plane";
+
+export default function FleetRoute() {
+  return (
+    <ControlPlaneLayout
+      title="fleet"
+      deck="Machine-level status placeholders for ap-pro and ap-mini. Live heartbeats come later through workers/state and chief/infra proof."
+    >
+      <section>
+        <SectionHeader
+          eyebrow="machines"
+          title="pro and mini"
+          detail="Codex, Claude, task, mode, heartbeat"
+        />
+        <FleetGrid operations={operations} />
+      </section>
+    </ControlPlaneLayout>
+  );
+}

--- a/apps/admin-solid/src/routes/handoffs.tsx
+++ b/apps/admin-solid/src/routes/handoffs.tsx
@@ -1,0 +1,24 @@
+import {
+  ControlPlaneLayout,
+  HandoffTable,
+  SectionHeader,
+} from "~/components/ControlPlane";
+import { handoffs } from "~/data/control-plane";
+
+export default function HandoffsRoute() {
+  return (
+    <ControlPlaneLayout
+      title="handoffs"
+      deck="Newest, stale, unabsorbed, and owner-routed handoffs with proof pointers. This keeps agent state out of chat memory."
+    >
+      <section>
+        <SectionHeader
+          eyebrow="coordination"
+          title="handoff absorption"
+          detail="newest / stale / unabsorbed / owner thread"
+        />
+        <HandoffTable handoffs={handoffs} />
+      </section>
+    </ControlPlaneLayout>
+  );
+}

--- a/apps/admin-solid/src/routes/index.tsx
+++ b/apps/admin-solid/src/routes/index.tsx
@@ -3,13 +3,13 @@ import {
   SectionHeader,
   WorkCardView,
 } from "~/components/ControlPlane";
-import { workCards } from "~/data/control-plane";
+import { coverageCards, feedSource, workCards } from "~/data/control-plane";
 
 export default function Home() {
   return (
     <ControlPlaneLayout
       title="control-plane shell"
-      deck="A read-only admin surface for deciding what is safe to do next. This first slice uses local sample data and keeps every live mutation behind proof and approval gates."
+      deck={`A read-only admin surface for deciding what is safe to do next. This static feed copy comes from Infra ${feedSource.infra_commit} and keeps every live mutation behind proof and approval gates.`}
     >
       <section>
         <SectionHeader
@@ -19,6 +19,19 @@ export default function Home() {
         />
         <div class="grid actions-grid">
           {workCards.map((card) => (
+            <WorkCardView card={card} />
+          ))}
+        </div>
+      </section>
+
+      <section>
+        <SectionHeader
+          eyebrow="feed coverage"
+          title="what the bundle can see"
+          detail={feedSource.snapshot_type}
+        />
+        <div class="grid actions-grid">
+          {coverageCards.map((card) => (
             <WorkCardView card={card} />
           ))}
         </div>

--- a/apps/admin-solid/src/routes/index.tsx
+++ b/apps/admin-solid/src/routes/index.tsx
@@ -1,16 +1,28 @@
-import { CommitFeed } from "~/components/CommitFeed";
-import { LinkVaultPanel } from "~/components/LinkVaultPanel";
+import {
+  ControlPlaneLayout,
+  SectionHeader,
+  WorkCardView,
+} from "~/components/ControlPlane";
+import { workCards } from "~/data/control-plane";
 
 export default function Home() {
   return (
-    <main>
-      <h1>anipotts / admin</h1>
-      <p class="muted">
-        v2 build. SolidStart on Cloudflare Workers, live state via Durable Object WebSockets. No
-        polling.
-      </p>
-      <LinkVaultPanel />
-      <CommitFeed />
-    </main>
+    <ControlPlaneLayout
+      title="control-plane shell"
+      deck="A read-only admin surface for deciding what is safe to do next. This first slice uses local sample data and keeps every live mutation behind proof and approval gates."
+    >
+      <section>
+        <SectionHeader
+          eyebrow="safe next actions"
+          title="what to do next"
+          detail="mocked local data"
+        />
+        <div class="grid actions-grid">
+          {workCards.map((card) => (
+            <WorkCardView card={card} />
+          ))}
+        </div>
+      </section>
+    </ControlPlaneLayout>
   );
 }

--- a/apps/admin-solid/src/routes/mutations.tsx
+++ b/apps/admin-solid/src/routes/mutations.tsx
@@ -1,0 +1,24 @@
+import {
+  ControlPlaneLayout,
+  MutationTable,
+  SectionHeader,
+} from "~/components/ControlPlane";
+import { authorityCards, proofs, workCards } from "~/data/control-plane";
+
+export default function MutationsRoute() {
+  return (
+    <ControlPlaneLayout
+      title="mutation queue"
+      deck="Proposed, approved, running, verified, and blocked operations in one place. This page does not execute anything."
+    >
+      <section>
+        <SectionHeader
+          eyebrow="operation state"
+          title="mutation lifecycle"
+          detail="proposed / approved / running / verified / blocked"
+        />
+        <MutationTable rows={workCards} authorities={authorityCards} proofs={proofs} />
+      </section>
+    </ControlPlaneLayout>
+  );
+}

--- a/apps/admin-solid/src/routes/ops/destructive.tsx
+++ b/apps/admin-solid/src/routes/ops/destructive.tsx
@@ -1,0 +1,24 @@
+import {
+  ControlPlaneLayout,
+  DestructiveGrid,
+  SectionHeader,
+} from "~/components/ControlPlane";
+import { destructiveGates } from "~/data/control-plane";
+
+export default function DestructiveOpsRoute() {
+  return (
+    <ControlPlaneLayout
+      title="destructive ops"
+      deck="Delete, auth, secrets, DNS, deploy, payment, and account operations are hard gated. This route shows proof requirements only."
+    >
+      <section>
+        <SectionHeader
+          eyebrow="hard gates"
+          title="no live controls"
+          detail="proof-backed approvals only"
+        />
+        <DestructiveGrid gates={destructiveGates} />
+      </section>
+    </ControlPlaneLayout>
+  );
+}

--- a/apps/admin-solid/src/routes/repos.tsx
+++ b/apps/admin-solid/src/routes/repos.tsx
@@ -1,0 +1,24 @@
+import {
+  ControlPlaneLayout,
+  RepoTable,
+  SectionHeader,
+} from "~/components/ControlPlane";
+import { repos } from "~/data/control-plane";
+
+export default function ReposRoute() {
+  return (
+    <ControlPlaneLayout
+      title="repos"
+      deck="Repository status placeholders for dirty state, branch position, active worktrees, and PR or deploy impact."
+    >
+      <section>
+        <SectionHeader
+          eyebrow="source state"
+          title="repo and worktree risk"
+          detail="mocked until git publisher lands"
+        />
+        <RepoTable repos={repos} />
+      </section>
+    </ControlPlaneLayout>
+  );
+}

--- a/apps/admin-solid/src/routes/repos.tsx
+++ b/apps/admin-solid/src/routes/repos.tsx
@@ -1,6 +1,7 @@
 import {
   ControlPlaneLayout,
   RepoTable,
+  RuntimeRepoOverlayPanel,
   SectionHeader,
 } from "~/components/ControlPlane";
 import { repos } from "~/data/control-plane";
@@ -9,15 +10,19 @@ export default function ReposRoute() {
   return (
     <ControlPlaneLayout
       title="repos"
-      deck="Repository status placeholders for dirty state, branch position, active worktrees, and PR or deploy impact."
+      deck="Static repo states with local-dev runtime overlays for branch, git availability, dirty counts, and deploy impact."
     >
       <section>
         <SectionHeader
           eyebrow="source state"
           title="repo and worktree risk"
-          detail="mocked until git publisher lands"
+          detail="static bundle plus runtime overlay"
         />
         <RepoTable repos={repos} />
+      </section>
+
+      <section>
+        <RuntimeRepoOverlayPanel />
       </section>
     </ControlPlaneLayout>
   );


### PR DESCRIPTION
## summary
- add read-only apps/admin-solid control-plane shell with required overview, mutations, fleet, repos, handoffs, and destructive ops routes
- model mocked data with chief/infra contract fields from Infra b5fcc37
- keep every deploy, DNS, env, secret, live worker, and destructive operation as display-only gated state

## verification
- pnpm --filter @anipotts/admin-solid typecheck
- pnpm --filter @anipotts/admin-solid build
- python3 coord/admin/validate_admin_contract.py from /Users/anipotts/Infra
- git diff --check
- local dev route smoke for /, /mutations, /fleet, /repos, /handoffs, and /ops/destructive on localhost:3001

## live impact
none. draft PR only. no deploy, DNS, env, secrets, Cloudflare, or live worker mutation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new admin control-plane experience with dedicated pages for overview, fleet, handoffs, mutations, repos, and destructive operations.
  * Introduced clearer status and risk indicators, improved cards, tables, and grid-based layouts for easier scanning.
  * Added a runtime overlay panel that shows local feed data when available.

* **Style**
  * Refreshed the admin UI with a dark theme, updated typography, and responsive layouts for smaller screens.

* **Bug Fixes**
  * Improved fallback and error handling for runtime feed loading so the page degrades gracefully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->