### PR TITLE
feat: port passkey auth to astro admin

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -13,6 +13,8 @@
   },
   "dependencies": {
     "@astrojs/cloudflare": "^12.6.0",
+    "@simplewebauthn/browser": "13.3.0",
+    "@simplewebauthn/server": "13.3.2",
     "astro": "^5.16.0"
   },
   "devDependencies": {

--- a/apps/admin/src/env.d.ts
+++ b/apps/admin/src/env.d.ts
@@ -3,7 +3,7 @@
 type D1PreparedStatement = {
   bind(...values: unknown[]): D1PreparedStatement;
   first<T = unknown>(): Promise<T | null>;
-  run(): Promise<unknown>;
+  run(): Promise<{ results?: unknown[]; success?: boolean; meta?: unknown }>;
   all<T = unknown>(): Promise<{ results?: T[] }>;
 };
 

--- a/apps/admin/src/lib/passkey-auth.ts
+++ b/apps/admin/src/lib/passkey-auth.ts
@@ -1,0 +1,643 @@
+import {
+  generateAuthenticationOptions,
+  generateRegistrationOptions,
+  verifyAuthenticationResponse,
+  verifyRegistrationResponse,
+} from "@simplewebauthn/server";
+import type {
+  AuthenticationResponseJSON,
+  AuthenticatorTransportFuture,
+  RegistrationResponseJSON,
+  WebAuthnCredential,
+} from "@simplewebauthn/server";
+
+export const PASSKEY_SESSION_COOKIE = "admin_passkey_session";
+
+const SESSION_DAYS = 30;
+const SESSION_MAX_AGE_SECONDS = SESSION_DAYS * 24 * 60 * 60;
+const CHALLENGE_MAX_AGE_MS = 10 * 60 * 1000;
+const RP_ID = "admin.anipotts.com";
+const RP_NAME = "anipotts admin";
+const EXPECTED_ORIGIN = "https://admin.anipotts.com";
+const LOCAL_ORIGIN = "http://localhost:3001";
+const USER_ID = "ani";
+const USER_NAME = "ani@admin.anipotts.com";
+const USER_DISPLAY_NAME = "Ani";
+
+type D1Result<T = unknown> = {
+  results?: T[];
+  success?: boolean;
+  meta?: unknown;
+};
+
+type D1PreparedStatement = {
+  bind(...values: unknown[]): D1PreparedStatement;
+  first<T = unknown>(): Promise<T | null>;
+  run(): Promise<D1Result>;
+  all<T = unknown>(): Promise<D1Result<T>>;
+};
+
+export type D1Database = {
+  prepare(query: string): D1PreparedStatement;
+};
+
+type CredentialRow = {
+  id: string;
+  user_id: string;
+  credential_id: string;
+  public_key: string;
+  counter: number;
+  transports: string;
+  device_type: string | null;
+  backed_up: number | null;
+  created_at: string;
+  last_used_at: string | null;
+  revoked_at: string | null;
+};
+
+type ChallengePurpose = "registration" | "authentication";
+
+type ChallengeRow = {
+  id: string;
+  purpose: ChallengePurpose;
+  challenge: string;
+  credential_id: string | null;
+  created_at: string;
+  expires_at: string;
+  used_at: string | null;
+};
+
+type SessionRow = {
+  id: string;
+  token_hash: string;
+  credential_id: string;
+  created_at: string;
+  expires_at: string;
+  revoked_at: string | null;
+};
+
+export type PasskeyContext = {
+  request: Request;
+  url: URL;
+  locals: App.Locals;
+  cookies: {
+    get(name: string): { value: string } | undefined;
+  };
+};
+
+export type PasskeyStatus = {
+  available: boolean;
+  mode: "ready" | "missing_db";
+  credential_count: number;
+  has_session: boolean;
+  can_register: boolean;
+  access_identity_present: boolean;
+  access_identity_hint: string | null;
+  expected_origin: string;
+  current_origin: string;
+  next_safe_action: string;
+};
+
+export function json(data: unknown, init?: ResponseInit): Response {
+  return Response.json(data, {
+    ...init,
+    headers: {
+      "cache-control": "no-store",
+      ...(init?.headers ?? {}),
+    },
+  });
+}
+
+export function handlePasskeyError(error: unknown): Response {
+  if (error instanceof Response) return error;
+  return json(
+    {
+      error: "passkey_request_failed",
+      detail: error instanceof Error ? error.message : "unknown error",
+    },
+    { status: 400 },
+  );
+}
+
+export async function getPasskeyStatus(
+  context: PasskeyContext,
+): Promise<PasskeyStatus> {
+  const db = dbFromContext(context);
+  const accessIdentity = accessIdentityHint(context);
+  if (!db) {
+    return {
+      available: false,
+      mode: "missing_db",
+      credential_count: 0,
+      has_session: false,
+      can_register: false,
+      access_identity_present: Boolean(accessIdentity),
+      access_identity_hint: accessIdentity,
+      expected_origin: EXPECTED_ORIGIN,
+      current_origin: context.url.origin,
+      next_safe_action:
+        "deploy with DB binding and apply migration before enrollment",
+    };
+  }
+
+  let credentialCount = 0;
+  let session: SessionRow | null = null;
+  try {
+    credentialCount = await countActiveCredentials(db);
+    session = await getSession(context, db);
+  } catch (error) {
+    if (!isMissingPasskeyTable(error)) throw error;
+    return {
+      available: false,
+      mode: "missing_db",
+      credential_count: 0,
+      has_session: false,
+      can_register: false,
+      access_identity_present: Boolean(accessIdentity),
+      access_identity_hint: accessIdentity,
+      expected_origin: EXPECTED_ORIGIN,
+      current_origin: context.url.origin,
+      next_safe_action:
+        "apply drizzle/migrations/0006_admin_passkeys.sql before enrollment",
+    };
+  }
+  const canRegister =
+    Boolean(session) || (credentialCount === 0 && Boolean(accessIdentity));
+
+  return {
+    available: true,
+    mode: "ready",
+    credential_count: credentialCount,
+    has_session: Boolean(session),
+    can_register: canRegister,
+    access_identity_present: Boolean(accessIdentity),
+    access_identity_hint: accessIdentity,
+    expected_origin: EXPECTED_ORIGIN,
+    current_origin: context.url.origin,
+    next_safe_action: session
+      ? "passkey session active"
+      : "register the first passkey while Cloudflare Access identity is present",
+  };
+}
+
+export async function hasActivePasskeySession(
+  context: PasskeyContext,
+): Promise<boolean> {
+  const db = dbFromContext(context);
+  if (!db) return false;
+  try {
+    return Boolean(await getSession(context, db));
+  } catch {
+    return false;
+  }
+}
+
+export async function registrationOptions(
+  context: PasskeyContext,
+): Promise<Response> {
+  const db = requiredDb(context);
+  const status = await getPasskeyStatus(context);
+  if (!status.can_register) {
+    return json(
+      {
+        error: "registration_not_allowed",
+        next_safe_action:
+          "authenticate first or register while Cloudflare Access identity is present",
+      },
+      { status: 403 },
+    );
+  }
+
+  const credentials = await listActiveCredentials(db);
+  const options = await generateRegistrationOptions({
+    rpName: RP_NAME,
+    rpID: RP_ID,
+    userID: new TextEncoder().encode(USER_ID),
+    userName: USER_NAME,
+    userDisplayName: USER_DISPLAY_NAME,
+    attestationType: "none",
+    authenticatorSelection: {
+      authenticatorAttachment: "platform",
+      residentKey: "preferred",
+      userVerification: "required",
+    },
+    excludeCredentials: credentials.map((credential) => ({
+      id: credential.credential_id,
+      transports: parseTransports(credential.transports),
+    })),
+    timeout: 90_000,
+  });
+
+  await storeChallenge(db, "registration", options.challenge);
+  return json(options);
+}
+
+export async function verifyRegistration(
+  context: PasskeyContext,
+): Promise<Response> {
+  const db = requiredDb(context);
+  const body = (await context.request.json()) as RegistrationResponseJSON;
+  const challenge = await consumeChallenge(db, "registration");
+  const result = await verifyRegistrationResponse({
+    response: body,
+    expectedChallenge: challenge.challenge,
+    expectedOrigin: expectedOrigin(context),
+    expectedRPID: RP_ID,
+    requireUserVerification: true,
+  });
+
+  if (!result.verified) {
+    return json(
+      { verified: false, error: "registration_verification_failed" },
+      { status: 400 },
+    );
+  }
+
+  const info = result.registrationInfo;
+  await db
+    .prepare(
+      `INSERT INTO admin_passkey_credentials
+        (id, user_id, credential_id, public_key, counter, transports, device_type, backed_up, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .bind(
+      randomId(),
+      USER_ID,
+      info.credential.id,
+      bytesToBase64Url(info.credential.publicKey),
+      info.credential.counter,
+      JSON.stringify(body.response.transports ?? []),
+      info.credentialDeviceType,
+      info.credentialBackedUp ? 1 : 0,
+      nowIso(),
+      nowIso(),
+    )
+    .run();
+
+  return json({
+    verified: true,
+    next_safe_action: "use authenticate to create an app-native session",
+  });
+}
+
+export async function authenticationOptions(
+  context: PasskeyContext,
+): Promise<Response> {
+  const db = requiredDb(context);
+  const credentials = await listActiveCredentials(db);
+  if (credentials.length === 0) {
+    return json(
+      {
+        error: "no_credentials",
+        next_safe_action: "register the first passkey behind Cloudflare Access",
+      },
+      { status: 409 },
+    );
+  }
+
+  const options = await generateAuthenticationOptions({
+    rpID: RP_ID,
+    allowCredentials: credentials.map((credential) => ({
+      id: credential.credential_id,
+      transports: parseTransports(credential.transports),
+    })),
+    userVerification: "required",
+    timeout: 90_000,
+  });
+
+  await storeChallenge(db, "authentication", options.challenge);
+  return json(options);
+}
+
+export async function verifyAuthentication(
+  context: PasskeyContext,
+): Promise<Response> {
+  const db = requiredDb(context);
+  const body = (await context.request.json()) as AuthenticationResponseJSON;
+  const credential = await findCredential(db, body.id);
+  if (!credential) {
+    return json(
+      { verified: false, error: "credential_not_found" },
+      { status: 404 },
+    );
+  }
+
+  const challenge = await consumeChallenge(db, "authentication");
+  const result = await verifyAuthenticationResponse({
+    response: body,
+    expectedChallenge: challenge.challenge,
+    expectedOrigin: expectedOrigin(context),
+    expectedRPID: RP_ID,
+    credential: toWebAuthnCredential(credential),
+    requireUserVerification: true,
+  });
+
+  if (!result.verified) {
+    return json(
+      { verified: false, error: "authentication_verification_failed" },
+      { status: 400 },
+    );
+  }
+
+  await db
+    .prepare(
+      `UPDATE admin_passkey_credentials
+       SET counter = ?, device_type = ?, backed_up = ?, last_used_at = ?, updated_at = ?
+       WHERE credential_id = ?`,
+    )
+    .bind(
+      result.authenticationInfo.newCounter,
+      result.authenticationInfo.credentialDeviceType,
+      result.authenticationInfo.credentialBackedUp ? 1 : 0,
+      nowIso(),
+      nowIso(),
+      credential.credential_id,
+    )
+    .run();
+
+  const token = randomToken();
+  const tokenHash = await hashToken(token);
+  const expires = new Date(
+    Date.now() + SESSION_MAX_AGE_SECONDS * 1000,
+  ).toISOString();
+  await db
+    .prepare(
+      `INSERT INTO admin_passkey_sessions
+        (id, token_hash, credential_id, created_at, expires_at, last_seen_at)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    )
+    .bind(
+      randomId(),
+      tokenHash,
+      credential.credential_id,
+      nowIso(),
+      expires,
+      nowIso(),
+    )
+    .run();
+
+  return json(
+    {
+      verified: true,
+      next_safe_action: "passkey session active",
+    },
+    { headers: { "set-cookie": sessionCookie(token) } },
+  );
+}
+
+export async function logout(context: PasskeyContext): Promise<Response> {
+  const db = dbFromContext(context);
+  const token = context.cookies.get(PASSKEY_SESSION_COOKIE)?.value;
+  if (db && token) {
+    const tokenHash = await hashToken(token);
+    await db
+      .prepare(
+        `UPDATE admin_passkey_sessions
+         SET revoked_at = ?, updated_at = ?
+         WHERE token_hash = ? AND revoked_at IS NULL`,
+      )
+      .bind(nowIso(), nowIso(), tokenHash)
+      .run();
+  }
+
+  return json(
+    { ok: true, next_safe_action: "passkey session cleared" },
+    { headers: { "set-cookie": expiredSessionCookie() } },
+  );
+}
+
+export function dbFromContext(context: PasskeyContext): D1Database | null {
+  return context.locals.runtime?.env.DB ?? null;
+}
+
+function requiredDb(context: PasskeyContext): D1Database {
+  const db = dbFromContext(context);
+  if (!db) {
+    throw json(
+      {
+        error: "db_binding_missing",
+        next_safe_action:
+          "deploy with DB binding and apply migration before enrollment",
+      },
+      { status: 503 },
+    );
+  }
+  return db;
+}
+
+async function listActiveCredentials(db: D1Database): Promise<CredentialRow[]> {
+  const result = await db
+    .prepare(
+      `SELECT * FROM admin_passkey_credentials
+       WHERE user_id = ? AND revoked_at IS NULL
+       ORDER BY created_at ASC`,
+    )
+    .bind(USER_ID)
+    .all<CredentialRow>();
+  return result.results ?? [];
+}
+
+async function countActiveCredentials(db: D1Database): Promise<number> {
+  const row = await db
+    .prepare(
+      `SELECT COUNT(*) AS count FROM admin_passkey_credentials
+       WHERE user_id = ? AND revoked_at IS NULL`,
+    )
+    .bind(USER_ID)
+    .first<{ count: number }>();
+  return Number(row?.count ?? 0);
+}
+
+async function findCredential(
+  db: D1Database,
+  credentialId: string,
+): Promise<CredentialRow | null> {
+  return db
+    .prepare(
+      `SELECT * FROM admin_passkey_credentials
+       WHERE credential_id = ? AND revoked_at IS NULL`,
+    )
+    .bind(credentialId)
+    .first<CredentialRow>();
+}
+
+async function storeChallenge(
+  db: D1Database,
+  purpose: ChallengePurpose,
+  challenge: string,
+): Promise<void> {
+  const expiresAt = new Date(Date.now() + CHALLENGE_MAX_AGE_MS).toISOString();
+  await db
+    .prepare(
+      `INSERT INTO admin_passkey_challenges
+        (id, purpose, challenge, created_at, expires_at)
+       VALUES (?, ?, ?, ?, ?)`,
+    )
+    .bind(randomId(), purpose, challenge, nowIso(), expiresAt)
+    .run();
+}
+
+async function consumeChallenge(
+  db: D1Database,
+  purpose: ChallengePurpose,
+): Promise<ChallengeRow> {
+  const row = await db
+    .prepare(
+      `SELECT * FROM admin_passkey_challenges
+       WHERE purpose = ? AND used_at IS NULL AND expires_at > ?
+       ORDER BY created_at DESC
+       LIMIT 1`,
+    )
+    .bind(purpose, nowIso())
+    .first<ChallengeRow>();
+
+  if (!row) {
+    throw json({ error: "challenge_missing_or_expired" }, { status: 400 });
+  }
+
+  await db
+    .prepare(
+      `UPDATE admin_passkey_challenges
+       SET used_at = ?
+       WHERE id = ? AND used_at IS NULL`,
+    )
+    .bind(nowIso(), row.id)
+    .run();
+  return row;
+}
+
+async function getSession(
+  context: PasskeyContext,
+  db: D1Database,
+): Promise<SessionRow | null> {
+  const token = context.cookies.get(PASSKEY_SESSION_COOKIE)?.value;
+  if (!token) return null;
+  const tokenHash = await hashToken(token);
+  const row = await db
+    .prepare(
+      `SELECT * FROM admin_passkey_sessions
+       WHERE token_hash = ? AND revoked_at IS NULL AND expires_at > ?
+       LIMIT 1`,
+    )
+    .bind(tokenHash, nowIso())
+    .first<SessionRow>();
+  if (!row) return null;
+  await db
+    .prepare(
+      `UPDATE admin_passkey_sessions
+       SET last_seen_at = ?, updated_at = ?
+       WHERE id = ?`,
+    )
+    .bind(nowIso(), nowIso(), row.id)
+    .run();
+  return row;
+}
+
+function toWebAuthnCredential(row: CredentialRow): WebAuthnCredential {
+  return {
+    id: row.credential_id,
+    publicKey: base64UrlToBytes(row.public_key),
+    counter: row.counter,
+    transports: parseTransports(row.transports),
+  };
+}
+
+function parseTransports(raw: string): AuthenticatorTransportFuture[] {
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(
+      (item): item is AuthenticatorTransportFuture => typeof item === "string",
+    );
+  } catch {
+    return [];
+  }
+}
+
+function expectedOrigin(context: PasskeyContext): string {
+  const origin = context.request.headers.get("origin");
+  if (origin === LOCAL_ORIGIN && import.meta.env.DEV) return LOCAL_ORIGIN;
+  return EXPECTED_ORIGIN;
+}
+
+function accessIdentityHint(context: PasskeyContext): string | null {
+  const email = context.request.headers.get(
+    "cf-access-authenticated-user-email",
+  );
+  if (!email) return import.meta.env.DEV ? "local-dev" : null;
+  const [name, domain] = email.split("@");
+  if (!name || !domain) return "access-user";
+  return `${name.slice(0, 2)}***@${domain}`;
+}
+
+function sessionCookie(token: string): string {
+  return [
+    `${PASSKEY_SESSION_COOKIE}=${token}`,
+    "Path=/",
+    `Max-Age=${SESSION_MAX_AGE_SECONDS}`,
+    "HttpOnly",
+    "Secure",
+    "SameSite=Lax",
+  ].join("; ");
+}
+
+function expiredSessionCookie(): string {
+  return [
+    `${PASSKEY_SESSION_COOKIE}=`,
+    "Path=/",
+    "Max-Age=0",
+    "HttpOnly",
+    "Secure",
+    "SameSite=Lax",
+  ].join("; ");
+}
+
+function randomId(): string {
+  return crypto.randomUUID();
+}
+
+function randomToken(): string {
+  return bytesToBase64Url(crypto.getRandomValues(new Uint8Array(32)));
+}
+
+async function hashToken(token: string): Promise<string> {
+  const bytes = new TextEncoder().encode(token);
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  return bytesToHex(new Uint8Array(digest));
+}
+
+function bytesToBase64Url(bytes: Uint8Array): string {
+  return btoa(String.fromCharCode(...bytes))
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replaceAll("=", "");
+}
+
+function base64UrlToBytes(value: string): Uint8Array<ArrayBuffer> {
+  const padded = value
+    .replaceAll("-", "+")
+    .replaceAll("_", "/")
+    .padEnd(Math.ceil(value.length / 4) * 4, "=");
+  const binary = atob(padded);
+  const bytes = new Uint8Array(new ArrayBuffer(binary.length));
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return bytes;
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return [...bytes].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function isMissingPasskeyTable(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    error.message.includes("admin_passkey_") &&
+    error.message.includes("no such table")
+  );
+}

--- a/apps/admin/src/middleware.ts
+++ b/apps/admin/src/middleware.ts
@@ -1,6 +1,6 @@
 import { defineMiddleware } from "astro:middleware";
+import { hasActivePasskeySession } from "./lib/passkey-auth";
 
-const SESSION_COOKIE = "admin_passkey_session";
 const PUBLIC_PATHS = [
   "/auth/passkey",
   "/api/health",
@@ -12,7 +12,7 @@ const PUBLIC_PATHS = [
 export const onRequest = defineMiddleware(async (context, next) => {
   if (isPublicPath(context.url.pathname)) return next();
 
-  const hasSession = await hasActiveSession(context);
+  const hasSession = await hasActivePasskeySession(context);
   if (hasSession) return next();
 
   const nextPath = encodeURIComponent(
@@ -24,37 +24,8 @@ export const onRequest = defineMiddleware(async (context, next) => {
 function isPublicPath(pathname: string): boolean {
   return (
     PUBLIC_PATHS.includes(pathname) ||
+    pathname.startsWith("/api/admin/passkey/") ||
     pathname.startsWith("/_astro/") ||
     pathname.startsWith("/assets/")
   );
-}
-
-async function hasActiveSession(context: {
-  cookies: { get(name: string): { value: string } | undefined };
-  locals: App.Locals;
-}): Promise<boolean> {
-  const token = context.cookies.get(SESSION_COOKIE)?.value;
-  const db = context.locals.runtime?.env.DB;
-  if (!token || !db) return false;
-
-  const tokenHash = await hashToken(token);
-  const row = await db
-    .prepare(
-      `SELECT id FROM admin_passkey_sessions
-       WHERE token_hash = ? AND revoked_at IS NULL AND expires_at > ?
-       LIMIT 1`,
-    )
-    .bind(tokenHash, new Date().toISOString())
-    .first<{ id: string }>();
-
-  context.locals.passkeySessionActive = Boolean(row);
-  return Boolean(row);
-}
-
-async function hashToken(token: string): Promise<string> {
-  const bytes = new TextEncoder().encode(token);
-  const digest = await crypto.subtle.digest("SHA-256", bytes);
-  return [...new Uint8Array(digest)]
-    .map((byte) => byte.toString(16).padStart(2, "0"))
-    .join("");
 }

--- a/apps/admin/src/pages/api/admin/passkey/login-options.ts
+++ b/apps/admin/src/pages/api/admin/passkey/login-options.ts
@@ -1,0 +1,13 @@
+import type { APIRoute } from "astro";
+import {
+  authenticationOptions,
+  handlePasskeyError,
+} from "../../../../lib/passkey-auth";
+
+export const POST: APIRoute = async (context) => {
+  try {
+    return await authenticationOptions(context);
+  } catch (error) {
+    return handlePasskeyError(error);
+  }
+};

--- a/apps/admin/src/pages/api/admin/passkey/login-verify.ts
+++ b/apps/admin/src/pages/api/admin/passkey/login-verify.ts
@@ -1,0 +1,13 @@
+import type { APIRoute } from "astro";
+import {
+  handlePasskeyError,
+  verifyAuthentication,
+} from "../../../../lib/passkey-auth";
+
+export const POST: APIRoute = async (context) => {
+  try {
+    return await verifyAuthentication(context);
+  } catch (error) {
+    return handlePasskeyError(error);
+  }
+};

--- a/apps/admin/src/pages/api/admin/passkey/logout.ts
+++ b/apps/admin/src/pages/api/admin/passkey/logout.ts
@@ -1,0 +1,10 @@
+import type { APIRoute } from "astro";
+import { handlePasskeyError, logout } from "../../../../lib/passkey-auth";
+
+export const POST: APIRoute = async (context) => {
+  try {
+    return await logout(context);
+  } catch (error) {
+    return handlePasskeyError(error);
+  }
+};

--- a/apps/admin/src/pages/api/admin/passkey/register-options.ts
+++ b/apps/admin/src/pages/api/admin/passkey/register-options.ts
@@ -1,0 +1,13 @@
+import type { APIRoute } from "astro";
+import {
+  handlePasskeyError,
+  registrationOptions,
+} from "../../../../lib/passkey-auth";
+
+export const POST: APIRoute = async (context) => {
+  try {
+    return await registrationOptions(context);
+  } catch (error) {
+    return handlePasskeyError(error);
+  }
+};

--- a/apps/admin/src/pages/api/admin/passkey/register-verify.ts
+++ b/apps/admin/src/pages/api/admin/passkey/register-verify.ts
@@ -1,0 +1,13 @@
+import type { APIRoute } from "astro";
+import {
+  handlePasskeyError,
+  verifyRegistration,
+} from "../../../../lib/passkey-auth";
+
+export const POST: APIRoute = async (context) => {
+  try {
+    return await verifyRegistration(context);
+  } catch (error) {
+    return handlePasskeyError(error);
+  }
+};

--- a/apps/admin/src/pages/api/admin/passkey/status.ts
+++ b/apps/admin/src/pages/api/admin/passkey/status.ts
@@ -1,0 +1,5 @@
+import type { APIRoute } from "astro";
+import { getPasskeyStatus, json } from "../../../../lib/passkey-auth";
+
+export const GET: APIRoute = async (context) =>
+  json(await getPasskeyStatus(context));

--- a/apps/admin/src/pages/auth/passkey.astro
+++ b/apps/admin/src/pages/auth/passkey.astro
@@ -4,32 +4,23 @@ import AdminLayout from "../../layouts/AdminLayout.astro";
 
 <AdminLayout
   title="passkey auth"
-  deck="Astro admin auth boundary. Registration UI is still being ported from admin-solid."
+  deck="Biometric passkey auth is staged here before Cloudflare Access is removed from the canonical admin route."
 >
   <section class="grid">
     <article class="panel">
-      <p>state</p>
-      <h2>app-native session required</h2>
-      <p>
-        Protected Astro admin routes check the D1-backed
-        <code>admin_passkey_session</code> cookie before rendering.
-      </p>
+      <p>database</p>
+      <h2 id="passkey-db">checking</h2>
+      <p id="passkey-origin">expected origin: admin.anipotts.com</p>
     </article>
     <article class="panel">
-      <p>next</p>
-      <h2>port WebAuthn actions</h2>
-      <p>
-        Move register, login, logout, revoke, and status handlers from
-        admin-solid into this Astro app.
-      </p>
+      <p>credentials</p>
+      <h2 id="passkey-credentials">0</h2>
+      <p id="passkey-register-state">registration requires Access identity</p>
     </article>
     <article class="panel">
-      <p>Access removal</p>
-      <h2>blocked by proof</h2>
-      <p>
-        Cloudflare Access stays on until passkey registration and login are
-        proven.
-      </p>
+      <p>session</p>
+      <h2 id="passkey-session">inactive</h2>
+      <p id="passkey-next">loading</p>
     </article>
     <article class="panel">
       <p>rollback</p>
@@ -37,13 +28,189 @@ import AdminLayout from "../../layouts/AdminLayout.astro";
       <p>Rollback is the prior Cloudflare Access app or policy.</p>
     </article>
   </section>
+
   <div class="actions">
-    <button class="button" disabled>register passkey</button>
-    <button class="button secondary" disabled>authenticate</button>
-    <button class="button secondary" disabled>logout</button>
+    <button class="button" id="register-passkey" type="button">
+      register passkey
+    </button>
+    <button class="button secondary" id="login-passkey" type="button">
+      authenticate
+    </button>
+    <button class="button secondary" id="logout-passkey" type="button">
+      logout
+    </button>
   </div>
-  <div class="notice">
-    These controls are inert in the first Astro shell. They mark the exact route
-    where the WebAuthn actions will land.
-  </div>
+
+  <p class="notice" id="passkey-message">
+    Cloudflare Access must remain on until registration, login, logout, session
+    persistence, revoked credential denial, and unauthenticated blocking are
+    proven.
+  </p>
 </AdminLayout>
+
+<script>
+  import {
+    startAuthentication,
+    startRegistration,
+  } from "@simplewebauthn/browser";
+  import type {
+    PublicKeyCredentialCreationOptionsJSON,
+    PublicKeyCredentialRequestOptionsJSON,
+  } from "@simplewebauthn/server";
+
+  type ApiResult = {
+    verified?: boolean;
+    ok?: boolean;
+    error?: string;
+    detail?: string;
+    next_safe_action?: string;
+  };
+
+  type PasskeyStatus = {
+    available: boolean;
+    mode: "ready" | "missing_db";
+    credential_count: number;
+    has_session: boolean;
+    can_register: boolean;
+    access_identity_present: boolean;
+    access_identity_hint: string | null;
+    expected_origin: string;
+    current_origin: string;
+    next_safe_action: string;
+  };
+
+  const dbLabel = document.querySelector("#passkey-db");
+  const originLabel = document.querySelector("#passkey-origin");
+  const credentialsLabel = document.querySelector("#passkey-credentials");
+  const registerState = document.querySelector("#passkey-register-state");
+  const sessionLabel = document.querySelector("#passkey-session");
+  const nextLabel = document.querySelector("#passkey-next");
+  const message = document.querySelector("#passkey-message");
+  const registerButton = document.querySelector<HTMLButtonElement>(
+    "#register-passkey",
+  );
+  const loginButton = document.querySelector<HTMLButtonElement>("#login-passkey");
+  const logoutButton =
+    document.querySelector<HTMLButtonElement>("#logout-passkey");
+
+  let status: PasskeyStatus | null = null;
+
+  registerButton?.addEventListener("click", () => void register());
+  loginButton?.addEventListener("click", () => void authenticate());
+  logoutButton?.addEventListener("click", () => void logout());
+
+  await refreshStatus();
+
+  async function refreshStatus() {
+    const response = await fetch("/api/admin/passkey/status", {
+      cache: "no-store",
+    });
+    status = (await response.json()) as PasskeyStatus;
+    renderStatus();
+  }
+
+  function renderStatus() {
+    if (!status) return;
+    setText(dbLabel, status.available ? "available" : "missing");
+    setText(
+      originLabel,
+      `expected ${status.expected_origin}; current ${status.current_origin}`,
+    );
+    setText(credentialsLabel, String(status.credential_count));
+    setText(
+      registerState,
+      status.can_register
+        ? "registration allowed"
+        : "registration locked until Access identity or active session",
+    );
+    setText(sessionLabel, status.has_session ? "active" : "inactive");
+    setText(nextLabel, status.next_safe_action);
+    if (registerButton) registerButton.disabled = !status.can_register;
+    if (loginButton) loginButton.disabled = !status.available;
+    if (logoutButton) logoutButton.disabled = !status.has_session;
+  }
+
+  async function register() {
+    await withBusy("starting passkey registration", async () => {
+      const options = await postJson<PublicKeyCredentialCreationOptionsJSON>(
+        "/api/admin/passkey/register-options",
+      );
+      const credential = await startRegistration({ optionsJSON: options });
+      const result = await postJson(
+        "/api/admin/passkey/register-verify",
+        credential,
+      );
+      setText(message, result.next_safe_action ?? "passkey registered");
+      await refreshStatus();
+    });
+  }
+
+  async function authenticate() {
+    await withBusy("starting passkey authentication", async () => {
+      const options = await postJson<PublicKeyCredentialRequestOptionsJSON>(
+        "/api/admin/passkey/login-options",
+      );
+      const assertion = await startAuthentication({ optionsJSON: options });
+      const result = await postJson(
+        "/api/admin/passkey/login-verify",
+        assertion,
+      );
+      setText(message, result.next_safe_action ?? "passkey session active");
+      await refreshStatus();
+    });
+  }
+
+  async function logout() {
+    await withBusy("clearing passkey session", async () => {
+      const result = await postJson("/api/admin/passkey/logout");
+      setText(message, result.next_safe_action ?? "session cleared");
+      await refreshStatus();
+    });
+  }
+
+  async function withBusy(label: string, action: () => Promise<void>) {
+    setBusy(true);
+    setText(message, label);
+    try {
+      await action();
+    } catch (error) {
+      setText(message, errorMessage(error));
+    } finally {
+      setBusy(false);
+      renderStatus();
+    }
+  }
+
+  async function postJson<TResponse = ApiResult>(
+    path: string,
+    body?: unknown,
+  ): Promise<TResponse> {
+    const response = await fetch(path, {
+      method: "POST",
+      headers: body ? { "content-type": "application/json" } : undefined,
+      body: body ? JSON.stringify(body) : undefined,
+    });
+    const data = (await response.json()) as TResponse;
+    const apiData = data as ApiResult;
+    if (!response.ok) {
+      throw new Error(
+        apiData.detail ?? apiData.error ?? `request failed: ${response.status}`,
+      );
+    }
+    return data;
+  }
+
+  function setBusy(busy: boolean) {
+    if (registerButton) registerButton.disabled = busy || !status?.can_register;
+    if (loginButton) loginButton.disabled = busy || !status?.available;
+    if (logoutButton) logoutButton.disabled = busy || !status?.has_session;
+  }
+
+  function setText(node: Element | null, value: string) {
+    if (node) node.textContent = value;
+  }
+
+  function errorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : "passkey request failed";
+  }
+</script>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,12 @@ importers:
       '@astrojs/cloudflare':
         specifier: ^12.6.0
         version: 12.6.13(@types/node@22.19.19)(astro@5.18.2(@types/node@22.19.19)(aws4fetch@1.0.20)(db0@0.3.4(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260518.1)(@opentelemetry/api@1.9.0)))(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.59.0)(terser@5.47.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0))(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0)
+      '@simplewebauthn/browser':
+        specifier: 13.3.0
+        version: 13.3.0
+      '@simplewebauthn/server':
+        specifier: 13.3.2
+        version: 13.3.2
       astro:
         specifier: ^5.16.0
         version: 5.18.2(@types/node@22.19.19)(aws4fetch@1.0.20)(db0@0.3.4(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260518.1)(@opentelemetry/api@1.9.0)))(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.59.0)(terser@5.47.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0)


### PR DESCRIPTION
## summary
- port passkey status, registration, authentication, and logout helpers from admin-solid into apps/admin
- add Astro API endpoints under /api/admin/passkey/* and wire /auth/passkey to real WebAuthn controls
- keep first enrollment gated by Cloudflare Access identity or an existing passkey session so legacy-admin cannot claim the empty credential store

## verification
- pnpm --filter @anipotts/admin lint
- pnpm --filter @anipotts/admin typecheck
- pnpm --filter @anipotts/admin build
- pnpm exec wrangler --cwd apps/admin deploy --dry-run
- local curl smoke: /auth/passkey 200, /api/admin/passkey/status 200, /api/health 200, protected routes redirect to /auth/passkey
- read-only D1 check: admin_passkey_credentials=0, admin_passkey_sessions=0, admin_passkey_challenges=0, rows_written=0

## notes
- Browser runtime control was unavailable in this thread, so rendered validation used local server plus HTTP proof.
- Cloudflare Access removal is still blocked until the Astro admin is on the canonical protected host and passkey register/login/logout/session proof succeeds.
- no secrets, env values, write-paths, D1 writes, DNS changes, or Access policy changes in this PR