### PR TITLE
feat: gate admin routes with passkey session

### DIFF
--- a/apps/admin-solid/app.config.ts
+++ b/apps/admin-solid/app.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from "@solidjs/start/config";
 
 export default defineConfig({
+  middleware: "./src/middleware.ts",
   server: {
     preset: "cloudflare-module",
     rollupConfig: {

--- a/apps/admin-solid/src/lib/passkey-auth.ts
+++ b/apps/admin-solid/src/lib/passkey-auth.ts
@@ -168,6 +168,18 @@ export async function getPasskeyStatus(
   };
 }
 
+export async function hasActivePasskeySession(
+  event: HTTPEvent,
+): Promise<boolean> {
+  const db = dbFromEvent(event);
+  if (!db) return false;
+  try {
+    return Boolean(await getSession(event, db));
+  } catch {
+    return false;
+  }
+}
+
 export async function registrationOptions(event: HTTPEvent): Promise<Response> {
   const db = requiredDb(event);
   const status = await getPasskeyStatus(event);
@@ -384,7 +396,8 @@ function requiredDb(event: HTTPEvent): D1Database {
     throw json(
       {
         error: "db_binding_missing",
-        next_safe_action: "deploy with DB binding and apply migration before enrollment",
+        next_safe_action:
+          "deploy with DB binding and apply migration before enrollment",
       },
       { status: 503 },
     );

--- a/apps/admin-solid/src/middleware.ts
+++ b/apps/admin-solid/src/middleware.ts
@@ -1,0 +1,31 @@
+import type { HTTPEvent } from "vinxi/http";
+import { getRequestURL, sendRedirect } from "vinxi/http";
+import { hasActivePasskeySession } from "./lib/passkey-auth";
+
+async function onRequest(event: HTTPEvent): Promise<void> {
+  const url = getRequestURL(event, {
+    xForwardedHost: true,
+    xForwardedProto: true,
+  });
+
+  if (isPublicPath(url.pathname)) return;
+
+  const hasSession = await hasActivePasskeySession(event);
+  if (hasSession) return;
+
+  const next = encodeURIComponent(`${url.pathname}${url.search}`);
+  await sendRedirect(event, `/auth/passkey?next=${next}`, 302);
+}
+
+export default { onRequest };
+
+function isPublicPath(pathname: string): boolean {
+  return (
+    pathname === "/auth/passkey" ||
+    pathname.startsWith("/api/admin/passkey/") ||
+    pathname.startsWith("/_build/") ||
+    pathname.startsWith("/assets/") ||
+    pathname.startsWith("/favicon") ||
+    pathname.startsWith("/.well-known/")
+  );
+}


### PR DESCRIPTION
## summary\n- add SolidStart middleware for app-native admin route gating\n- allow only /auth/passkey, /api/admin/passkey/*, and static assets without an app passkey session\n- redirect protected admin routes to /auth/passkey when unauthenticated\n\n## why\nCloudflare Access cannot be removed safely until admin-solid has its own route boundary. This makes passkey auth the app-native wall before Access removal.\n\n## verification\n- pnpm --filter @anipotts/admin-solid typecheck\n- pnpm --filter @anipotts/admin-solid build\n\n## deploy lane\nApproved 2026-06-27 admin-solid lane: merge after green checks and deploy admin_solid=true only.\n