### PR TITLE
Define admin v2 policy and architecture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,8 @@
 # anipotts-com agent guide
 
 This repo owns the public site and the protected admin UI. It should be easy
-for Codex and Claude Code to build, verify, merge, and deploy ordinary site and
-read-only admin improvements without reopening stale permission debates.
+for Codex and Claude Code to build, verify, merge, and deploy ordinary public
+site work while keeping admin control paths on stricter authority.
 
 `AGENTS.md` is a symlink to this file. Keep them equivalent.
 
@@ -16,8 +16,8 @@ read-only admin improvements without reopening stale permission debates.
 - Content operations: `~/Content`, not this repo
 - Fleet state: `~/Infra/coord`, handoffs, registries, and admin feed files
 
-The target direction is that text content on `anipotts.com` is editable through
-`admin.anipotts.com`, so routine wording changes should move toward admin data
+The target direction is that text content on `anipotts.com` becomes editable
+through `admin.anipotts.com`, so routine wording changes move toward admin data
 or content records instead of recurring source deploys.
 
 ## commands
@@ -43,8 +43,8 @@ pnpm turbo build --filter=@anipotts/www...
 
 ## architecture
 
-- `apps/www`: Astro 5 static site on Cloudflare Workers.
-- `apps/admin-solid`: SolidStart admin control plane behind Cloudflare Access.
+- `apps/www`: Astro 5 site on Cloudflare Workers.
+- `apps/admin-solid`: current admin control plane behind Cloudflare Access.
 - `apps/admin`: older admin surface kept for compatibility while replacement
   work continues.
 - `apps/labs`: labs subdomain.
@@ -54,9 +54,44 @@ pnpm turbo build --filter=@anipotts/www...
   helpers.
 
 The admin control plane is read-only first. It may render `NEEDS-ANI`, repo
-state, fleet state, stale rule drift, live gates, and proof paths. Admin write
-paths, production collectors, control buttons, outbound sends, and account
-mutations require separate authority.
+state, fleet state, stale rule drift, live gates, proof paths, and future
+content-editor previews. Admin write paths, production collectors, control
+buttons, outbound sends, and account mutations require separate authority.
+
+## permission model
+
+Public site lane:
+
+- Agents may proactively create branches and PRs for safe content, copy, route,
+  layout, accessibility, and visual polish work.
+- Agents may run checks, commit, push, mark PRs ready, and merge when required
+  checks pass and the diff stays inside public site presentation or static
+  content.
+- Public site deploys from approved merges are normal when path-filtered CI
+  selects `apps/www`.
+- Do not use code edits as the permanent answer when the same wording should
+  become admin-editable content.
+
+Admin read-only lane:
+
+- Agents may proactively branch and PR read-only admin UI, schema display,
+  static feed rendering, local-dev runtime metadata, and proof views.
+- Agents may merge and deploy read-only admin UI only when the PR is approved,
+  checks pass, and the deploy target is limited to the intended admin worker.
+- The current live protected admin target is `apps/admin-solid` on
+  `admin.anipotts.com`.
+- Admin v2 should stay Astro-aligned and sidebar-first, with interactive islands
+  only where live state needs them.
+
+Admin control lane:
+
+- Any write path, content save, deploy trigger, approval bridge, external send,
+  account action, collector change, or live control button needs exact current
+  authority.
+- Authority must name the operation, allowed surface, forbidden actions, proof
+  requirement, and rollback or stop path.
+- Disabled UI for future controls is acceptable only when it cannot execute.
+- The default state for new admin capabilities is read-only proof rendering.
 
 ## agent lanes
 
@@ -65,8 +100,8 @@ approved safe lanes when checks pass.
 
 Safe lanes:
 
-- public site presentation and layout without secrets, auth, DNS, payments, or
-  external writes.
+- public site presentation, content records, and layout without secrets, auth,
+  DNS, payments, or external writes.
 - `apps/admin-solid` read-only UI, route, copy, static feed, and local-dev
   runtime display work.
 - docs and repo guide updates that reduce stale blockers and align with
@@ -74,12 +109,14 @@ Safe lanes:
 - tests, validation, build config, and deploy workflow path filters that do not
   expand secrets or live permissions.
 
-Merge/deploy lane:
+Merge and deploy lane:
 
 - A same-repo PR may be merged by an agent after required checks pass when the
   diff is fully inside a safe lane.
 - Main pushes trigger the path-filtered Deploy workflow. That is expected for
-  safe site and read-only admin UI work.
+  safe public site and approved read-only admin UI work.
+- Docs-only changes should be merged normally when reviewed, but should not
+  deploy app targets.
 - Record the merge, deploy run, and verification URL in the PR or bus when the
   work is fleet-visible.
 
@@ -98,8 +135,10 @@ or an explicit current Ani instruction covering the exact action:
 - force-push, history rewrite, destructive cleanup, or source/personal deletes.
 - health-data mutation, `/Users/ojas` mutation, or printing secret values.
 
-Do not use stale local "no deploy" text to block a safe-lane admin or site UI
-deploy after checks. Do stop when the diff crosses a hard gate.
+Do not use stale local "no deploy" text to block a safe-lane public site deploy
+after checks. For admin, confirm that the change is read-only, approved, and
+limited to the intended target before deploy. Do stop when the diff crosses a
+hard gate.
 
 ## data and content
 
@@ -112,6 +151,10 @@ Prefer small read-only slices:
 - render the queue or state first,
 - verify authenticated and unauthenticated behavior,
 - only then propose write paths with authority.
+
+See `docs/admin-v2-architecture.md` for the current admin v2 direction and
+`docs/content-admin-editor-brief.md` for the public-site content model that
+should eventually be editable through admin.
 
 ## environment
 

--- a/apps/admin-solid/README.md
+++ b/apps/admin-solid/README.md
@@ -1,40 +1,83 @@
 # @anipotts/admin-solid
 
-SolidStart admin (v2) for the personal cloud. Subscribes to Durable Objects in `@anipotts/state` over WebSockets so the dashboard updates in real time without polling.
+Current protected admin control-plane shell for `admin.anipotts.com`.
 
-This is **step 3** of the personal-cloud-architecture build (see `docs/personal-cloud-architecture.md`). Built alongside the existing `apps/admin` (Next.js) at `admin-v2.anipotts.com`. Tile-by-tile parity, then DNS swap to `admin.anipotts.com` and the Next admin retires.
+This app is read-only first. It renders the fleet/admin feed model:
 
-## Quick start
+`intent / authority / operation / proof / state`
+
+## current role
+
+- practical operator dashboard for Ani and agents
+- protected by Cloudflare Access at `admin.anipotts.com`
+- static feed copy from Infra for committed sample state
+- local-dev runtime loader for safe metadata overlays
+- no admin write path, content save path, deploy trigger, DNS control, secret
+  editor, or approval bridge execution path
+
+## routes
+
+| route              | purpose                                               |
+| ------------------ | ----------------------------------------------------- |
+| `/`                | safe-next-action overview and feed coverage           |
+| `/needs-ani`       | typed human syscall queue and future bridge contract  |
+| `/mutations`       | proposed, approved, running, verified, blocked states |
+| `/fleet`           | machine and agent operation placeholders              |
+| `/repos`           | static repo state plus local-dev runtime overlays     |
+| `/handoffs`        | handoff absorption and owner routing                  |
+| `/ops/destructive` | proof-backed destructive operation gates              |
+
+## data
+
+- static sample: `src/data/static/admin-feed.sample.json`
+- adapter: `src/data/control-plane.ts`
+- bridge design only: `src/data/approval-bridge.ts`
+- local runtime endpoint: `/api/admin/runtime-feed`
+- runtime source path:
+  `/Users/anipotts/Infra/state/runtime/admin/admin-feed.current.json`
+
+Runtime overlays are metadata-only. They must not include dirty filenames, file
+contents, secret values, health payload rows, private messages, message ids, or
+dollar amounts.
+
+## commands
 
 ```bash
-pnpm install
-# In one terminal:
-pnpm --filter @anipotts/state dev
-# In another:
 pnpm --filter @anipotts/admin-solid dev
-# Open http://localhost:3001
+pnpm --filter @anipotts/admin-solid typecheck
+pnpm --filter @anipotts/admin-solid build
 ```
 
-## Routes
+## deploy
 
-| Route | Component                                     |
-| ----- | --------------------------------------------- |
-| `/`   | `LinkVaultPanel` (live links list, save form) |
+Deploys go through the repo-level path-filtered GitHub Actions workflow. Do not
+run `wrangler deploy` manually unless Ani has approved that exact action.
 
-## Adding a panel
+The deploy target is `anipotts-admin-solid`; its custom domain route is
+`admin.anipotts.com`.
 
-1. Create `src/components/<Panel>.tsx` that opens a `StateClient` against `/<do>/ws` on the state worker.
-2. Drop it into a route under `src/routes/`.
-3. The panel gets live updates via the WebSocket; mutations go via REST POST to the same worker.
+## gates
 
-## Deploy
+Allowed without fresh authority after normal PR review and checks:
 
-```bash
-pnpm --filter @anipotts/admin-solid exec wrangler deploy
-```
+- read-only routes
+- feed adapters
+- static sample rendering
+- local-dev metadata overlays
+- layout and usability improvements
 
-After deploy, hostname is `https://anipotts-admin-solid.<account>.workers.dev`. To bind to `admin-v2.anipotts.com`, uncomment the `[[routes]]` block in `wrangler.toml` once the zone is in CF.
+Requires fresh authority:
 
-## Architecture
+- content writes
+- deploy triggers from the UI
+- approval bridge execution
+- Cloudflare Access changes
+- DNS changes
+- env or secret changes
+- production collector changes
+- account or payment actions
 
-The full vision: `docs/personal-cloud-architecture.md` in the same monorepo.
+## v2 direction
+
+The next admin direction is Astro-aligned and sidebar-first. See
+`docs/admin-v2-architecture.md`.

--- a/docs/admin-v2-architecture.md
+++ b/docs/admin-v2-architecture.md
@@ -1,0 +1,248 @@
+# admin.anipotts.com v2 architecture
+
+## goal
+
+`admin.anipotts.com` should become Ani's practical operator dashboard and,
+later, the web editing surface for public-site text and content.
+
+The dashboard must answer one operational question first:
+
+`what is safe to do next?`
+
+The current control-plane model remains the backbone:
+
+`intent / authority / operation / proof / state`
+
+## current baseline
+
+Live baseline:
+
+- app: `apps/admin-solid`
+- worker: `anipotts-admin-solid`
+- host: `admin.anipotts.com`
+- protection: Cloudflare Access
+- deployed state: read-only admin feed shell
+- latest proven queue: `/needs-ani`
+
+Current strengths:
+
+- dense operational pages already exist
+- `NEEDS-ANI` is rendered as typed human syscalls
+- static Infra feed and local-dev runtime overlays are wired
+- deploy workflow can target only admin-solid
+- unauthenticated users are blocked by Cloudflare Access
+
+Current gaps:
+
+- app framework is separate from the Astro public site direction
+- route components and data adapters are still tightly coupled
+- content editing is modeled in docs but not represented in the live admin nav
+- no formal read model for public-site editable content
+- no disabled preview for future save or publish workflows
+
+## recommended v2 shape
+
+Build v2 as an Astro-aligned Cloudflare app with a sidebar-first operator shell.
+Use Astro for routing, layout, and server-rendered read views. Use Solid islands
+only where live state, filters, optimistic previews, or stream updates need
+client-side state.
+
+Recommended app options:
+
+- short term: keep improving `apps/admin-solid` while v2 is documented
+- medium term: create `apps/admin-v2` as an Astro app and port read-only routes
+- final target: move `admin.anipotts.com` to the Astro-aligned app after proof
+
+Do not rewrite only for framework symmetry. Rewrite when the v2 shell can reduce
+deployment surface, make content editing easier, and share site-rendering
+patterns with `apps/www`.
+
+## information architecture
+
+Primary sidebar:
+
+- overview
+- needs ani
+- mutations
+- fleet
+- repos
+- handoffs
+- deploys
+- content
+- proof
+- destructive ops
+- settings
+
+Overview should show:
+
+- safe next action
+- blocked-by-Ani queue count
+- active operations
+- stale handoffs
+- dirty repo count
+- deploy impact
+- newest proof
+- hard gates
+
+`/content` should be read-only first:
+
+- homepage copy and proof cards
+- project cards and project detail bodies
+- writing titles, summaries, tags, status, and body preview
+- newsletter block copy
+- source path or record id
+- last proof or last edited timestamp when available
+
+## data architecture
+
+Use one adapter boundary:
+
+`source feed -> normalized admin model -> route view model -> UI`
+
+Source categories:
+
+- static admin feed from Infra
+- runtime admin feed from Infra state
+- public-site content collections from `apps/www/src/content`
+- page content from D1-backed CMS records
+- future state-worker feed for live fleet state
+
+Adapters should emit safe read models that carry:
+
+- `id`
+- `title`
+- `status`
+- `risk_level`
+- `next_safe_action`
+- `authority_state`
+- `required_approval_ids`
+- `allowed_actions`
+- `forbidden_actions`
+- `proof_ids`
+- `evidence_uri`
+- `redaction`
+- `source_ref`
+- `updated_at`
+
+Never include secret values, dirty filenames, file contents, private messages,
+health payload rows, message ids, signed document bodies, or dollar amounts in
+admin feed payloads unless a future authority explicitly permits that exact
+field.
+
+## content editing model
+
+Read-only content preview comes first.
+
+Future editable content should be modeled as operations, not direct writes:
+
+1. editor creates a proposed content operation
+2. preview renders old value and proposed value
+3. authority decides whether the operation is public-site safe or admin-gated
+4. proof records source, reviewer, and expected live impact
+5. approved operation writes to the chosen content store
+6. post-write proof verifies rendered route or record state
+
+Initial content surfaces:
+
+- homepage heading, summary, mention copy, and proof cards
+- selected project card fields
+- project detail markdown body
+- writing frontmatter and body
+- newsletter block copy
+- redirect and route labels only after separate review
+
+Do not start with cross-posting or social publishing. Those are outbound send
+paths and need stricter authority.
+
+## permission split
+
+Public site lane:
+
+- agents may branch, edit, verify, push, and PR safe content and UI work
+- agents may merge approved public-site PRs when checks pass
+- deploy through path-filtered workflow is expected after approved merge
+- live impact should be recorded in the PR or handoff
+
+Admin read-only lane:
+
+- agents may branch and PR read-only dashboards, routes, schema display, and
+  feed adapters
+- deploy requires approval when the live admin target changes
+- authenticated and unauthenticated proof should be captured when available
+- route output must respect redaction rules
+
+Admin control lane:
+
+- write paths require exact current authority
+- approval bridge execution requires exact current authority
+- deploy buttons require exact current authority
+- content-save APIs require exact current authority
+- collector, DNS, Access, env, and secret changes require exact current
+  authority
+
+## smallest first implementation slice
+
+First slice: add a read-only `/content` route to the current admin shell.
+
+Scope:
+
+- no framework rewrite
+- no writes
+- no D1 mutation
+- no deploy unless separately approved after PR
+- no new secret or Access changes
+
+Deliverables:
+
+- route: `/content`
+- adapter: public-site content read model
+- sections for homepage, projects, writing, and newsletter
+- each row shows source, current rendered value, editability candidate, risk, and
+  next safe action
+- docs link to `docs/content-admin-editor-brief.md`
+- local build and typecheck
+
+Why this slice:
+
+- it moves admin toward the requested editing surface
+- it stays read-only
+- it exposes what should become editable before adding save behavior
+- it helps separate content data from source-code deploy habit
+- it can ship on the current app without waiting for Astro migration
+
+Second slice:
+
+- extract shared admin view-model types
+- add content operation preview objects
+- render disabled save/publish affordances with required authority labels
+- keep every button inert
+
+Third slice:
+
+- decide whether to keep `apps/admin-solid` or introduce `apps/admin-v2` Astro
+- port shell layout if Astro gives lower complexity
+- only then propose approved write APIs
+
+## verification expectations
+
+For read-only admin slices:
+
+```bash
+pnpm turbo typecheck --filter=@anipotts/admin-solid...
+pnpm turbo build --filter=@anipotts/admin-solid...
+```
+
+For future Astro v2 slices:
+
+```bash
+pnpm turbo typecheck --filter=<admin-v2-package>...
+pnpm turbo build --filter=<admin-v2-package>...
+```
+
+For deploy proof after approved merge:
+
+- PR merge commit
+- Deploy run id
+- target jobs run and skipped
+- unauthenticated Cloudflare Access behavior
+- authenticated route render when browser auth is available

--- a/docs/content-admin-editor-brief.md
+++ b/docs/content-admin-editor-brief.md
@@ -2,6 +2,13 @@
 
 this is the content shape that should feed the next admin editor pass. it stays scoped to public-site content and does not prescribe the admin thread's implementation architecture.
 
+Admin v2 architecture lives in `docs/admin-v2-architecture.md`. This file is
+the public-site content inventory that the admin route should read first.
+
+The next implementation slice is a read-only `/content` admin route. It should
+show what can become editable without adding save behavior, outbound publishing,
+or any live write path.
+
 ## current inventory
 
 | surface              | source                                                                    | current shape                                                                                                    | notes                                                         |
@@ -24,6 +31,29 @@ this is the content shape that should feed the next admin editor pass. it stays 
 | p1       | add newsletter headline, deck, cta, and status messages | the subscribe module should be editable without code                     | admin editor                  |
 | p2       | decide canonical project source                         | markdown and `packages/lib/src/data/projects.ts` duplicate similar facts | admin editor plus site thread |
 | p2       | classify old posts before publishing to Buttondown      | current writing can seed the newsletter, but should not be auto-sent     | newsletter thread             |
+
+## first read-only admin slice
+
+The first admin implementation should not edit content. It should render a
+content inventory table that helps Ani and agents decide what can safely become
+editable later.
+
+Rows should include:
+
+| field                | source                       | purpose                                      |
+| -------------------- | ---------------------------- | -------------------------------------------- |
+| `surface`            | route or component           | homepage, projects, writing, newsletter      |
+| `source_ref`         | file path or record id       | points to current source truth               |
+| `current_value`      | rendered text or field value | what the public site currently uses          |
+| `editability`        | enum                         | `ready`, `needs_schema`, `needs_owner`       |
+| `risk_level`         | enum                         | public-site copy risk, not admin write risk  |
+| `next_safe_action`   | text                         | branch/PR cleanup or keep read-only          |
+| `required_authority` | array                        | empty for read-only, populated before writes |
+| `proof_ids`          | array                        | route, screenshot, content file, or record   |
+
+The route should group content by homepage, projects, writing, and newsletter.
+It should not include credentials, outbound publishing controls, social APIs, or
+hidden admin write endpoints.
 
 ## recommended admin schema
 


### PR DESCRIPTION
## Summary
- clarify the repo guide around public-site, admin read-only, and admin control permission lanes
- update the admin-solid README to match the current protected read-only control-plane shell
- add `docs/admin-v2-architecture.md` with the Astro-aligned sidebar-first v2 direction
- extend the content editor brief with the smallest first slice: a read-only `/content` admin route

## Verification
- `pnpm exec prettier --check CLAUDE.md apps/admin-solid/README.md docs/content-admin-editor-brief.md docs/admin-v2-architecture.md`
- `git diff --check`

## Live impact
None. Docs-only branch. No deploy, DNS, auth, env, secret, admin write path, collector, or production mutation.
