### PR TITLE
fix: scope agent deploy targets

### DIFF
--- a/.github/workflows/agent-pr-automerge.yml
+++ b/.github/workflows/agent-pr-automerge.yml
@@ -59,22 +59,13 @@ jobs:
 
           www=false
           admin=false
+          admin_solid=false
           labs=false
           ingest=false
           newsletter=false
           weekly_email=false
 
           while IFS= read -r file; do
-            case "$file" in
-              package.json|pnpm-lock.yaml|pnpm-workspace.yaml|turbo.json)
-                www=true
-                admin=true
-                labs=true
-                ingest=true
-                newsletter=true
-                weekly_email=true
-                ;;
-            esac
             case "$file" in
               apps/www/*|packages/lib/*|packages/styles/*|packages/types/*)
                 www=true
@@ -83,6 +74,11 @@ jobs:
             case "$file" in
               apps/admin/*|packages/config/*|packages/lib/*|packages/services-platform/*|packages/styles/*|packages/types/*|services/*)
                 admin=true
+                ;;
+            esac
+            case "$file" in
+              apps/admin-solid/*|packages/config/*|packages/lib/*|packages/services-platform/*|packages/styles/*|packages/types/*|services/*)
+                admin_solid=true
                 ;;
             esac
             case "$file" in
@@ -110,6 +106,7 @@ jobs:
           {
             echo "www=$www"
             echo "admin=$admin"
+            echo "admin_solid=$admin_solid"
             echo "labs=$labs"
             echo "ingest=$ingest"
             echo "newsletter=$newsletter"
@@ -126,6 +123,7 @@ jobs:
         if: >
           steps.targets.outputs.www == 'true' ||
           steps.targets.outputs.admin == 'true' ||
+          steps.targets.outputs.admin_solid == 'true' ||
           steps.targets.outputs.labs == 'true' ||
           steps.targets.outputs.ingest == 'true' ||
           steps.targets.outputs.newsletter == 'true' ||
@@ -139,6 +137,7 @@ jobs:
             --ref main \
             -f www=${{ steps.targets.outputs.www }} \
             -f admin=${{ steps.targets.outputs.admin }} \
+            -f admin_solid=${{ steps.targets.outputs.admin_solid }} \
             -f labs=${{ steps.targets.outputs.labs }} \
             -f ingest=${{ steps.targets.outputs.ingest }} \
             -f newsletter=${{ steps.targets.outputs.newsletter }} \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,10 +9,11 @@
 #   TYPEFULLY_SOCIAL_SET_ID - Typefully social set ID
 #
 # Path-filtered deploys: each deploy-X job only runs when files relevant to
-# that target actually changed. Root dependency changes trigger every deployed
-# target because they can affect any build. Docs-only commits skip the workflow
-# entirely via paths-ignore. Workflow-only changes run detection but deploy
-# nothing. No untrusted input is interpolated into run: blocks anywhere here.
+# that target actually changed. Root dependency changes do not fan out to every
+# target; use workflow_dispatch for an explicit deploy when a root-only change
+# needs promotion. Docs-only commits skip the workflow entirely via
+# paths-ignore. Workflow-only changes run detection but deploy nothing. No
+# untrusted input is interpolated into run: blocks anywhere here.
 
 name: Deploy
 
@@ -92,19 +93,12 @@ jobs:
         id: filter
         with:
           filters: |
-            root: &root
-              - "package.json"
-              - "pnpm-lock.yaml"
-              - "pnpm-workspace.yaml"
-              - "turbo.json"
             www:
-              - *root
               - "apps/www/**"
               - "packages/lib/**"
               - "packages/styles/**"
               - "packages/types/**"
             admin:
-              - *root
               - "apps/admin/**"
               - "packages/config/**"
               - "packages/lib/**"
@@ -113,7 +107,6 @@ jobs:
               - "packages/types/**"
               - "services/**"
             admin-solid:
-              - *root
               - "apps/admin-solid/**"
               - "packages/config/**"
               - "packages/lib/**"
@@ -122,17 +115,13 @@ jobs:
               - "packages/types/**"
               - "services/**"
             labs:
-              - *root
               - "apps/labs/**"
               - "packages/config/**"
             ingest:
-              - *root
               - "workers/ingest/**"
             newsletter:
-              - *root
               - "workers/newsletter/**"
             weekly-email:
-              - *root
               - "workers/weekly-email/**"
 
   deploy-www:


### PR DESCRIPTION
## summary
- stop root dependency file changes from automatically deploying every target
- add admin_solid to agent automerge target detection and workflow dispatch
- keep root-only changes deployable by explicit workflow_dispatch only

## verification
- ruby YAML parse for .github/workflows/agent-pr-automerge.yml and .github/workflows/deploy.yml
- git diff --check

## live impact
- none from this PR; workflow/settings only
