### PR TITLE
Add read-only admin content review queue

### DIFF
--- a/apps/admin-solid/README.md
+++ b/apps/admin-solid/README.md
@@ -22,6 +22,7 @@ This app is read-only first. It renders the fleet/admin feed model:
 | `/`                | safe-next-action overview and feed coverage           |
 | `/content`         | read-only public-site content inventory               |
 | `/content/preview` | draft content operation previews with no write path   |
+| `/content/review`  | grouped source-to-proposal editorial review queue     |
 | `/needs-ani`       | typed human syscall queue and future bridge contract  |
 | `/mutations`       | proposed, approved, running, verified, blocked states |
 | `/fleet`           | machine and agent operation placeholders              |

--- a/apps/admin-solid/src/app.css
+++ b/apps/admin-solid/src/app.css
@@ -28,6 +28,7 @@ body {
   background: var(--bg);
   color: var(--text);
   font-family: var(--font-sans);
+  overflow-x: hidden;
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
 }
@@ -113,6 +114,7 @@ main {
 h1,
 h2,
 h3,
+h4,
 p,
 dl,
 dd {
@@ -137,6 +139,12 @@ h3 {
   line-height: 1.35;
 }
 
+h4 {
+  font-size: 0.84rem;
+  font-weight: 620;
+  line-height: 1.35;
+}
+
 .app-header {
   align-items: end;
   border: 1px solid var(--border);
@@ -147,11 +155,19 @@ h3 {
   padding: 18px;
 }
 
+.app-header > *,
+.section-header > *,
+.card-top > *,
+.review-surface-head > * {
+  min-width: 0;
+}
+
 .lede {
   color: var(--muted);
   line-height: 1.55;
   margin-top: 8px;
   max-width: 880px;
+  overflow-wrap: anywhere;
 }
 
 .eyebrow,
@@ -176,6 +192,7 @@ dt,
   color: var(--muted);
   font-size: 0.76rem;
   line-height: 1.45;
+  overflow-wrap: anywhere;
 }
 
 .model-chip {
@@ -206,6 +223,7 @@ dt,
 
 .strip-card {
   min-height: 120px;
+  min-width: 0;
   padding: 12px;
 }
 
@@ -315,14 +333,19 @@ dt,
 .status-pill[data-state="valid"],
 .status-pill[data-state="active"],
 .status-pill[data-state="absorbed"],
-.status-pill[data-state="current"] {
+.status-pill[data-state="current"],
+.status-pill[data-state="ready"],
+.status-pill[data-state="preview"] {
   background: rgba(34, 197, 94, 0.12);
   color: #86efac;
 }
 
 .status-pill[data-state="needs-approval"],
 .status-pill[data-state="approved"],
-.status-pill[data-state="proposed"] {
+.status-pill[data-state="proposed"],
+.status-pill[data-state="draft"],
+.status-pill[data-state="needs_schema"],
+.status-pill[data-state="needs_owner"] {
   background: rgba(245, 158, 11, 0.12);
   color: #fcd34d;
 }
@@ -400,6 +423,7 @@ dd,
   font-size: 0.78rem;
   font-weight: 520;
   line-height: 1.35;
+  overflow-wrap: anywhere;
 }
 
 .table-card {
@@ -476,13 +500,15 @@ dd,
 
 .needs-grid,
 .content-grid,
-.preview-grid {
+.preview-grid,
+.review-board {
   display: grid;
   gap: 14px;
 }
 
 .needs-group,
-.content-group {
+.content-group,
+.review-surface {
   overflow: hidden;
 }
 
@@ -560,6 +586,123 @@ dd,
   line-height: 1.5;
 }
 
+.review-surface-head {
+  align-items: center;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  gap: 12px;
+  justify-content: space-between;
+  padding: 12px;
+}
+
+.review-counts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  justify-content: flex-end;
+}
+
+.review-counts span,
+.text-link {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  line-height: 1;
+  padding: 7px 9px;
+}
+
+.review-lanes {
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr);
+}
+
+.review-lane {
+  border-right: 1px solid var(--border);
+  min-width: 0;
+}
+
+.review-lane:last-child {
+  border-right: 0;
+}
+
+.review-lane-head {
+  align-items: center;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  justify-content: space-between;
+  padding: 10px 12px;
+}
+
+.review-item {
+  border-bottom: 1px solid var(--border);
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+}
+
+.review-item:last-child {
+  border-bottom: 0;
+}
+
+.review-item p,
+.review-empty,
+.review-steps p {
+  color: var(--muted);
+  font-size: 0.76rem;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
+.review-item.proposal {
+  background: rgba(255, 255, 255, 0.015);
+}
+
+.review-empty {
+  padding: 12px;
+}
+
+.review-gate {
+  display: grid;
+  gap: 14px;
+}
+
+.review-steps {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.review-steps div {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 6px;
+  min-width: 0;
+  padding: 10px;
+}
+
+.review-steps span {
+  color: var(--muted);
+  display: block;
+  font-family: var(--font-mono);
+  font-size: 0.64rem;
+  margin-bottom: 8px;
+}
+
+.review-steps strong {
+  display: block;
+  font-size: 0.82rem;
+  font-weight: 620;
+  margin-bottom: 6px;
+}
+
+.text-link:hover {
+  border-color: rgba(255, 255, 255, 0.18);
+  color: var(--text);
+}
+
 .fact-grid {
   display: grid;
   gap: 8px;
@@ -590,8 +733,19 @@ dd,
   .runtime-row,
   .handoff-row,
   .needs-ani-row,
-  .content-row {
+  .content-row,
+  .review-lanes,
+  .review-steps {
     grid-template-columns: 1fr;
+  }
+
+  .review-lane {
+    border-right: 0;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .review-lane:last-child {
+    border-bottom: 0;
   }
 }
 
@@ -610,7 +764,19 @@ dd,
   }
 
   main {
+    max-width: 100vw;
     padding: 14px;
+  }
+
+  .app-header,
+  .page-stack,
+  .top-strip,
+  .table-card,
+  .panel-card,
+  .review-surface {
+    max-width: 100%;
+    min-width: 0;
+    overflow-wrap: anywhere;
   }
 
   .app-header,
@@ -625,7 +791,8 @@ dd,
   }
 
   .section-header,
-  .card-top {
+  .card-top,
+  .review-surface-head {
     align-items: stretch;
     flex-direction: column;
   }

--- a/apps/admin-solid/src/components/ControlPlane.tsx
+++ b/apps/admin-solid/src/components/ControlPlane.tsx
@@ -24,6 +24,7 @@ const navItems = [
   { href: "/", label: "overview" },
   { href: "/content", label: "content" },
   { href: "/content/preview", label: "previews" },
+  { href: "/content/review", label: "review" },
   { href: "/mutations", label: "mutations" },
   { href: "/fleet", label: "fleet" },
   { href: "/repos", label: "repos" },
@@ -617,6 +618,197 @@ export function ContentInventoryTable(props: { rows: ContentInventoryItem[] }) {
         }}
       </For>
     </div>
+  );
+}
+
+const contentReviewSurfaces: Array<{
+  surface: ContentInventoryItem["surface"];
+  title: string;
+  intent: string;
+}> = [
+  {
+    surface: "homepage",
+    title: "homepage",
+    intent: "above-fold copy, proof cards, and public credibility claims",
+  },
+  {
+    surface: "projects",
+    title: "projects",
+    intent: "project card fields, detail bodies, links, and source truth",
+  },
+  {
+    surface: "writing",
+    title: "writing",
+    intent: "frontmatter, summaries, body edits, and public article links",
+  },
+  {
+    surface: "newsletter",
+    title: "newsletter",
+    intent: "subscribe block copy, backfill planning, and send-path separation",
+  },
+];
+
+export function ContentReviewBoard(props: {
+  inventory: ContentInventoryItem[];
+  previews: ContentPreviewItem[];
+}) {
+  return (
+    <div class="review-board">
+      <For each={contentReviewSurfaces}>
+        {(surface) => {
+          const inventoryRows = props.inventory.filter(
+            (item) => item.surface === surface.surface,
+          );
+          const previewRows = props.previews.filter(
+            (item) => item.surface === surface.surface,
+          );
+          const readyRows = inventoryRows.filter(
+            (item) => item.editability === "ready",
+          );
+          const gatedRows = [
+            ...inventoryRows.filter((item) => item.required_authority.length),
+            ...previewRows.filter((item) => item.required_approval_ids.length),
+          ];
+
+          return (
+            <section class="table-card review-surface">
+              <div class="review-surface-head">
+                <div>
+                  <p class="eyebrow">{surface.intent}</p>
+                  <h2>{surface.title}</h2>
+                </div>
+                <div class="review-counts">
+                  <span>{inventoryRows.length} sources</span>
+                  <span>{previewRows.length} previews</span>
+                  <span>{gatedRows.length} gated</span>
+                </div>
+              </div>
+
+              <div class="review-lanes">
+                <div class="review-lane">
+                  <div class="review-lane-head">
+                    <h3>editable candidates</h3>
+                    <span class="muted">{readyRows.length} ready</span>
+                  </div>
+                  <For each={inventoryRows}>
+                    {(item) => (
+                      <article class="review-item">
+                        <div>
+                          <h4>{item.title}</h4>
+                          <p>{item.current_value}</p>
+                        </div>
+                        <div class="pill-row">
+                          <span
+                            class="status-pill"
+                            data-state={item.editability}
+                          >
+                            {item.editability}
+                          </span>
+                          <RiskPill risk={item.risk_level} />
+                        </div>
+                        <Fact label="source_ref" value={item.source_ref} />
+                        <Fact
+                          label="next_safe_action"
+                          value={item.next_safe_action}
+                        />
+                      </article>
+                    )}
+                  </For>
+                </div>
+
+                <div class="review-lane">
+                  <div class="review-lane-head">
+                    <h3>proposal queue</h3>
+                    <span class="muted">{previewRows.length} inert</span>
+                  </div>
+                  <Show
+                    when={previewRows.length > 0}
+                    fallback={
+                      <p class="review-empty">
+                        no proposal yet. keep this surface in inventory until a
+                        preview-only operation is modeled.
+                      </p>
+                    }
+                  >
+                    <For each={previewRows}>
+                      {(item) => (
+                        <article class="review-item proposal">
+                          <div>
+                            <h4>{item.title}</h4>
+                            <p>{item.next_safe_action}</p>
+                          </div>
+                          <div class="pill-row">
+                            <span
+                              class="status-pill"
+                              data-state={stateKey(item.status)}
+                            >
+                              {item.status}
+                            </span>
+                            <RiskPill risk={item.risk_level} />
+                          </div>
+                          <Fact
+                            label="authority_state"
+                            value={item.authority_state}
+                          />
+                          <Fact
+                            label="blocked_actions"
+                            value={formatList(item.blocked_actions)}
+                          />
+                        </article>
+                      )}
+                    </For>
+                  </Show>
+                </div>
+              </div>
+            </section>
+          );
+        }}
+      </For>
+    </div>
+  );
+}
+
+export function ContentReviewGate() {
+  return (
+    <article class="panel-card review-gate">
+      <div>
+        <p class="eyebrow">content editing path</p>
+        <h3>read, propose, review, then ask for authority</h3>
+      </div>
+      <div class="review-steps">
+        <div>
+          <span>01</span>
+          <strong>inventory</strong>
+          <p>map the current public-site source and rendered copy.</p>
+        </div>
+        <div>
+          <span>02</span>
+          <strong>preview</strong>
+          <p>compare current and proposed text without writing.</p>
+        </div>
+        <div>
+          <span>03</span>
+          <strong>syscall</strong>
+          <p>use NEEDS-ANI only when taste or live authority is required.</p>
+        </div>
+        <div>
+          <span>04</span>
+          <strong>write gate</strong>
+          <p>save and publish stay unavailable until explicitly authorized.</p>
+        </div>
+      </div>
+      <div class="pill-row">
+        <A class="text-link" href="/content">
+          inventory
+        </A>
+        <A class="text-link" href="/content/preview">
+          previews
+        </A>
+        <A class="text-link" href="/needs-ani">
+          needs ani
+        </A>
+      </div>
+    </article>
   );
 }
 

--- a/apps/admin-solid/src/routes/content/review.tsx
+++ b/apps/admin-solid/src/routes/content/review.tsx
@@ -1,0 +1,41 @@
+import {
+  ContentReviewBoard,
+  ContentReviewGate,
+  ControlPlaneLayout,
+  SectionHeader,
+} from "~/components/ControlPlane";
+import {
+  contentInventory,
+  contentInventorySource,
+  contentPreviewItems,
+} from "~/data/content-inventory";
+
+export default function ContentReviewRoute() {
+  return (
+    <ControlPlaneLayout
+      title="content review"
+      deck="A read-only editorial queue that groups current public-site sources beside inert proposal previews. It shows what is safe to review next without adding save or publish behavior."
+    >
+      <section>
+        <SectionHeader
+          eyebrow="editorial workbench"
+          title="source to proposal review"
+          detail={`${contentInventory.length} sources / ${contentPreviewItems.length} previews / ${contentInventorySource.mode}`}
+        />
+        <ContentReviewBoard
+          inventory={contentInventory}
+          previews={contentPreviewItems}
+        />
+      </section>
+
+      <section>
+        <SectionHeader
+          eyebrow="no-write contract"
+          title="path to future edits"
+          detail={contentInventorySource.architecture_doc}
+        />
+        <ContentReviewGate />
+      </section>
+    </ControlPlaneLayout>
+  );
+}


### PR DESCRIPTION
## summary
- add read-only `/content/review` route for source-to-proposal editorial review
- group content inventory and inert proposal previews by surface: homepage, projects, writing, newsletter
- add sidebar IA entry and admin-solid README route entry
- add dense review-board styling plus mobile overflow guards for long operator copy

## scope
- `apps/admin-solid` only
- read-only UI and static local data rendering only
- no save APIs
- no publish writes
- no content-store mutation
- no approval bridge sending
- no hidden write endpoints
- no DNS, Cloudflare Access/auth, env, secrets, root, launchd, endpoints, production collectors, legacy admin/workers, outbound actions, source/personal deletes, force-push, or history rewrite

## verification
- `pnpm exec prettier --check apps/admin-solid/README.md apps/admin-solid/src/components/ControlPlane.tsx apps/admin-solid/src/routes/content/review.tsx apps/admin-solid/src/app.css`
- `pnpm --filter @anipotts/admin-solid typecheck`
- `pnpm --filter @anipotts/admin-solid build`
- `git diff --check`
- local route smoke for `/content`, `/content/preview`, `/content/review`, and `/needs-ani`
- Chrome headless screenshot smoke for `/content/review` desktop and mobile; Browser/IAB tool was not exposed, so Chrome headless was used as fallback

## approval needed
Draft until Ani/fleet explicitly approves: `ready/merge/deploy PR #<this-pr> admin-solid only for read-only /content/review admin UI`.
