### PR TITLE
Add read-only admin content inventory

### DIFF
--- a/apps/admin-solid/README.md
+++ b/apps/admin-solid/README.md
@@ -20,6 +20,7 @@ This app is read-only first. It renders the fleet/admin feed model:
 | route              | purpose                                               |
 | ------------------ | ----------------------------------------------------- |
 | `/`                | safe-next-action overview and feed coverage           |
+| `/content`         | read-only public-site content inventory               |
 | `/needs-ani`       | typed human syscall queue and future bridge contract  |
 | `/mutations`       | proposed, approved, running, verified, blocked states |
 | `/fleet`           | machine and agent operation placeholders              |

--- a/apps/admin-solid/src/app.css
+++ b/apps/admin-solid/src/app.css
@@ -11,7 +11,9 @@
   --blocked: #ef4444;
   --stale: #a78bfa;
   --destructive: #fb7185;
-  --font-sans: "Inter", -apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif;
+  --font-sans:
+    "Inter", -apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui,
+    sans-serif;
   --font-mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace;
 }
 
@@ -33,6 +35,73 @@ body {
 a {
   color: inherit;
   text-decoration: none;
+}
+
+.app-shell {
+  display: grid;
+  grid-template-columns: 240px minmax(0, 1fr);
+  min-height: 100vh;
+}
+
+.sidebar {
+  background: #0d0d0d;
+  border-right: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding: 18px 14px;
+  position: sticky;
+  top: 0;
+  height: 100vh;
+}
+
+.sidebar-brand {
+  border-bottom: 1px solid var(--border);
+  display: grid;
+  gap: 6px;
+  padding-bottom: 16px;
+}
+
+.sidebar-brand strong {
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 0.95rem;
+  font-weight: 650;
+}
+
+.sidebar-brand span,
+.side-note {
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  line-height: 1.45;
+}
+
+.side-nav {
+  display: grid;
+  gap: 6px;
+}
+
+.side-nav a {
+  border: 1px solid transparent;
+  border-radius: 6px;
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  padding: 9px 10px;
+}
+
+.side-nav a[aria-current="page"],
+.side-nav a:hover {
+  background: var(--panel);
+  border-color: var(--border);
+  color: var(--text);
+}
+
+.side-note {
+  display: grid;
+  gap: 10px;
+  margin-top: auto;
 }
 
 main {
@@ -119,34 +188,11 @@ dt,
   white-space: nowrap;
 }
 
-.nav-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  margin: 14px 0;
-}
-
-.nav-row a {
-  background: var(--panel);
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  color: var(--muted);
-  font-family: var(--font-mono);
-  font-size: 0.78rem;
-  padding: 9px 11px;
-}
-
-.nav-row a[aria-current="page"],
-.nav-row a:hover {
-  border-color: rgba(56, 189, 248, 0.4);
-  color: var(--text);
-}
-
 .top-strip {
   display: grid;
   gap: 10px;
   grid-template-columns: repeat(6, minmax(0, 1fr));
-  margin-bottom: 20px;
+  margin: 14px 0 20px;
 }
 
 .strip-card,
@@ -372,15 +418,22 @@ dd,
 }
 
 .mutation-row {
-  grid-template-columns: minmax(180px, 0.75fr) minmax(460px, 2.5fr) minmax(120px, 0.4fr);
+  grid-template-columns: minmax(180px, 0.75fr) minmax(460px, 2.5fr) minmax(
+      120px,
+      0.4fr
+    );
 }
 
 .authority-row {
-  grid-template-columns: minmax(220px, 0.8fr) repeat(3, minmax(180px, 1fr)) minmax(120px, 0.4fr);
+  grid-template-columns:
+    minmax(220px, 0.8fr) repeat(3, minmax(180px, 1fr))
+    minmax(120px, 0.4fr);
 }
 
 .proof-row {
-  grid-template-columns: minmax(240px, 1fr) repeat(3, minmax(180px, 1fr)) minmax(90px, 0.35fr);
+  grid-template-columns:
+    minmax(240px, 1fr) repeat(3, minmax(180px, 1fr))
+    minmax(90px, 0.35fr);
 }
 
 .repo-row {
@@ -398,22 +451,37 @@ dd,
 
 .needs-ani-row {
   align-items: start;
-  grid-template-columns: minmax(280px, 1.2fr) 110px 96px minmax(90px, 0.4fr) minmax(120px, 0.55fr) minmax(260px, 1.1fr) minmax(320px, 1.4fr) minmax(120px, 0.45fr);
+  grid-template-columns:
+    minmax(280px, 1.2fr) 110px 96px minmax(90px, 0.4fr)
+    minmax(120px, 0.55fr) minmax(260px, 1.1fr) minmax(320px, 1.4fr) minmax(
+      120px,
+      0.45fr
+    );
+}
+
+.content-row {
+  align-items: start;
+  grid-template-columns:
+    minmax(280px, 1.25fr) minmax(220px, 0.9fr) minmax(110px, 0.4fr)
+    90px minmax(160px, 0.75fr) minmax(160px, 0.75fr);
 }
 
 .repo-row .proof-line,
 .runtime-row .proof-line,
 .handoff-row .proof-line,
-.needs-ani-row .proof-line {
+.needs-ani-row .proof-line,
+.content-row .proof-line {
   grid-column: 1 / -1;
 }
 
-.needs-grid {
+.needs-grid,
+.content-grid {
   display: grid;
   gap: 14px;
 }
 
-.needs-group {
+.needs-group,
+.content-group {
   overflow: hidden;
 }
 
@@ -452,6 +520,11 @@ dd,
   padding-left: 18px;
 }
 
+.gate-panel {
+  display: grid;
+  gap: 12px;
+}
+
 .fact-grid {
   display: grid;
   gap: 8px;
@@ -481,12 +554,26 @@ dd,
   .repo-row,
   .runtime-row,
   .handoff-row,
-  .needs-ani-row {
+  .needs-ani-row,
+  .content-row {
     grid-template-columns: 1fr;
   }
 }
 
 @media (max-width: 720px) {
+  .app-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    height: auto;
+    position: static;
+  }
+
+  .side-nav {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
   main {
     padding: 14px;
   }

--- a/apps/admin-solid/src/components/ControlPlane.tsx
+++ b/apps/admin-solid/src/components/ControlPlane.tsx
@@ -16,10 +16,12 @@ import type {
   RuntimeRepoOverlay,
   WorkCard,
 } from "~/data/control-plane";
+import type { ContentInventoryItem } from "~/data/content-inventory";
 import { topStrip } from "~/data/control-plane";
 
 const navItems = [
   { href: "/", label: "overview" },
+  { href: "/content", label: "content" },
   { href: "/mutations", label: "mutations" },
   { href: "/fleet", label: "fleet" },
   { href: "/repos", label: "repos" },
@@ -34,30 +36,47 @@ export function ControlPlaneLayout(props: {
   children: JSX.Element;
 }) {
   return (
-    <main>
-      <header class="app-header">
-        <div>
+    <div class="app-shell">
+      <aside class="sidebar">
+        <div class="sidebar-brand">
           <p class="eyebrow">admin.anipotts.com</p>
-          <h1>{props.title}</h1>
-          <p class="lede">{props.deck}</p>
+          <strong>operator console</strong>
+          <span>read-only control plane</span>
         </div>
-        <div class="model-chip">intent / authority / operation / proof / state</div>
-      </header>
 
-      <nav class="nav-row" aria-label="admin control-plane sections">
-        <For each={navItems}>
-          {(item) => (
-            <A href={item.href} end={item.href === "/"}>
-              {item.label}
-            </A>
-          )}
-        </For>
-      </nav>
+        <nav class="side-nav" aria-label="admin control-plane sections">
+          <For each={navItems}>
+            {(item) => (
+              <A href={item.href} end={item.href === "/"}>
+                {item.label}
+              </A>
+            )}
+          </For>
+        </nav>
 
-      <TopStrip />
+        <div class="side-note">
+          <span class="model-chip">
+            intent / authority / operation / proof / state
+          </span>
+          <p class="muted">No write path is active from this shell.</p>
+        </div>
+      </aside>
 
-      <div class="page-stack">{props.children}</div>
-    </main>
+      <main>
+        <header class="app-header">
+          <div>
+            <p class="eyebrow">safe next action</p>
+            <h1>{props.title}</h1>
+            <p class="lede">{props.deck}</p>
+          </div>
+          <div class="model-chip">read-only first</div>
+        </header>
+
+        <TopStrip />
+
+        <div class="page-stack">{props.children}</div>
+      </main>
+    </div>
   );
 }
 
@@ -198,9 +217,18 @@ export function MutationTable(props: {
               <h3>{row.title}</h3>
               <p class="muted">authority_state: {row.authority_state}</p>
             </div>
-            <Fact label="required_approval_ids" value={row.required_approval_ids.join(", ")} />
-            <Fact label="allowed_actions" value={row.allowed_actions.join(", ")} />
-            <Fact label="forbidden_actions" value={row.forbidden_actions.join(", ")} />
+            <Fact
+              label="required_approval_ids"
+              value={row.required_approval_ids.join(", ")}
+            />
+            <Fact
+              label="allowed_actions"
+              value={row.allowed_actions.join(", ")}
+            />
+            <Fact
+              label="forbidden_actions"
+              value={row.forbidden_actions.join(", ")}
+            />
             <div class="pill-row align-end">
               <StatusPill state={row.status} />
               <RiskPill risk={row.risk_level} />
@@ -246,7 +274,9 @@ export function FleetGrid(props: { operations: OperationCard[] }) {
               <Fact label="heartbeat_at" value={operation.heartbeat_at} />
               <Fact label="stop_path" value={operation.stop_path} />
             </div>
-            <p class="proof-line">next_safe_action: {operation.next_safe_action}</p>
+            <p class="proof-line">
+              next_safe_action: {operation.next_safe_action}
+            </p>
           </article>
         )}
       </For>
@@ -265,8 +295,14 @@ export function RepoTable(props: { repos: RepoCard[] }) {
               <p class="muted">{repo.path}</p>
             </div>
             <Fact label="branch" value={repo.branch} />
-            <Fact label="dirty_tracked" value={formatList(repo.dirty_tracked)} />
-            <Fact label="untracked_count" value={String(repo.untracked_count)} />
+            <Fact
+              label="dirty_tracked"
+              value={formatList(repo.dirty_tracked)}
+            />
+            <Fact
+              label="untracked_count"
+              value={String(repo.untracked_count)}
+            />
             <Fact label="deploy_impact" value={repo.deploy_impact} />
             <Fact label="proof_ids" value={repo.proof_ids.join(", ")} />
             <p class="proof-line">next_safe_action: {repo.next_safe_action}</p>
@@ -278,7 +314,9 @@ export function RepoTable(props: { repos: RepoCard[] }) {
 }
 
 export function RuntimeRepoOverlayPanel() {
-  const [runtime, setRuntime] = createSignal<RuntimeOverlayResponse | null>(null);
+  const [runtime, setRuntime] = createSignal<RuntimeOverlayResponse | null>(
+    null,
+  );
 
   onMount(async () => {
     try {
@@ -290,11 +328,15 @@ export function RuntimeRepoOverlayPanel() {
         mode: "error",
         generated_at: null,
         machine: null,
-        source_path: "/Users/anipotts/Infra/state/runtime/admin/admin-feed.current.json",
+        source_path:
+          "/Users/anipotts/Infra/state/runtime/admin/admin-feed.current.json",
         safety: null,
         overlays: [],
         needs_ani_queue: [],
-        error: error instanceof Error ? error.message : "runtime overlay fetch failed",
+        error:
+          error instanceof Error
+            ? error.message
+            : "runtime overlay fetch failed",
       });
     }
   });
@@ -306,23 +348,32 @@ export function RuntimeRepoOverlayPanel() {
           <p class="eyebrow">local-dev runtime</p>
           <h2>repo overlays</h2>
         </div>
-        <Show when={runtime()} fallback={<span class="muted">loading local runtime feed</span>}>
+        <Show
+          when={runtime()}
+          fallback={<span class="muted">loading local runtime feed</span>}
+        >
           {(data) => (
             <span class="muted">
-              {data().available ? `${data().overlays.length} overlays / ${data().machine ?? "unknown machine"}` : data().mode}
+              {data().available
+                ? `${data().overlays.length} overlays / ${data().machine ?? "unknown machine"}`
+                : data().mode}
             </span>
           )}
         </Show>
       </div>
 
-      <Show when={runtime()} fallback={<p class="proof-line">runtime loader is local-dev only</p>}>
+      <Show
+        when={runtime()}
+        fallback={<p class="proof-line">runtime loader is local-dev only</p>}
+      >
         {(data) => (
           <>
             <Show
               when={data().available}
               fallback={
                 <p class="proof-line">
-                  runtime overlay unavailable: {data().error ?? data().mode}. source_path: {data().source_path}
+                  runtime overlay unavailable: {data().error ?? data().mode}.
+                  source_path: {data().source_path}
                 </p>
               }
             >
@@ -334,12 +385,27 @@ export function RuntimeRepoOverlayPanel() {
             </Show>
 
             <div class="runtime-safety">
-              <Fact label="generated_at" value={data().generated_at ?? "not available"} />
+              <Fact
+                label="generated_at"
+                value={data().generated_at ?? "not available"}
+              />
               <Fact label="source_path" value={data().source_path} />
-              <Fact label="safety_mode" value={data().safety?.mode ?? "not available"} />
-              <Fact label="secret_values" value={String(data().safety?.secret_values_included ?? false)} />
-              <Fact label="file_contents" value={String(data().safety?.file_contents_included ?? false)} />
-              <Fact label="health_payloads" value={String(data().safety?.health_payloads_included ?? false)} />
+              <Fact
+                label="safety_mode"
+                value={data().safety?.mode ?? "not available"}
+              />
+              <Fact
+                label="secret_values"
+                value={String(data().safety?.secret_values_included ?? false)}
+              />
+              <Fact
+                label="file_contents"
+                value={String(data().safety?.file_contents_included ?? false)}
+              />
+              <Fact
+                label="health_payloads"
+                value={String(data().safety?.health_payloads_included ?? false)}
+              />
             </div>
           </>
         )}
@@ -355,12 +421,24 @@ function RuntimeOverlayRow(props: { overlay: RuntimeRepoOverlay }) {
         <h3>{props.overlay.repo}</h3>
         <p class="muted">{props.overlay.repo_root_label}</p>
       </div>
-      <Fact label="git" value={props.overlay.git_available ? "available" : "unavailable"} />
+      <Fact
+        label="git"
+        value={props.overlay.git_available ? "available" : "unavailable"}
+      />
       <Fact label="branch" value={props.overlay.branch ?? "not a git tree"} />
       <Fact label="head_sha" value={props.overlay.head_sha ?? "none"} />
-      <Fact label="ahead/behind" value={`${props.overlay.ahead ?? "n/a"} / ${props.overlay.behind ?? "n/a"}`} />
-      <Fact label="dirty_tracked_count" value={String(props.overlay.dirty_tracked_count ?? "n/a")} />
-      <Fact label="untracked_count" value={String(props.overlay.untracked_count ?? "n/a")} />
+      <Fact
+        label="ahead/behind"
+        value={`${props.overlay.ahead ?? "n/a"} / ${props.overlay.behind ?? "n/a"}`}
+      />
+      <Fact
+        label="dirty_tracked_count"
+        value={String(props.overlay.dirty_tracked_count ?? "n/a")}
+      />
+      <Fact
+        label="untracked_count"
+        value={String(props.overlay.untracked_count ?? "n/a")}
+      />
       <Fact label="deploy_impact" value={props.overlay.deploy_impact} />
       <p class="proof-line">
         {props.overlay.live_runtime_role}. {props.overlay.notes}
@@ -381,10 +459,15 @@ export function HandoffTable(props: { handoffs: HandoffCard[] }) {
             </div>
             <StatusPill state={handoff.status} />
             <Fact label="freshness" value={handoff.freshness} />
-            <Fact label="absorbed_at" value={handoff.absorbed_at ?? "not absorbed"} />
+            <Fact
+              label="absorbed_at"
+              value={handoff.absorbed_at ?? "not absorbed"}
+            />
             <Fact label="target_owner" value={handoff.target_owner} />
             <Fact label="proof_ids" value={handoff.proof_ids.join(", ")} />
-            <p class="proof-line">next_safe_action: {handoff.next_safe_action}</p>
+            <p class="proof-line">
+              next_safe_action: {handoff.next_safe_action}
+            </p>
           </article>
         )}
       </For>
@@ -392,7 +475,11 @@ export function HandoffTable(props: { handoffs: HandoffCard[] }) {
   );
 }
 
-const needGroups: Array<{ bucket: NeedsAniItem["bucket"]; title: string; detail: string }> = [
+const needGroups: Array<{
+  bucket: NeedsAniItem["bucket"];
+  title: string;
+  detail: string;
+}> = [
   {
     bucket: "unblockable_now",
     title: "unblockable now",
@@ -420,7 +507,9 @@ export function NeedsAniQueue(props: { items: NeedsAniItem[] }) {
     <div class="needs-grid">
       <For each={needGroups}>
         {(group) => {
-          const items = props.items.filter((item) => item.bucket === group.bucket);
+          const items = props.items.filter(
+            (item) => item.bucket === group.bucket,
+          );
           return (
             <section class="table-card needs-group">
               <div class="needs-group-head">
@@ -456,6 +545,105 @@ export function NeedsAniQueue(props: { items: NeedsAniItem[] }) {
   );
 }
 
+const contentGroups: Array<{
+  surface: ContentInventoryItem["surface"];
+  title: string;
+  detail: string;
+}> = [
+  {
+    surface: "homepage",
+    title: "homepage",
+    detail: "hero copy, proof cards, mentions, and selected making cards",
+  },
+  {
+    surface: "projects",
+    title: "projects",
+    detail: "card fields, detail bodies, links, tags, and visibility",
+  },
+  {
+    surface: "writing",
+    title: "writing",
+    detail: "frontmatter, previews, status, artifacts, and body source",
+  },
+  {
+    surface: "newsletter",
+    title: "newsletter",
+    detail: "subscribe block copy and future content records",
+  },
+];
+
+export function ContentInventoryTable(props: { rows: ContentInventoryItem[] }) {
+  return (
+    <div class="content-grid">
+      <For each={contentGroups}>
+        {(group) => {
+          const rows = props.rows.filter(
+            (row) => row.surface === group.surface,
+          );
+          return (
+            <section class="table-card content-group">
+              <div class="needs-group-head">
+                <div>
+                  <p class="eyebrow">{group.detail}</p>
+                  <h2>{group.title}</h2>
+                </div>
+                <span class="model-chip">{rows.length} rows</span>
+              </div>
+              <For each={rows}>
+                {(row) => (
+                  <article class="table-row content-row">
+                    <div>
+                      <h3>{row.title}</h3>
+                      <p class="muted">{row.current_value}</p>
+                    </div>
+                    <Fact label="source_ref" value={row.source_ref} />
+                    <Fact label="editability" value={row.editability} />
+                    <RiskPill risk={row.risk_level} />
+                    <Fact
+                      label="required_authority"
+                      value={formatList(row.required_authority)}
+                    />
+                    <Fact label="proof_ids" value={formatList(row.proof_ids)} />
+                    <p class="proof-line">
+                      next_safe_action: {row.next_safe_action}
+                    </p>
+                  </article>
+                )}
+              </For>
+            </section>
+          );
+        }}
+      </For>
+    </div>
+  );
+}
+
+export function ContentWriteGate() {
+  return (
+    <article class="panel-card gate-panel">
+      <div>
+        <p class="eyebrow">write path status</p>
+        <h3>content editing is modeled, not active</h3>
+      </div>
+      <div class="fact-grid">
+        <Fact label="allowed_now" value="inspect current content source refs" />
+        <Fact
+          label="blocked_now"
+          value="save, publish, sync, and outbound posting"
+        />
+        <Fact
+          label="authority_needed"
+          value="content operation id plus proof and stop path"
+        />
+        <Fact
+          label="next_slice"
+          value="disabled proposal preview, still no writes"
+        />
+      </div>
+    </article>
+  );
+}
+
 export function ApprovalBridgePanel(props: { design: ApprovalBridgeDesign }) {
   return (
     <div class="grid two">
@@ -471,7 +659,12 @@ export function ApprovalBridgePanel(props: { design: ApprovalBridgeDesign }) {
         </div>
         <div class="fact-grid">
           <For each={props.design.inbound_contract}>
-            {(field) => <Fact label={field.field} value={`${field.source}: ${field.notes}`} />}
+            {(field) => (
+              <Fact
+                label={field.field}
+                value={`${field.source}: ${field.notes}`}
+              />
+            )}
           </For>
         </div>
       </article>
@@ -485,7 +678,12 @@ export function ApprovalBridgePanel(props: { design: ApprovalBridgeDesign }) {
         </div>
         <div class="fact-grid">
           <For each={props.design.outbound_contract}>
-            {(field) => <Fact label={field.field} value={`${field.source}: ${field.notes}`} />}
+            {(field) => (
+              <Fact
+                label={field.field}
+                value={`${field.source}: ${field.notes}`}
+              />
+            )}
           </For>
         </div>
         <ul class="stop-list">
@@ -520,9 +718,18 @@ export function DestructiveGrid(props: { gates: DestructiveGate[] }) {
               state={gate.status}
             />
             <div class="fact-grid">
-              <Fact label="required_approval_ids" value={gate.required_approval_ids.join(", ")} />
-              <Fact label="allowed_actions" value={gate.allowed_actions.join(", ")} />
-              <Fact label="forbidden_actions" value={gate.forbidden_actions.join(", ")} />
+              <Fact
+                label="required_approval_ids"
+                value={gate.required_approval_ids.join(", ")}
+              />
+              <Fact
+                label="allowed_actions"
+                value={gate.allowed_actions.join(", ")}
+              />
+              <Fact
+                label="forbidden_actions"
+                value={gate.forbidden_actions.join(", ")}
+              />
               <Fact label="evidence_uri" value={gate.evidence_uri} />
               <Fact label="redaction" value={gate.redaction} />
             </div>

--- a/apps/admin-solid/src/data/content-inventory.ts
+++ b/apps/admin-solid/src/data/content-inventory.ts
@@ -1,0 +1,195 @@
+import type { RiskLevel } from "./control-plane";
+
+export type ContentSurface = "homepage" | "projects" | "writing" | "newsletter";
+export type ContentEditability = "ready" | "needs_schema" | "needs_owner";
+
+export type ContentInventoryItem = {
+  id: string;
+  surface: ContentSurface;
+  title: string;
+  source_ref: string;
+  current_value: string;
+  editability: ContentEditability;
+  risk_level: RiskLevel;
+  next_safe_action: string;
+  required_authority: string[];
+  proof_ids: string[];
+};
+
+export const contentInventorySource = {
+  source_doc: "docs/content-admin-editor-brief.md",
+  architecture_doc: "docs/admin-v2-architecture.md",
+  mode: "read_only_static_inventory",
+  generated_from: "apps/www source files at main 31204f6",
+};
+
+export const contentInventory: ContentInventoryItem[] = [
+  {
+    id: "homepage.heading",
+    surface: "homepage",
+    title: "hero heading",
+    source_ref: "apps/www/src/data/site.ts:homeContent.heading",
+    current_value: "hi, i'm ani",
+    editability: "ready",
+    risk_level: "low",
+    next_safe_action:
+      "Expose as a future content field after the read-only inventory is proven.",
+    required_authority: [],
+    proof_ids: ["content.homepage.heading.source"],
+  },
+  {
+    id: "homepage.summary",
+    surface: "homepage",
+    title: "hero summary",
+    source_ref: "apps/www/src/data/site.ts:homeContent.summary",
+    current_value:
+      "Structured AI, Our Bad Habit, Atlantic Records, and agent workflow copy are source-backed in site config.",
+    editability: "ready",
+    risk_level: "medium",
+    next_safe_action:
+      "Model proposal preview before allowing edits because this is above-fold public copy.",
+    required_authority: [],
+    proof_ids: ["content.homepage.summary.source"],
+  },
+  {
+    id: "homepage.proof_cards",
+    surface: "homepage",
+    title: "proof cards",
+    source_ref: "apps/www/src/data/site.ts:homeContent.proof",
+    current_value:
+      "Structured AI, Quantercise, Paragon Global Investments, and public tooling cards feed the homepage proof grid.",
+    editability: "ready",
+    risk_level: "medium",
+    next_safe_action:
+      "Expose card fields with source URL validation and preview-only proof before any save path.",
+    required_authority: [],
+    proof_ids: ["content.homepage.proof.source"],
+  },
+  {
+    id: "homepage.making_selection",
+    surface: "homepage",
+    title: "homepage making selection",
+    source_ref: "apps/www/src/pages/index.astro:homeMakingSlugs",
+    current_value:
+      "quantercise-extension, saeshify, nyu-purity-test, and habittracker-obh are selected in source order.",
+    editability: "needs_schema",
+    risk_level: "medium",
+    next_safe_action:
+      "Keep source-backed until the editor has an ordered relation model for featured project cards.",
+    required_authority: [],
+    proof_ids: ["content.homepage.making.source"],
+  },
+  {
+    id: "projects.card_fields",
+    surface: "projects",
+    title: "project card fields",
+    source_ref: "apps/www/src/content/projects/*.md",
+    current_value:
+      "title, subtitle, description, year, category, role, duration, status, visibility, sort order, links, and tags.",
+    editability: "ready",
+    risk_level: "low",
+    next_safe_action:
+      "Render markdown frontmatter in admin first; writes should remain gated behind content operation proposals.",
+    required_authority: [],
+    proof_ids: ["content.projects.frontmatter.schema"],
+  },
+  {
+    id: "projects.detail_body",
+    surface: "projects",
+    title: "project detail body",
+    source_ref: "apps/www/src/content/projects/*.md body",
+    current_value:
+      "Project bodies plus optional technical and roadmap arrays drive detail pages where present.",
+    editability: "ready",
+    risk_level: "medium",
+    next_safe_action:
+      "Add read-only markdown preview before body editing because detail pages carry public claims.",
+    required_authority: [],
+    proof_ids: ["content.projects.body.schema"],
+  },
+  {
+    id: "projects.duplicate_source",
+    surface: "projects",
+    title: "project source duplication",
+    source_ref: "docs/content-admin-editor-brief.md:open questions",
+    current_value:
+      "Markdown collections and package data have overlapping project facts that need a source-truth decision.",
+    editability: "needs_owner",
+    risk_level: "medium",
+    next_safe_action:
+      "Decide canonical project source before enabling writes that could split project state.",
+    required_authority: ["content.project-source.owner-decision"],
+    proof_ids: ["content.projects.source-truth.open-question"],
+  },
+  {
+    id: "writing.frontmatter",
+    surface: "writing",
+    title: "writing frontmatter",
+    source_ref: "apps/www/src/content/writing/*.md",
+    current_value:
+      "title, summary, tags, status, dates, content type, project, and artifact fields are already schema-backed.",
+    editability: "ready",
+    risk_level: "low",
+    next_safe_action:
+      "Show published and draft rows read-only before proposing status or scheduling edits.",
+    required_authority: [],
+    proof_ids: ["content.writing.frontmatter.schema"],
+  },
+  {
+    id: "writing.body",
+    surface: "writing",
+    title: "writing body",
+    source_ref: "apps/www/src/content/writing/*.md body",
+    current_value:
+      "Published article bodies are markdown files in the Astro writing collection.",
+    editability: "ready",
+    risk_level: "medium",
+    next_safe_action:
+      "Use preview-only diffs before edits; publishing and outbound syndication stay separate.",
+    required_authority: [],
+    proof_ids: ["content.writing.body.source"],
+  },
+  {
+    id: "writing.claude_stats_link",
+    surface: "writing",
+    title: "stale claude stats link",
+    source_ref: "apps/www/src/content/writing/saturdays-are-for-claude-code.md",
+    current_value:
+      "Current main still links to /claude; draft PR #73 changes this to /orchestrating.",
+    editability: "ready",
+    risk_level: "low",
+    next_safe_action:
+      "Refresh or close PR #73 depending on whether Ani wants that public cleanup deployed.",
+    required_authority: [],
+    proof_ids: ["pr.73.public-cleanup.pending"],
+  },
+  {
+    id: "newsletter.subscribe_copy",
+    surface: "newsletter",
+    title: "subscribe block copy",
+    source_ref: "apps/www/src/components/NewsletterSubscribe.astro",
+    current_value:
+      "Default lede, CTA label, success text, error text, and Buttondown link live in the component props.",
+    editability: "needs_schema",
+    risk_level: "medium",
+    next_safe_action:
+      "Choose D1 page_content or site config as the editable source before adding save behavior.",
+    required_authority: ["content.newsletter-source.owner-decision"],
+    proof_ids: ["content.newsletter.component.defaults"],
+  },
+  {
+    id: "newsletter.backfill",
+    surface: "newsletter",
+    title: "newsletter backfill candidates",
+    source_ref:
+      "docs/content-admin-editor-brief.md:newsletter backfill options",
+    current_value:
+      "Existing writing can seed newsletter planning, but nothing should auto-send from admin.",
+    editability: "needs_owner",
+    risk_level: "high",
+    next_safe_action:
+      "Keep as read-only planning until newsletter ownership and outbound-send authority are explicit.",
+    required_authority: ["newsletter.publish.owner-decision"],
+    proof_ids: ["content.newsletter.backfill.plan"],
+  },
+];

--- a/apps/admin-solid/src/routes/content.tsx
+++ b/apps/admin-solid/src/routes/content.tsx
@@ -1,0 +1,37 @@
+import {
+  ContentInventoryTable,
+  ContentWriteGate,
+  ControlPlaneLayout,
+  SectionHeader,
+} from "~/components/ControlPlane";
+import {
+  contentInventory,
+  contentInventorySource,
+} from "~/data/content-inventory";
+
+export default function ContentRoute() {
+  return (
+    <ControlPlaneLayout
+      title="content inventory"
+      deck="A read-only map of public-site text and content sources. This page shows what can become editable later without adding save behavior."
+    >
+      <section>
+        <SectionHeader
+          eyebrow="public site content"
+          title="editable surface candidates"
+          detail={`${contentInventory.length} rows / ${contentInventorySource.mode}`}
+        />
+        <ContentInventoryTable rows={contentInventory} />
+      </section>
+
+      <section>
+        <SectionHeader
+          eyebrow="authority"
+          title="writes stay gated"
+          detail={contentInventorySource.architecture_doc}
+        />
+        <ContentWriteGate />
+      </section>
+    </ControlPlaneLayout>
+  );
+}

--- a/docs/site-open-pr-triage-2026-06-24.md
+++ b/docs/site-open-pr-triage-2026-06-24.md
@@ -1,0 +1,49 @@
+# site open PR triage, 2026-06-24
+
+## PR #72, admin-solid fleet dashboard MVP
+
+PR: https://github.com/anipotts/anipotts.com/pull/72
+
+State:
+
+- draft
+- stale
+- merge-conflicted against current main
+- original checks were green on 2026-06-24
+- touched `apps/admin-solid` dashboard shell files that have since been
+  superseded by merged control-plane work
+
+Recommendation:
+
+- close as superseded after this admin content-inventory branch lands
+- do not merge or refresh directly
+- useful intent has already been absorbed into the live read-only control-plane
+  direction through PRs #75, #76, #77, and #78
+- any remaining visual/sidebar ideas should be reimplemented from current main,
+  not conflict-resolved from PR #72
+
+## PR #73, public site links and homepage cards
+
+PR: https://github.com/anipotts/anipotts.com/pull/73
+
+State:
+
+- draft
+- old but small
+- original checks were green on 2026-06-23
+- current main still has the `/claude` writing link and the same homepage making
+  selection that PR #73 changes
+
+Recommendation:
+
+- keep parked unless Ani wants that small public cleanup to deploy
+- if wanted, refresh or cherry-pick the two-line diff onto current main and open
+  a clean PR
+- do not merge the stale draft as-is without rerunning checks
+
+## current site direction
+
+Admin work should continue from current main with read-only operator dashboard
+slices. The next shipped implementation should be `/content`, a read-only
+public-site content inventory that exposes source refs and editability
+candidates without any save, publish, sync, or outbound-send path.


### PR DESCRIPTION
## Summary
- add a sidebar-first admin shell to make the control plane feel more like an operator dashboard
- add `/content` as the first read-only admin v2 slice for public-site content inventory
- model homepage, project, writing, and newsletter content source refs, editability candidates, risk, proof ids, and next safe actions
- keep content writes, save buttons, publishing, sync, and outbound actions inactive
- record stale PR #72/#73 triage in `docs/site-open-pr-triage-2026-06-24.md`

## Stale PR triage
- #72: close as superseded after this branch lands. Its fleet dashboard intent was absorbed by the merged admin control-plane work, and the branch is now conflicted.
- #73: keep parked unless Ani wants that small public cleanup deployed. If wanted, refresh or cherry-pick the two-line diff onto current main and rerun checks.

## Verification
- `pnpm exec prettier --check apps/admin-solid/src/components/ControlPlane.tsx apps/admin-solid/src/data/content-inventory.ts apps/admin-solid/src/routes/content.tsx apps/admin-solid/src/app.css apps/admin-solid/README.md docs/site-open-pr-triage-2026-06-24.md`
- `pnpm --filter @anipotts/admin-solid typecheck`
- `pnpm --filter @anipotts/admin-solid build`
- local dev route smoke for `/`, `/content`, `/needs-ani`, `/repos`
- `git diff --check`

## Live impact
None from this branch. No deploy, DNS, Access/auth, env, secret, write path, collector, endpoint, launchd, or production mutation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new read-only admin page for viewing public-site content inventory.
  * The page now shows content areas like homepage, projects, writing, and newsletter, plus related access guidance.

* **Bug Fixes**
  * Improved admin layout responsiveness, including better behavior on smaller screens and a cleaner sidebar/navigation arrangement.

* **Documentation**
  * Updated the admin README and planning notes to reflect the new content inventory route and current site direction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->