### PR TITLE
fix: disable admin-solid workers dev route

### DIFF
--- a/apps/admin-solid/wrangler.toml
+++ b/apps/admin-solid/wrangler.toml
@@ -3,7 +3,7 @@ compatibility_date = "2025-04-01"
 compatibility_flags = ["nodejs_compat"]
 account_id = "0f856093bdcd34a7da1bde5ee4385163"
 main = "worker-entry.mjs"
-workers_dev = true
+workers_dev = false
 
 [assets]
 directory = ".output/public"


### PR DESCRIPTION
## summary
- disable the admin-solid workers.dev route
- keep admin-solid reachable through the custom domain boundary

## verification
- pnpm --filter @anipotts/admin-solid typecheck
- pnpm --filter @anipotts/admin-solid build
- pnpm exec wrangler --cwd apps/admin-solid deploy --dry-run

## deploy target
- admin_solid only after merge
