### PR TITLE
fix: load passkey polyfill before worker

### DIFF
--- a/apps/admin-solid/worker-entry.mjs
+++ b/apps/admin-solid/worker-entry.mjs
@@ -1,0 +1,5 @@
+import "reflect-metadata";
+
+import worker from "./.output/server/index.mjs";
+
+export default worker;

--- a/apps/admin-solid/wrangler.toml
+++ b/apps/admin-solid/wrangler.toml
@@ -2,7 +2,7 @@ name = "anipotts-admin-solid"
 compatibility_date = "2025-04-01"
 compatibility_flags = ["nodejs_compat"]
 account_id = "0f856093bdcd34a7da1bde5ee4385163"
-main = ".output/server/index.mjs"
+main = "worker-entry.mjs"
 workers_dev = true
 
 [assets]


### PR DESCRIPTION
## summary
- add a stable admin-solid Worker wrapper that imports reflect-metadata before Nitro
- point Wrangler at the wrapper entry
- keep passkey middleware/auth code unchanged

## verification
- pnpm --filter @anipotts/admin-solid typecheck
- pnpm --filter @anipotts/admin-solid build
- pnpm exec wrangler --cwd apps/admin-solid deploy --dry-run

## deploy target
- admin_solid only after merge
