### PR TITLE
deploy: cut over astro admin route

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -168,10 +168,14 @@ jobs:
 
   deploy-admin:
     name: Deploy admin
-    needs: [changes]
+    needs: [changes, deploy-admin-solid]
     if: >
-      (github.event_name == 'workflow_dispatch' && inputs.admin == 'true') ||
-      (github.event_name == 'push' && needs.changes.outputs.admin == 'true')
+      always() &&
+      (needs['deploy-admin-solid'].result == 'success' || needs['deploy-admin-solid'].result == 'skipped') &&
+      (
+        (github.event_name == 'workflow_dispatch' && inputs.admin == 'true') ||
+        (github.event_name == 'push' && needs.changes.outputs.admin == 'true')
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,8 +39,8 @@ For admin UI, feed, content review, auth staging, and operator-dashboard work:
 - deploy only the affected admin target
 - record deploy run, skipped targets, and route proof
 
-`apps/admin-solid` is transitional. Move parity into `apps/admin`, prove it, then
-archive or remove `apps/admin-solid`.
+`apps/admin-solid` is legacy rollback. Keep it only until the Astro admin
+cutover and passkey proof are complete, then archive or remove it.
 
 Approved includes reviewed D1 migrations needed by the green PR, passkey auth
 rollout, and Cloudflare Access removal after passkey proof.
@@ -67,7 +67,7 @@ For `admin.anipotts.com`, use this order:
 
 1. merge the reviewed passkey PR
 2. apply its reviewed D1 migration to `anipotts-db`
-3. deploy `admin_solid=true` only
+3. deploy `admin=true` only
 4. prove passkey register, login, logout, session persistence, and blocked
    failure paths
 5. prove `/auth/passkey`, `/`, `/content`, `/content/review`, and `/needs-ani`

--- a/apps/admin-solid/wrangler.toml
+++ b/apps/admin-solid/wrangler.toml
@@ -21,10 +21,10 @@ database_id = "a8aadf73-bbf4-447c-97db-cb3e50b4e26f"
 [vars]
 PUBLIC_STATE_API = "https://api.anipotts.com"
 
-# Custom domain bound 2026-05-14 via CF API. Lives at admin.anipotts.com,
-# fronted by the existing Cloudflare Access policy that previously protected
-# the legacy Next admin (which now serves at legacy-admin.anipotts.com).
+# Legacy rollback route after apps/admin claims the canonical admin.anipotts.com
+# custom domain. Do not restore this worker to the canonical route unless
+# rolling back the Astro admin cutover.
 [[routes]]
-pattern = "admin.anipotts.com"
+pattern = "legacy-admin-solid.anipotts.com"
 custom_domain = true
 zone_id = "d56476e2905a2a19ad86aaa4b7c719c2"

--- a/apps/admin/wrangler.toml
+++ b/apps/admin/wrangler.toml
@@ -5,10 +5,10 @@ account_id = "0f856093bdcd34a7da1bde5ee4385163"
 main = "./dist/_worker.js/index.js"
 workers_dev = false
 
-# Transitional custom domain while the Astro admin reaches parity. The canonical
-# admin.anipotts.com route still belongs to apps/admin-solid until cutover proof.
+# Canonical admin route. Cloudflare Access remains in front until app-native
+# passkey proof is complete and Access removal is separately verified.
 [[routes]]
-pattern = "legacy-admin.anipotts.com"
+pattern = "admin.anipotts.com"
 custom_domain = true
 zone_id = "d56476e2905a2a19ad86aaa4b7c719c2"
 

--- a/docs/platform-architecture.md
+++ b/docs/platform-architecture.md
@@ -10,8 +10,8 @@ structured content/state model, and one predictable CI/CD path.
 | Surface        | Target                                    | Status                   | Next action                                               |
 | -------------- | ----------------------------------------- | ------------------------ | --------------------------------------------------------- |
 | public site    | `apps/www`                                | keep                     | keep as Astro public app for `anipotts.com`               |
-| admin site     | `apps/admin`                              | Astro shell started      | port admin-solid behavior and then cut over               |
-| current admin  | `apps/admin-solid`                        | migrate then remove      | port routes into `apps/admin`, then archive or delete     |
+| admin site     | `apps/admin`                              | canonical cutover        | prove passkey registration and then remove Access         |
+| current admin  | `apps/admin-solid`                        | legacy rollback          | keep briefly on legacy route, then archive or delete      |
 | legacy admin   | old Next.js code in `apps/admin`          | replace in place         | keep only useful models while rebuilding Astro admin      |
 | labs           | `apps/labs`                               | archive/delete candidate | preserve useful content docs, then remove app target      |
 | workers        | `workers/*`                               | review individually      | keep only production-required workers                     |
@@ -22,12 +22,12 @@ structured content/state model, and one predictable CI/CD path.
 
 ### apps
 
-| Path               | Role today                                      | Classification           |
-| ------------------ | ----------------------------------------------- | ------------------------ |
-| `apps/www`         | public Astro site and newsletter endpoints      | keep                     |
-| `apps/admin-solid` | live protected admin dashboard, passkey staging | migrate                  |
-| `apps/admin`       | Astro admin shell on legacy route               | migrate to canonical     |
-| `apps/labs`        | legacy Next.js labs surface                     | archive/delete candidate |
+| Path               | Role today                                 | Classification           |
+| ------------------ | ------------------------------------------ | ------------------------ |
+| `apps/www`         | public Astro site and newsletter endpoints | keep                     |
+| `apps/admin`       | Astro admin app for `admin.anipotts.com`   | keep                     |
+| `apps/admin-solid` | transitional Solid admin rollback surface  | archive/remove next      |
+| `apps/labs`        | legacy Next.js labs surface                | archive/delete candidate |
 
 ### workers
 


### PR DESCRIPTION
## Summary\n- move canonical admin.anipotts.com from apps/admin-solid to the Astro apps/admin worker\n- keep admin-solid available on legacy-admin-solid.anipotts.com as rollback while passkey proof completes\n- serialize deploy-admin after deploy-admin-solid so a merged push touching both route configs releases the canonical route first\n- update repo docs to treat apps/admin as canonical and admin-solid as rollback/archive-next\n\n## Verification\n- git diff --check\n- python3 YAML parse for .github/workflows/*.yml\n- pnpm exec wrangler --version -> 4.92.0\n- pnpm turbo typecheck --filter=@anipotts/admin...\n- pnpm turbo build --filter=@anipotts/admin...\n- pnpm turbo typecheck --filter=@anipotts/admin-solid...\n- pnpm turbo build --filter=@anipotts/admin-solid...\n- pnpm exec wrangler --cwd apps/admin deploy --dry-run\n- pnpm exec wrangler --cwd apps/admin-solid deploy --dry-run\n\n## Live impact\nOn merge, expected deploy impact is admin-solid first, then admin. Public www, labs, ingest, newsletter, weekly-email, and unrelated workers should skip. Cloudflare Access remains on; no Access policy, DNS, env, secret, D1 data, write-path, or production collector mutation is included.