### PR TITLE
Add admin auth and content editing ADR

### DIFF
--- a/docs/admin-access-simplification-plan.md
+++ b/docs/admin-access-simplification-plan.md
@@ -1,0 +1,117 @@
+# admin access simplification plan
+
+Date: 2026-06-25
+Status: approved for metadata audit and staged design only
+
+## current audited state
+
+The live `admin.anipotts.com` boundary is Cloudflare Access in front of the
+`apps/admin-solid` Worker. A metadata-only API audit found:
+
+- one account-level Access app matching `admin.anipotts.com`
+- app type: self-hosted
+- app hostname: `admin.anipotts.com`
+- session duration: 24h
+- app-level allowed IdP restriction: none
+- policies: one allow policy using an email selector
+- identity providers: one one-time-pin provider
+
+The audit did not print secret values, policy email values, full object ids,
+tokens, cookies, private payloads, or user lists. It did not mutate Access,
+DNS, routes, env, secrets, users, groups, or policies.
+
+Unauthenticated route probes still return Cloudflare Access 302 responses for:
+
+- `https://admin.anipotts.com/`
+- `https://admin.anipotts.com/content`
+
+## decision
+
+Keep Cloudflare Access as the edge gate. Simplify the login experience inside
+Access before considering any app-native replacement.
+
+The current one-time-pin flow is secure enough for the read-only dashboard, but
+it is not the target operator experience. The next design target should be a
+single strong IdP with instant authentication where Cloudflare supports it,
+restricted to Ani's account or an explicit admin group.
+
+Do not remove Access as part of login simplification.
+
+## target shape
+
+Preferred staged target:
+
+- keep the same `admin.anipotts.com` self-hosted Access application
+- use one intended IdP for Ani
+- restrict the allow policy to an explicit identity selector or admin group
+- set app-level allowed IdPs to the intended provider after validation
+- keep session duration explicit
+- keep unauthenticated browser probes blocked before Worker content returns
+- keep app code read-only until write-path authority exists
+
+The clean candidate remains Cloudflare account membership or another strong IdP
+managed through Cloudflare Access. If Cloudflare account membership is used, the
+policy should restrict access to Ani's Cloudflare account membership or a named
+admin group, not a broad account-wide default.
+
+## staged rollout
+
+Stage 0: current state
+
+- Access protects `admin.anipotts.com`.
+- One-time-pin IdP is active.
+- Read-only admin routes are live.
+
+Stage 1: metadata packet
+
+- record app hostname, type, session duration, IdP type, and policy selector
+  kinds
+- do not include full ids, emails, tokens, cookies, or policy payloads in public
+  repo docs
+- capture unauthenticated 302 proof for root and protected admin routes
+
+Stage 2: proposed target config
+
+- choose exact IdP
+- choose exact selector or group
+- choose exact session duration
+- choose rollback config
+- choose proof routes
+- prepare a no-secret diff packet for review
+
+Stage 3: live Access change, gated
+
+- requires exact current authority for Cloudflare Access policy or app mutation
+- apply only the approved Access config
+- verify unauthenticated Access 302 behavior
+- verify authenticated root and changed routes
+- verify rollback path remains available
+- record proof in bus or handoff
+
+## rollback
+
+Rollback should restore the previous Access app policy and IdP shape without
+DNS changes. The fallback is to return to one-time-pin access with the existing
+allow policy selector.
+
+Rollback proof should include:
+
+- Access app still exists for `admin.anipotts.com`
+- unauthenticated root returns 302 to Access
+- authenticated root renders
+- no Worker route or DNS mutation was required
+
+## exact authority still needed
+
+Before any live Access change, Ani must approve:
+
+- the exact Access app
+- the exact target IdP
+- the exact selector or group
+- the exact session duration
+- whether app-level allowed IdPs should be restricted
+- the rollback config
+- the proof routes
+
+This plan does not authorize DNS, Cloudflare Access mutation, auth removal,
+env or secret changes, Worker route changes, deploys, or app-native auth.

--- a/docs/admin-auth-content-adr.md
+++ b/docs/admin-auth-content-adr.md
@@ -1,8 +1,8 @@
 # adr: admin auth boundary and content editing path
 
 Date: 2026-06-25
-Status: proposed
-Scope: design only
+Status: accepted for design
+Scope: design plus metadata-only audit
 
 ## decision
 
@@ -21,6 +21,17 @@ For content editing, keep admin read-only until the route model is stable. The
 next content architecture should use explicit content operations and a published
 content read model, not direct file writes from the browser. Draft, preview,
 approve, publish, and proof should be separate states.
+
+Ani approved these bounded next steps on 2026-06-25:
+
+- metadata-only Cloudflare Access admin app audit for `admin.anipotts.com`
+- staged Cloudflare Access login simplification planning for
+  `admin.anipotts.com`
+- admin content draft operation schema and inert write-path design
+
+Those approvals do not authorize live Access policy changes, DNS changes, env or
+secret changes, endpoint changes, deploys, admin write paths, content publish
+writes, or removal of Cloudflare Access.
 
 ## current boundary
 
@@ -293,6 +304,16 @@ Implementation order:
   Cloudflare Access.
 - Unauthenticated `curl` to `https://admin.anipotts.com/content` returned HTTP
   302 to Cloudflare Access.
+- Metadata-only Cloudflare Access API audit found one self-hosted Access app for
+  `admin.anipotts.com`, one allow policy using an email selector, one one-time
+  pin identity provider, a 24 hour session duration, and no app-level allowed
+  IdP restriction. Identifiers were redacted to suffixes only during inspection
+  and are not required for this public repo doc.
+
+See also:
+
+- `docs/admin-access-simplification-plan.md`
+- `docs/admin-content-draft-operations.md`
 
 ## references
 
@@ -307,27 +328,24 @@ Implementation order:
 
 ## next exact authority needed
 
-For an Access config audit:
+Completed design authority:
 
 `approve metadata-only Cloudflare Access admin app audit for admin.anipotts.com`
 
-Allowed by that authority should be limited to reading app name, hostname, IdP
-type, policy selectors, session duration, and allowed user/group metadata. It
-should forbid policy mutation, DNS changes, route changes, token printing, secret
-printing, and user addition/removal.
-
-For an Access simplification change:
-
 `approve staged Cloudflare Access login simplification for admin.anipotts.com`
-
-That authority must name the exact IdP, selector, session duration, rollback
-path, and proof route. It should still forbid removing Access unless separately
-approved.
-
-For content write work:
 
 `approve admin content draft operation schema and inert write-path design`
 
-That should allow schema and static/sample adapters only. Live writes, D1
-migration, public rendering from records, and publish actions each need separate
-authority.
+The first and third items are now represented in this ADR and companion docs.
+The second item is accepted as a staged plan only because it does not name the
+exact target IdP selector, session duration, policy shape, rollback operation,
+or proof route.
+
+For a live Access simplification change, the next authority must name the exact
+Access app, target IdP, selector, session duration, rollback path, and proof
+routes. It should still forbid removing Access unless separately approved.
+
+For content write work, the next authority must name the exact storage target,
+schema migration, API route, preview route, rollback behavior, and live render
+proof. Live writes, D1 migration, public rendering from records, and publish
+actions each need separate authority.

--- a/docs/admin-auth-content-adr.md
+++ b/docs/admin-auth-content-adr.md
@@ -1,0 +1,333 @@
+# adr: admin auth boundary and content editing path
+
+Date: 2026-06-25
+Status: proposed
+Scope: design only
+
+## decision
+
+Keep Cloudflare Access in front of `admin.anipotts.com` for the next admin
+slice. Do not remove it until a replacement has equal or better security,
+operational proof, rollback, and exact authority for the live auth change.
+
+The near-term simplification should be to improve the Access identity
+experience, not to move auth into the app yet. The cleanest candidate is
+Cloudflare Access with Cloudflare account membership as the identity provider,
+restricted to Ani's Cloudflare account, with instant authentication where
+appropriate. That preserves the edge gate while reducing one-time-pin style
+friction.
+
+For content editing, keep admin read-only until the route model is stable. The
+next content architecture should use explicit content operations and a published
+content read model, not direct file writes from the browser. Draft, preview,
+approve, publish, and proof should be separate states.
+
+## current boundary
+
+Observed from repo state and unauthenticated live probes:
+
+- Current admin app: `apps/admin-solid`
+- Worker: `anipotts-admin-solid`
+- Custom domain: `admin.anipotts.com`
+- Worker config: `apps/admin-solid/wrangler.toml`
+- Deploy path: `.github/workflows/deploy.yml`, `Deploy admin-solid`
+- Live unauthenticated proof: `https://admin.anipotts.com/` and
+  `https://admin.anipotts.com/content` return HTTP 302 to Cloudflare Access.
+- Legacy admin: `apps/admin`, custom domain `legacy-admin.anipotts.com`
+- Current admin-solid app auth: none inside the app shell. The live protection
+  boundary is Cloudflare Access before the Worker route.
+- Current write posture: admin-solid routes are read-only. The runtime loader is
+  local-dev metadata only. Content save, publish, deploy, approval bridge,
+  collector, DNS, Access, env, and secret paths are gated.
+
+The current setup is secure mainly because unauthenticated traffic does not
+reach the app content. Removing Access without a replacement would immediately
+turn admin app bugs, future routes, and accidental debug output into public
+exposure risks.
+
+## goals
+
+- Reduce login friction for Ani without lowering the security bar.
+- Keep a strong edge gate while admin is still evolving quickly.
+- Make the future auth model compatible with an Astro-aligned admin v2.
+- Allow content editing to avoid routine code deploys once approved.
+- Keep every write path inert until separate authority exists.
+
+## non-goals
+
+- No live auth change in this ADR.
+- No DNS, route, Access policy, env, secret, endpoint, or deploy mutation.
+- No production content store mutation.
+- No admin write path or publish path.
+- No replacement of `apps/admin-solid` with Astro in this slice.
+
+## option a: keep and improve Cloudflare Access
+
+Shape:
+
+- Keep Access as the edge gate for `admin.anipotts.com`.
+- Replace or improve the identity experience behind Access.
+- Prefer Cloudflare account membership or another strong IdP over email-only
+  one-time-pin flow.
+- Use instant authentication if there is only one intended IdP.
+- Keep route-level app code read-only until write paths are separately approved.
+
+Pros:
+
+- Current live protection model stays intact.
+- Unauthenticated requests are blocked before app code runs.
+- No app session storage, CSRF, password reset, or passkey recovery code needed.
+- Can protect future Astro admin and existing Solid admin the same way.
+- Good rollback: keep or restore the Access app and policy.
+
+Cons:
+
+- Still depends on Cloudflare Zero Trust configuration.
+- The login experience can feel heavier than app-native auth.
+- Per-route app roles are awkward unless the app also verifies identity headers.
+- Auth state is outside the repo unless represented by generated config or
+  audited handoffs.
+
+When to choose:
+
+- Now.
+- While admin is read-only.
+- While content writes, deploy buttons, approval bridges, and collectors are not
+  live.
+
+Recommended improvement path:
+
+1. Metadata-only audit of current Access app, IdP, policy selectors, session
+   duration, and allowed users.
+2. Design a target Access config that uses a stronger, simpler IdP.
+3. Stage the config on a non-production admin hostname or temporary app.
+4. Switch `admin.anipotts.com` only after exact authority and rollback proof.
+
+## option b: app-native auth in Astro admin
+
+Shape:
+
+- Future `apps/admin-v2` Astro app owns login, session cookies, CSRF protection,
+  audit events, and roles.
+- Auth can be password plus passkey, magic link, GitHub OAuth, or OIDC.
+- Cloudflare Access either remains as defense in depth or is removed later.
+
+Pros:
+
+- Can make the admin UX feel native and simple.
+- Can model app roles, write authority, proof, and audit in one place.
+- Fits future content editing because operations can tie to an app session.
+- Can support passkeys and device-bound sessions.
+
+Cons:
+
+- Much larger security surface than Access-only.
+- Needs session storage, cookie hardening, CSRF, rate limiting, recovery, audit,
+  and logout behavior.
+- Needs rigorous tests before it protects live admin.
+- A bug in app auth can expose the admin app unless Access remains in front.
+
+When to choose:
+
+- After admin v2 route model is stable.
+- When write paths need per-action identity inside the app.
+- Only with Access still in front until app auth has production proof.
+
+Recommended posture:
+
+- Build app-native auth as a second layer first, not a replacement.
+- Require app-native auth only for future write/control routes.
+- Keep read-only routes behind Access until the replacement has a rollback plan.
+
+## option c: GitHub, passkey, or OIDC style auth
+
+Shape:
+
+- GitHub OAuth or OIDC: authenticate through a known identity provider.
+- Passkey/WebAuthn: authenticate using platform credentials.
+- Managed OIDC through Cloudflare Access or app-native OIDC can bridge either
+  model.
+
+Pros:
+
+- Stronger and more familiar than shared passwords.
+- GitHub membership can map naturally to repo/admin work.
+- Passkeys reduce phishing risk when implemented correctly.
+- OIDC gives a standard path for future clients and service boundaries.
+
+Cons:
+
+- GitHub OAuth adds app registration, callback URL, token handling, and provider
+  outage dependency.
+- Passkeys need enrollment, recovery, device loss handling, and storage.
+- OIDC still needs session and role design if handled in-app.
+- If implemented directly in the app, it does not give the same edge-blocking
+  behavior as Access.
+
+When to choose:
+
+- GitHub/OIDC: when admin needs named operators and reviewable roles.
+- Passkeys: when the app has a stable session store and recovery policy.
+- Cloudflare Access OIDC: when the goal is simpler login while keeping the edge
+  gate.
+
+## option d: local-only or tunnel-first admin
+
+Shape:
+
+- Admin is only reachable through a private network, device client, or tunnel.
+- Public `admin.anipotts.com` is removed or becomes a thin redirect.
+- Access requires device enrollment, Tailscale, WARP, or a similar private path.
+
+Pros:
+
+- Very strong exposure reduction.
+- Good for root, launchd, health, and machine-control surfaces.
+- No public login page for sensitive operator actions.
+- Pairs well with a separate public read-only status dashboard.
+
+Cons:
+
+- Worse mobile and browser ergonomics.
+- Device enrollment becomes the main dependency.
+- Harder to share authenticated proof from normal browser sessions.
+- Not ideal for quick content review from any trusted machine.
+
+When to choose:
+
+- For future destructive/admin-control routes.
+- For machine-local controls and root-adjacent operations.
+- Not as the default path for read-only content review.
+
+## when to remove Cloudflare Access
+
+Do not remove Access until all of these are true:
+
+- Replacement auth is implemented and tested on a staging hostname.
+- The replacement blocks unauthenticated requests before protected content is
+  returned.
+- Session cookies are secure, httpOnly, sameSite, scoped, rotated, and audited.
+- CSRF and rate limiting exist for every mutation route.
+- Recovery and device-loss behavior are documented.
+- Route-level roles distinguish read-only, content draft, publish, deploy, and
+  destructive operations.
+- Auth logs are recorded without secret values or private payloads.
+- Rollback restores Access without DNS or route ambiguity.
+- Ani gives exact current authority for the live auth change.
+
+The earliest safe removal point is after an Astro-aligned admin v2 has app-native
+auth running behind Access with authenticated render proof and write-path tests.
+Even then, keeping Access as defense in depth may remain the better tradeoff.
+
+## recommended path
+
+Short term:
+
+1. Keep Cloudflare Access on `admin.anipotts.com`.
+2. Improve the Access login path through a design-reviewed Access config.
+3. Keep `apps/admin-solid` moving for read-only operator and content review.
+4. Open draft PRs for UI/read-model work and require exact authority for live
+   admin deploys.
+
+Medium term:
+
+1. Build an Astro-aligned `apps/admin-v2` shell only after route/data ownership
+   is stable.
+2. Add app-native identity as a second layer behind Access for future write
+   surfaces.
+3. Use per-operation authority checks for content writes, deploys, approval
+   bridge sends, and destructive actions.
+4. Preserve Access until app-native auth has proof equal to or stronger than the
+   current edge gate.
+
+## content editing path without routine deploys
+
+Target model:
+
+`source default -> content record -> draft operation -> preview -> approval -> published record -> render proof`
+
+Recommended storage shape:
+
+- Source defaults remain in `apps/www` and content collections as rollback.
+- A typed content store holds published overrides for editable public-site text.
+- A separate draft operation store holds proposed edits, reviewer notes,
+  authority ids, proof ids, and blocked actions.
+- Admin renders draft and published state, but cannot write until approved.
+- Public site reads published records at runtime or build-time depending on the
+  field.
+
+Recommended first editable surfaces:
+
+- Homepage heading, summary, and proof card copy.
+- Project card fields that already map cleanly to markdown frontmatter.
+- Writing title and summary records before body editing.
+- Newsletter block copy, but not outbound sends.
+
+Required before writes:
+
+- Content schema and migration plan.
+- D1 or equivalent binding design.
+- Preview route proof.
+- Audit event format.
+- Rollback to source defaults.
+- Exact authority for creating the write path.
+- Exact authority for publishing to live public routes.
+
+Implementation order:
+
+1. Continue read-only admin routes: `/content`, `/content/preview`,
+   `/content/review`.
+2. Add a typed draft operation model with static samples only.
+3. Add a disabled write affordance that names the required authority.
+4. Design the content store schema and migration.
+5. Implement write APIs only after separate authority.
+
+## proof from this review
+
+- `apps/admin-solid/wrangler.toml` confirms Worker `anipotts-admin-solid` and
+  custom domain `admin.anipotts.com`.
+- `.github/workflows/deploy.yml` confirms `Deploy admin-solid` is a separate
+  workflow target.
+- `apps/admin-solid/README.md` confirms the current app role and gates.
+- Unauthenticated `curl` to `https://admin.anipotts.com/` returned HTTP 302 to
+  Cloudflare Access.
+- Unauthenticated `curl` to `https://admin.anipotts.com/content` returned HTTP
+  302 to Cloudflare Access.
+
+## references
+
+- Cloudflare Access self-hosted application docs:
+  `https://developers.cloudflare.com/cloudflare-one/access-controls/applications/http-apps/self-hosted-public-app/`
+- Cloudflare as identity provider docs:
+  `https://developers.cloudflare.com/cloudflare-one/integrations/identity-providers/cloudflare/`
+- Cloudflare Tunnel and device-client private access docs:
+  `https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/use-cases/ssh/ssh-device-client/`
+- Cloudflare Access for Infrastructure docs:
+  `https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/use-cases/ssh/ssh-infrastructure-access/`
+
+## next exact authority needed
+
+For an Access config audit:
+
+`approve metadata-only Cloudflare Access admin app audit for admin.anipotts.com`
+
+Allowed by that authority should be limited to reading app name, hostname, IdP
+type, policy selectors, session duration, and allowed user/group metadata. It
+should forbid policy mutation, DNS changes, route changes, token printing, secret
+printing, and user addition/removal.
+
+For an Access simplification change:
+
+`approve staged Cloudflare Access login simplification for admin.anipotts.com`
+
+That authority must name the exact IdP, selector, session duration, rollback
+path, and proof route. It should still forbid removing Access unless separately
+approved.
+
+For content write work:
+
+`approve admin content draft operation schema and inert write-path design`
+
+That should allow schema and static/sample adapters only. Live writes, D1
+migration, public rendering from records, and publish actions each need separate
+authority.

--- a/docs/admin-content-draft-operations.md
+++ b/docs/admin-content-draft-operations.md
@@ -1,0 +1,149 @@
+# admin content draft operations
+
+Date: 2026-06-25
+Status: approved for schema and inert design only
+
+## purpose
+
+Admin content editing should not write directly from a browser form into public
+site source, deployed content, or outbound channels. The first write-path shape
+is an inert operation model that can be rendered, previewed, reviewed, and
+proved before any storage or publish mutation exists.
+
+The target flow is:
+
+`source default -> content record -> draft operation -> preview -> approval -> published record -> render proof`
+
+## operation schema v0
+
+Each draft operation should be represented as a plain data object:
+
+```json
+{
+  "operation_id": "content-draft-homepage-summary-2026-06-25",
+  "kind": "content_draft",
+  "surface": "public_site",
+  "route": "/",
+  "source_ref": "apps/www/src/data/site.ts#homepage.summary",
+  "field_path": "homepage.summary",
+  "current_value_ref": "source_default",
+  "proposed_value": "new copy goes here",
+  "status": "draft",
+  "risk_level": "low",
+  "authority_state": "not_required_for_draft",
+  "required_approval_ids": [],
+  "allowed_actions": ["render_preview", "request_review"],
+  "forbidden_actions": ["save", "publish", "deploy", "send"],
+  "preview_targets": ["/content/preview", "/"],
+  "proof_ids": [],
+  "evidence_uri": "repo://apps/www/src/data/site.ts",
+  "redaction": "public_copy_only",
+  "created_by": "agent",
+  "created_at": "2026-06-25T00:00:00Z",
+  "expires_at": "2026-07-25T00:00:00Z",
+  "rollback_ref": "source_default"
+}
+```
+
+Required fields:
+
+- `operation_id`
+- `kind`
+- `surface`
+- `route`
+- `source_ref`
+- `field_path`
+- `current_value_ref`
+- `proposed_value`
+- `status`
+- `risk_level`
+- `authority_state`
+- `allowed_actions`
+- `forbidden_actions`
+- `preview_targets`
+- `redaction`
+- `rollback_ref`
+
+Optional fields:
+
+- `required_approval_ids`
+- `proof_ids`
+- `evidence_uri`
+- `created_by`
+- `created_at`
+- `expires_at`
+- `reviewer_note`
+
+## states
+
+Allowed initial states:
+
+- `draft`
+- `previewed`
+- `needs_ani`
+- `blocked`
+
+Future gated states:
+
+- `approved`
+- `publishing`
+- `published`
+- `verified`
+- `reverted`
+
+The current admin app may render all states, but it must not create live writes.
+Only `draft`, `previewed`, `needs_ani`, and `blocked` should appear in static or
+local-dev sample data until write authority exists.
+
+## authority mapping
+
+Draft-only copy proposals can be low risk when they touch public-site text and
+do not publish. They can be created and reviewed in safe branches or static
+admin data.
+
+Publishing requires exact authority when any operation:
+
+- writes to D1, KV, R2, a CMS table, or repo source
+- changes public rendered content without a PR merge
+- triggers deploy, cache purge, or route invalidation
+- sends, posts, files, pays, applies, deletes, or mutates an account
+- touches auth, DNS, env, secrets, endpoints, collectors, root, or launchd
+
+## inert write-path design
+
+The first implementation should expose disabled controls only:
+
+- `preview` may render local/sample proposed values
+- `request review` may show the needed authority text
+- `save` remains disabled
+- `publish` remains disabled
+- `deploy` remains absent unless separately approved
+
+No hidden API routes should exist for disabled controls. A disabled button is
+not enough if an endpoint can still be called directly.
+
+## future storage
+
+The eventual content store can use tables shaped like:
+
+- `content_records`: published field overrides
+- `content_draft_operations`: draft and preview operations
+- `content_publish_events`: immutable publish proof
+
+Storage design remains gated. This doc does not authorize a D1 migration,
+binding change, Worker route, content write API, public-site runtime read from
+records, or publish action.
+
+## proof requirements before writes
+
+Before implementing any real write path, require:
+
+- storage target and binding approved
+- migration reviewed and reversible
+- API route and method approved
+- CSRF/session posture defined
+- Access boundary still proven
+- preview route proven
+- publish rollback defined
+- audit event schema approved
+- exact authority recorded for the live write action

--- a/docs/admin-newsletter-scope-packet-2026-06-25.md
+++ b/docs/admin-newsletter-scope-packet-2026-06-25.md
@@ -1,0 +1,218 @@
+# admin and newsletter scope packet: 2026-06-25
+
+Status: no-mutation scope packet
+
+## operating direction
+
+Stop creating new admin/site PRs until the desired slice is clearly scoped.
+
+The default sequence is:
+
+1. define the desired user workflow
+2. classify the gate
+3. make one scoped edit
+4. verify locally and in GitHub
+5. merge/deploy only when the lane and authority match
+
+Admin is second priority after brand/deals. Keep read-only dashboard work moving
+only when it supports the defined operator/content system.
+
+## open PR inventory
+
+Admin and site PRs:
+
+- PR #86: `Add read-only admin content review queue`
+  - Classification: merge-ready after exact approval
+  - Reason: read-only `apps/admin-solid` route, green checks, clean merge state
+  - Action: keep
+  - Approval: `approve PR #86 ready/merge/deploy admin-solid only for read-only /content/review`
+- PR #87: `Add admin auth and content editing ADR`
+  - Classification: design-only, merge-ready after exact approval
+  - Reason: docs-only, green checks, clean merge state
+  - Action: keep as the scope packet container
+  - Approval: `approve PR #87 ready/merge docs-only, no deploy target`
+- PR #73: `Clean public site links and homepage cards`
+  - Classification: stale public-site candidate
+  - Reason: older draft, public-site lane, not part of current admin/newsletter
+    scope
+  - Action: refresh/cherry-pick later only if Ani wants that public cleanup
+  - Approval: separate public-site approval before merge/deploy
+
+Dependabot PRs:
+
+- PR #49: posthog-js update
+  - Classification: should close/replace or regenerate
+  - Reason: old dependency PR with failed review
+- PR #39: tailwind-merge update
+  - Classification: should close/replace or regenerate
+  - Reason: old dependency PR with failed review
+- PR #38: resend update
+  - Classification: should close/replace or regenerate
+  - Reason: old dependency PR with failed review
+- PR #37: otplib update
+  - Classification: should close/replace or regenerate
+  - Reason: old dependency PR with failed CI/review
+- PR #36: TypeScript update
+  - Classification: should close/replace or regenerate
+  - Reason: old dependency PR with failed CI/review
+- PR #33: dependabot/fetch-metadata update
+  - Classification: should close/replace or regenerate
+  - Reason: old GitHub Actions dependency PR with failed review/security
+- PR #32: actions/checkout update
+  - Classification: should close/replace or regenerate
+  - Reason: old GitHub Actions dependency PR with failed review
+- PR #31: dorny/paths-filter update
+  - Classification: should close/replace or regenerate
+  - Reason: old GitHub Actions dependency PR with failed review/security
+
+Do not mix dependency cleanup with admin/content/newsletter work.
+
+## desired admin ux
+
+Admin should answer:
+
+`what is safe to do next?`
+
+The practical dashboard should show:
+
+- `needs ani`: typed return queue, stale date, owner, action, next agent step
+- `content`: public-site current values, draft proposals, preview state, source
+  refs
+- `newsletter`: issue drafts, source material, section status, send gate,
+  preview proof
+- `repos`: dirty/divergent state, branch, PR, deploy impact, last check
+- `handoffs`: newest, stale, unabsorbed, owner thread, target owner
+- `machines`: ap-pro/ap-mini role, heartbeat, active work, blocked/running
+- `gates`: dns, Access, env, secrets, root, launchd, endpoints, publish, send
+- `proof`: last route render, deploy result, authenticated render, Access 302
+
+Keep the current `apps/admin-solid` shell until the route/data model is stable.
+Astro alignment is desirable, but a framework migration should wait until it
+reduces complexity instead of adding churn.
+
+## auth direction
+
+Cloudflare Access stays in front of `admin.anipotts.com`.
+
+Near-term auth work is design-only:
+
+- keep Access as the edge gate
+- simplify login inside Access first
+- record exact Access app, IdP, selector, session, rollback, and proof route
+  before any live mutation
+- treat app-native auth as a future second layer for write/control routes
+
+Do not remove Access or change policy until a reviewed migration has exact
+authority.
+
+## content queue
+
+The content queue should use operation objects, not direct browser writes.
+
+Read-only first:
+
+- source default
+- current rendered value
+- proposed draft value
+- preview route
+- risk level
+- authority state
+- proof id
+- blocked actions
+
+Future writes require exact authority for storage, migration, API route, preview
+route, rollback, and render proof.
+
+## newsletter at news.anipotts.com
+
+Newsletter work should be treated as content structure first, publish/send
+later.
+
+Draft structure:
+
+- issue slug
+- working title
+- thesis
+- sections
+- source refs
+- draft status
+- review questions
+- preview route
+- send gate
+- proof ids
+
+Admin should eventually show newsletter drafts beside public-site content, but
+outbound sends, mailing-list mutations, unsubscribe settings, analytics, and
+domain/routing changes stay gated.
+
+No authority exists in this packet to publish, send, deploy, change DNS, change
+env, or mutate newsletter provider settings.
+
+## approval model
+
+Admin read-only lane:
+
+- safe to branch, edit, verify, push, and PR
+- safe to merge/deploy only when exact admin-only authority is active
+- deploy should run only `admin_solid=true`
+- proof must show unrelated targets skipped
+
+Public site lane:
+
+- presentation/content PRs can be safe, but public live impact is different
+  from protected admin impact
+- public deploys should remain separately approved when the change is visible on
+  `anipotts.com`
+
+Newsletter lane:
+
+- draft structure and preview data are safe
+- publish/send/provider actions require exact authority
+- `news.anipotts.com` DNS, routing, and provider changes require exact authority
+
+## proposed admin-only automerge/autodeploy policy
+
+Design only. Do not change workflows yet.
+
+Eligible:
+
+- PR touches only `apps/admin-solid`, admin read-only static data, admin docs, or
+  safe shared read-model code
+- PR declares no write path, no auth change, no env/secrets, no DNS, no worker
+  service outside admin-solid
+- required checks are green
+- Claude review and security review pass
+- deploy workflow path filter resolves to `admin_solid=true`
+- all unrelated deploy targets are skipped
+
+Not eligible:
+
+- any Cloudflare Access, DNS, env, secret, endpoint, collector, root, launchd, or
+  auth mutation
+- any admin write path, content publish write, approval bridge send, newsletter
+  send, deploy button, or live control route
+- public `apps/www` visual/content changes unless separately approved
+- legacy `apps/admin` or non-admin workers
+
+Exact authority needed before implementing this policy:
+
+`approve admin-only automerge/autodeploy policy implementation for read-only apps/admin-solid PRs with skipped-target proof`
+
+## public-site gated
+
+Keep these separate from admin-only automation:
+
+- homepage and public copy changes on `anipotts.com`
+- project pages and writing surfaces
+- newsletter public route or `news.anipotts.com`
+- public redirects and route labels
+- SEO metadata that changes public rendering
+- analytics or tracking behavior
+- deploy workflow behavior for public targets
+
+## newsletter child thread
+
+A remote mini `anipotts.com` project thread was requested for newsletter content
+draft structure only. If thread creation succeeds, it should work in a separate
+worktree and report back without publish, deploy, DNS, auth, env, secret,
+provider, or outbound-send authority.

--- a/docs/admin-next-step-packet-2026-06-25.md
+++ b/docs/admin-next-step-packet-2026-06-25.md
@@ -1,0 +1,121 @@
+# admin next-step packet: 2026-06-25
+
+Status: no mutation packet
+
+## current state
+
+- Live public site main: `daee50c`
+- Admin host: `admin.anipotts.com`
+- Admin app: `apps/admin-solid`
+- Auth boundary: Cloudflare Access remains active
+- Priority: second after brand/deals
+
+Open admin PRs:
+
+- PR #86: `Add read-only admin content review queue`
+  - Branch: `codex/pro/admin-content-review-2026-06-25`
+  - Head: `f95d219`
+  - State: open draft
+  - Merge state: clean
+  - Checks: CI, security, Claude review, CodeRabbit green
+  - Scope: read-only `apps/admin-solid` route and styling
+- PR #87: `Add admin auth and content editing ADR`
+  - Branch: `codex/pro/admin-auth-content-adr-2026-06-25`
+  - Head: `1274d84`
+  - State: open draft
+  - Merge state: clean
+  - Checks: CI, security, Claude review, CodeRabbit green
+  - Scope: docs-only auth/content ADR, Access audit packet, inert draft
+    operation schema
+
+## safe to merge and deploy with exact approval
+
+PR #86 can be treated as the next admin-solid-only read-only candidate:
+
+- adds `/content/review`
+- groups current public-site content with inert proposal previews
+- adds no save API
+- adds no publish API
+- adds no content-store mutation
+- adds no approval bridge sending
+- adds no hidden write endpoint
+
+Recommended action if Ani wants this live:
+
+1. mark PR #86 ready
+2. merge PR #86 after checks remain green
+3. run deploy with `admin_solid=true`
+4. verify all unrelated deploy targets skipped
+5. prove unauthenticated Cloudflare Access 302 for `/content/review`
+6. prove authenticated render if browser auth is available
+
+Exact approval phrase:
+
+`approve PR #86 ready/merge/deploy admin-solid only for read-only /content/review`
+
+## safe to merge without deploy target
+
+PR #87 can be merged as docs-only when Ani wants the architecture recorded on
+main. It should not deploy app targets.
+
+Recommended action if Ani wants this merged:
+
+1. mark PR #87 ready
+2. merge PR #87 after checks remain green
+3. verify docs-only deploy behavior, with app targets skipped
+
+Exact approval phrase:
+
+`approve PR #87 ready/merge docs-only, no deploy target`
+
+## must remain design-only
+
+These remain gated:
+
+- removing Cloudflare Access
+- changing Cloudflare Access policy, IdP, session duration, or allowed users
+- DNS or route mutation
+- env or secret mutation
+- app-native auth activation
+- content save APIs
+- content publish writes
+- D1, KV, R2, CMS, or repo-source write paths
+- approval bridge sending
+- production collectors
+- live control or destructive operations
+
+Exact approval needed before live Access mutation:
+
+`approve live Cloudflare Access change for admin.anipotts.com: app=<app>, idp=<idp>, selector=<selector-or-group>, session=<duration>, rollback=<rollback>, proof=<routes>`
+
+Exact approval needed before content writes:
+
+`approve admin content write path: storage=<target>, migration=<id>, api=<route>, preview=<route>, rollback=<plan>, proof=<routes>`
+
+## next useful read-only admin vision
+
+Keep the current Solid admin shell until the route/data model stabilizes. The
+next read-only routes should make admin practical before a framework migration:
+
+- typed `NEEDS-ANI` return queue: show answer-ready items, stale items, and
+  agent next steps
+- content review: keep `/content`, `/content/preview`, and `/content/review`
+  moving as inert preview surfaces
+- handoffs: show newest, stale, unabsorbed, owner thread, target owner, and
+  absorbed status
+- stale rule drift: show AGENTS/CLAUDE, Infra policy, launchd docs, workflow
+  defaults, and open drift packets
+- repo state: dirty tracked count, untracked count, branch, upstream,
+  ahead/behind, deploy impact, and active PR
+- machine drift: ap-pro/ap-mini task, heartbeat, role, idle/running/blocked,
+  and last proof
+- live gates: DNS, Access, env, secrets, root, launchd, endpoints, deploy,
+  write paths, outbound sends
+- last proof: newest verified route, deploy run, authenticated render, and
+  unauthenticated Access proof
+- future content/newsletter: public-site text, project copy, writing metadata,
+  newsletter copy, and outbound publishing as gated future surfaces
+
+Astro alignment should stay design-only for now. The clean migration point is
+after the admin route model and content operation schema are stable enough that
+an Astro app reduces complexity instead of adding churn.

--- a/docs/admin-v2-architecture.md
+++ b/docs/admin-v2-architecture.md
@@ -193,6 +193,8 @@ Auth boundary note:
   operation schema that should precede any save or publish path.
 - See `docs/admin-next-step-packet-2026-06-25.md` for current PR status,
   read-only merge/deploy candidates, and exact approval language.
+- See `docs/admin-newsletter-scope-packet-2026-06-25.md` for the no-mutation
+  admin/content/newsletter operating scope before more PRs.
 
 ## smallest first implementation slice
 

--- a/docs/admin-v2-architecture.md
+++ b/docs/admin-v2-architecture.md
@@ -180,6 +180,14 @@ Admin control lane:
 - collector, DNS, Access, env, and secret changes require exact current
   authority
 
+Auth boundary note:
+
+- See `docs/admin-auth-content-adr.md` for the proposed design path. The current
+  recommendation is to keep Cloudflare Access as the edge gate, simplify the
+  identity experience first, and treat app-native auth as a future second layer
+  behind Access until it has proof equal to or stronger than the current
+  boundary.
+
 ## smallest first implementation slice
 
 First slice: add a read-only `/content` route to the current admin shell.

--- a/docs/admin-v2-architecture.md
+++ b/docs/admin-v2-architecture.md
@@ -191,6 +191,8 @@ Auth boundary note:
   audit result and staged login simplification plan.
 - See `docs/admin-content-draft-operations.md` for the inert content draft
   operation schema that should precede any save or publish path.
+- See `docs/admin-next-step-packet-2026-06-25.md` for current PR status,
+  read-only merge/deploy candidates, and exact approval language.
 
 ## smallest first implementation slice
 

--- a/docs/admin-v2-architecture.md
+++ b/docs/admin-v2-architecture.md
@@ -187,6 +187,10 @@ Auth boundary note:
   identity experience first, and treat app-native auth as a future second layer
   behind Access until it has proof equal to or stronger than the current
   boundary.
+- See `docs/admin-access-simplification-plan.md` for the metadata-only Access
+  audit result and staged login simplification plan.
+- See `docs/admin-content-draft-operations.md` for the inert content draft
+  operation schema that should precede any save or publish path.
 
 ## smallest first implementation slice
 


### PR DESCRIPTION
## summary
- record Ani's 2026-06-25 bounded approvals for admin auth/content design work
- add the redacted metadata-only Cloudflare Access audit result for `admin.anipotts.com`
- add a staged Access login simplification plan that keeps Access as the edge gate
- add the inert admin content draft operation schema and write-path design
- add the 2026-06-25 admin next-step packet for PR #86/#87 status, safe read-only merge/deploy candidates, design-only gates, and exact approval phrases
- add the admin/content/newsletter scope packet to pause further PR proliferation until the desired system is clearly scoped
- keep the auth ADR linked from `docs/admin-v2-architecture.md`

## scope
- docs only
- metadata-only Access audit only
- design only for staged login simplification
- schema/design only for content draft operations
- no Cloudflare Access policy changes
- no DNS, auth removal, env, secrets, root, launchd, endpoints, production collectors, routing, deploy, write path, outbound action, or source/personal delete

## proof
- inspected `apps/admin-solid/wrangler.toml`, `apps/admin-solid/README.md`, `.github/workflows/deploy.yml`, and current admin route/auth references
- unauthenticated `curl` to `https://admin.anipotts.com/` returned Cloudflare Access 302
- unauthenticated `curl` to `https://admin.anipotts.com/content` returned Cloudflare Access 302
- Cloudflare Access metadata audit found one self-hosted Access app for `admin.anipotts.com`, one allow policy using an email selector, one one-time-pin IdP, 24h session duration, and no app-level allowed-IdP restriction
- no secrets, tokens, policy emails, full ids, cookies, user lists, or private payloads were printed or committed
- reconfirmed open PR inventory and classification before writing the scope packet
- created a queued remote mini anipotts.com newsletter-content worktree thread with no publish/deploy/DNS/auth/env/secret/send authority

## verification
- `pnpm exec prettier --check docs/admin-auth-content-adr.md docs/admin-access-simplification-plan.md docs/admin-content-draft-operations.md docs/admin-v2-architecture.md`
- `pnpm exec prettier --check docs/admin-next-step-packet-2026-06-25.md docs/admin-v2-architecture.md`
- `pnpm exec prettier --check docs/admin-newsletter-scope-packet-2026-06-25.md docs/admin-v2-architecture.md`
- `git diff --check`
- `git diff --check HEAD~1..HEAD`

## authority now recorded in docs
- `approve metadata-only Cloudflare Access admin app audit for admin.anipotts.com`
- `approve staged Cloudflare Access login simplification for admin.anipotts.com`
- `approve admin content draft operation schema and inert write-path design`

## approval still needed before live mutation
- exact Cloudflare Access app, IdP, selector or group, session duration, rollback path, and proof routes before any live Access change
- exact storage target, schema migration, API route, preview route, rollback behavior, and live render proof before any content write path
- exact PR #86 merge/deploy approval before putting `/content/review` live
- exact workflow authority before implementing admin-only automerge/autodeploy behavior


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added several admin planning and decision documents covering access, authentication, content editing, and rollout guidance.
  * Clarified the current admin access posture and the preferred path for simplifying sign-in while keeping edge protection in place.
  * Defined staged approval, rollback, and proof requirements for future admin/content changes.
  * Added scope and workflow notes to separate read-only admin work from any write, deploy, or publishing actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->