### PR TITLE
fix: add admin-solid reflect polyfill

### DIFF
--- a/apps/admin-solid/package.json
+++ b/apps/admin-solid/package.json
@@ -18,6 +18,7 @@
     "@simplewebauthn/server": "13.3.2",
     "@solidjs/router": "^0.15.3",
     "@solidjs/start": "^1.3.2",
+    "reflect-metadata": "0.2.2",
     "solid-js": "^1.9.12",
     "vinxi": "^0.5.11"
   },

--- a/apps/admin-solid/src/entry-server.tsx
+++ b/apps/admin-solid/src/entry-server.tsx
@@ -1,3 +1,4 @@
+import "reflect-metadata";
 import { createHandler, StartServer } from "@solidjs/start/server";
 
 export default createHandler(() => (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,6 +118,9 @@ importers:
       '@solidjs/start':
         specifier: ^1.3.2
         version: 1.3.2(solid-js@1.9.12)(vinxi@0.5.11(@types/node@22.19.19)(aws4fetch@1.0.20)(db0@0.3.4(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260518.1)(@opentelemetry/api@1.9.0)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260518.1)(@opentelemetry/api@1.9.0))(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0))(vite@6.4.2(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0))
+      reflect-metadata:
+        specifier: 0.2.2
+        version: 0.2.2
       solid-js:
         specifier: ^1.9.12
         version: 1.9.12


### PR DESCRIPTION
## summary
- add `reflect-metadata` to admin-solid
- import it before the SolidStart server entry
- fixes Cloudflare Worker validation for the passkey server dependency

## verification
- `pnpm --filter @anipotts/admin-solid typecheck`
- `pnpm --filter @anipotts/admin-solid build`

## deploy lane
Approved 2026-06-27 admin-solid lane: merge after green checks and deploy `admin_solid=true` only.
