### PR TITLE
Refresh admin NEEDS-ANI queue from Infra

### DIFF
--- a/apps/admin-solid/src/data/static/README.md
+++ b/apps/admin-solid/src/data/static/README.md
@@ -6,6 +6,9 @@
 - Source commit: `32794b4`
 - Source path: `coord/admin/static/admin-feed.sample.json`
 - Builder: `coord/admin/build_static_snapshot.py`
+- NEEDS-ANI syscall source commit: `a754fb2`
+- NEEDS-ANI syscall source path: `coord/NEEDS-ANI.md`
+- NEEDS-ANI parser: `coord/admin/build_runtime_snapshot.py`
 
 This file is build-time sample data only. It must not become a live collector,
 write path, deploy trigger, env reader, secret reader, or cross-repo runtime

--- a/apps/admin-solid/src/data/static/README.md
+++ b/apps/admin-solid/src/data/static/README.md
@@ -6,7 +6,7 @@
 - Source commit: `32794b4`
 - Source path: `coord/admin/static/admin-feed.sample.json`
 - Builder: `coord/admin/build_static_snapshot.py`
-- NEEDS-ANI syscall source commit: `a754fb2`
+- NEEDS-ANI syscall source commit: `b31ea50`
 - NEEDS-ANI syscall source path: `coord/NEEDS-ANI.md`
 - NEEDS-ANI parser: `coord/admin/build_runtime_snapshot.py`
 

--- a/apps/admin-solid/src/data/static/needs-ani.syscalls.json
+++ b/apps/admin-solid/src/data/static/needs-ani.syscalls.json
@@ -133,5 +133,35 @@
     "status": "open",
     "type": "review-delete",
     "why": "`/Users/anipotts/.codex/worktrees/f98e/anipotts-com` is 1.5G and has source edits in `apps/www/src/data/site.ts`, `apps/www/src/pages/index.astro`, and `packages/lib/src/cms/defaults.ts`."
+  },
+  {
+    "agent_next": "execute only the chosen OBS config packet with archive/rollback proof; do not print config values.",
+    "ani_action": "reply `keep obs config`, `approve obs websocket config reset`, or `approve archive obs config`",
+    "bucket": "unblockable_now",
+    "expires_stale": "2026-06-29",
+    "id": "need-obs-config-cleanup-choice",
+    "owner": "fleet/cleanup",
+    "primary_action": "reply `keep obs config`, `approve obs websocket config reset`, or `approve archive obs config`",
+    "proof": "",
+    "requires_ani": true,
+    "source": "coord/NEEDS-ANI.md",
+    "status": "open",
+    "type": "choose",
+    "why": "OBS local config is small but includes `obs-websocket/config.json` with password-capable keys; values were not printed."
+  },
+  {
+    "agent_next": "if approved, archive the skill out of active `.agents/skills` with rollback proof; do not delete old archive copies.",
+    "ani_action": "reply `keep postiz skill` or `approve archive postiz skill`",
+    "bucket": "unblockable_now",
+    "expires_stale": "2026-06-29",
+    "id": "need-postiz-skill-cleanup-choice",
+    "owner": "fleet/cleanup",
+    "primary_action": "reply `keep postiz skill` or `approve archive postiz skill`",
+    "proof": "",
+    "requires_ani": true,
+    "source": "coord/NEEDS-ANI.md",
+    "status": "open",
+    "type": "choose",
+    "why": "an active local Postiz skill remains in `.agents/skills`, but Ani said Postiz is no longer used."
   }
 ]

--- a/apps/admin-solid/src/data/static/needs-ani.syscalls.json
+++ b/apps/admin-solid/src/data/static/needs-ani.syscalls.json
@@ -45,6 +45,36 @@
     "why": "jobs has ranked office-first targets, but deeper research and drafts need Ani's taste call."
   },
   {
+    "agent_next": "on or after 2026-07-05, capture the bounded analytics proof packet only, do not send/post/change platform state, and record proof.",
+    "ani_action": "reply `approve rayban 30 day analytics capture`",
+    "bucket": "unblockable_now",
+    "expires_stale": "2026-07-06",
+    "id": "need-rayban-30-day-analytics-capture",
+    "owner": "chief/brand",
+    "primary_action": "reply `approve rayban 30 day analytics capture`",
+    "proof": "",
+    "requires_ani": true,
+    "source": "coord/NEEDS-ANI.md",
+    "status": "open",
+    "type": "approve",
+    "why": "Ray-Ban is delivered with 7-day analytics recorded, but the 30-day analytics capture window opens on 2026-07-05 and live platform capture needs exact authority."
+  },
+  {
+    "agent_next": "update the Brand/Business deal path based on the choice; do not send, mark paid, or read private payloads without separate exact authority.",
+    "ani_action": "reply `keep higgsfield paused`, `approve higgsfield send-proof recovery`, or `business owns higgsfield payment proof`",
+    "bucket": "unblockable_now",
+    "expires_stale": "2026-06-28",
+    "id": "need-higgsfield-recovery-path",
+    "owner": "chief/brand",
+    "primary_action": "reply `keep higgsfield paused`, `approve higgsfield send-proof recovery`, or `business owns higgsfield payment proof`",
+    "proof": "",
+    "requires_ani": true,
+    "source": "coord/NEEDS-ANI.md",
+    "status": "open",
+    "type": "choose",
+    "why": "Higgsfield has local drafts but unresolved send proof and no payment/invoice proof in safe refs."
+  },
+  {
     "agent_next": "execute only the approved Phase 1 packet, validate references, commit, push, and record rollback.",
     "ani_action": "reply `approve infra layout phase 1` or name the part to revise",
     "bucket": "unblockable_now",


### PR DESCRIPTION
## summary
- refresh the read-only `apps/admin-solid` NEEDS-ANI static syscall fixture from Infra `origin/main` at `b31ea50`
- includes the Brand syscalls `need-rayban-30-day-analytics-capture` and `need-higgsfield-recovery-path`
- includes the cleanup choices `need-obs-config-cleanup-choice` and `need-postiz-skill-cleanup-choice`
- record the current NEEDS-ANI source commit/path/parser in the static data README

## scope
- data-only admin-solid refresh
- no admin write path
- no content publish writes
- no native config cleanup or source/personal config mutation
- no DNS, Cloudflare Access/auth, env, secrets, root, launchd, endpoints, legacy admin, workers, outbound actions, or live collector changes

## verification
- `pnpm --filter @anipotts/admin-solid typecheck`
- `pnpm --filter @anipotts/admin-solid build`
- `pnpm exec prettier --check apps/admin-solid/src/data/static/needs-ani.syscalls.json apps/admin-solid/src/data/static/README.md`
- `git diff --check`
- JSON shape/id check: 11 syscall rows, required Brand and OBS/Postiz IDs present, required keys present
- local route smoke: `http://localhost:3001/needs-ani` returned 200 and rendered Brand plus OBS/Postiz syscall IDs

## approval needed
Draft until Ani/fleet explicitly approves: `ready/merge/deploy PR #85 admin-solid only for read-only NEEDS-ANI queue refresh from Infra b31ea50`.
