### PR TITLE
fix: align astro admin canonical state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ This repo owns:
 
 - `anipotts.com`: public Astro site in `apps/www`
 - `admin.anipotts.com`: target Astro admin app in `apps/admin`
-- transitional admin worker in `apps/admin-solid`
+- legacy admin rollback worker in `apps/admin-solid`
 - legacy/reference surfaces in `apps/labs` and retained `workers/*`
 - shared code in `packages/*`
 

--- a/apps/admin/astro.config.mjs
+++ b/apps/admin/astro.config.mjs
@@ -3,7 +3,7 @@ import { defineConfig } from "astro/config";
 import cloudflare from "@astrojs/cloudflare";
 
 export default defineConfig({
-  site: "https://legacy-admin.anipotts.com",
+  site: "https://admin.anipotts.com",
   output: "server",
   trailingSlash: "never",
   adapter: cloudflare({

--- a/apps/admin/src/data/admin.ts
+++ b/apps/admin/src/data/admin.ts
@@ -33,10 +33,10 @@ export const navItems: NavItem[] = [
 
 export const overviewCards: DashboardCard[] = [
   {
-    title: "admin Astro migration",
-    status: "in progress",
-    risk: "medium",
-    next: "port admin-solid route behavior into this Astro target",
+    title: "admin Astro cutover",
+    status: "canonical route cut over",
+    risk: "low",
+    next: "prove passkey behavior, then remove the legacy Solid rollback",
   },
   {
     title: "passkey auth",
@@ -54,7 +54,7 @@ export const overviewCards: DashboardCard[] = [
     title: "legacy cleanup",
     status: "started",
     risk: "low",
-    next: "remove admin-solid after Astro parity and cutover",
+    next: "archive or remove admin-solid after passkey proof",
   },
 ];
 
@@ -115,15 +115,15 @@ export const repoRows: QueueRow[] = [
   },
   {
     title: "apps/admin",
-    owner: "legacy-admin route",
-    status: "Astro target",
-    evidence: "this branch",
+    owner: "admin.anipotts.com",
+    status: "canonical Astro app",
+    evidence: "deploy run 28302990801",
   },
   {
     title: "apps/admin-solid",
-    owner: "admin.anipotts.com",
-    status: "live transitional source",
-    evidence: "deploy run 28301610377",
+    owner: "legacy-admin-solid.anipotts.com",
+    status: "legacy rollback",
+    evidence: "deploy run 28302990801",
   },
 ];
 

--- a/apps/admin/src/layouts/AdminLayout.astro
+++ b/apps/admin/src/layouts/AdminLayout.astro
@@ -25,7 +25,7 @@ const { title = routeTitle(Astro.url.pathname), deck = "" } = Astro.props;
           <span class="brand-mark">a</span>
           <span>
             <strong>anipotts admin</strong>
-            <small>Astro migration</small>
+            <small>Astro canonical</small>
           </span>
         </a>
         <nav>
@@ -48,7 +48,7 @@ const { title = routeTitle(Astro.url.pathname), deck = "" } = Astro.props;
       <main>
         <header class="page-header">
           <div>
-            <p>admin.anipotts.com target</p>
+            <p>admin.anipotts.com</p>
             <h1>{title}</h1>
           </div>
           {deck && <span>{deck}</span>}

--- a/apps/admin/src/pages/api/health.ts
+++ b/apps/admin/src/pages/api/health.ts
@@ -4,5 +4,5 @@ export const GET: APIRoute = () =>
   Response.json({
     ok: true,
     app: "admin-astro",
-    target: "legacy-admin.anipotts.com",
+    target: "admin.anipotts.com",
   });

--- a/apps/admin/src/pages/index.astro
+++ b/apps/admin/src/pages/index.astro
@@ -5,7 +5,7 @@ import { overviewCards } from "../data/admin";
 
 <AdminLayout
   title="operator overview"
-  deck="Read-only Astro admin shell. Live canonical admin remains admin-solid until parity and passkey proof are complete."
+  deck="Canonical Astro admin shell. Cloudflare Access remains only until app-native passkey proof is complete."
 >
   <section class="grid" aria-label="operator overview cards">
     {
@@ -20,8 +20,8 @@ import { overviewCards } from "../data/admin";
     }
   </section>
   <div class="notice">
-    This app is the new Astro target for admin.anipotts.com. It is intentionally
-    protected by the app-native passkey session middleware and currently routed
-    through legacy-admin.anipotts.com while parity is built.
+    This app now owns admin.anipotts.com. It is intentionally protected by the
+    app-native passkey session middleware, with Cloudflare Access kept as the
+    outer guard until passkey proof is complete.
   </div>
 </AdminLayout>

--- a/docs/platform-architecture.md
+++ b/docs/platform-architecture.md
@@ -26,7 +26,7 @@ structured content/state model, and one predictable CI/CD path.
 | ------------------ | ------------------------------------------ | ------------------------ |
 | `apps/www`         | public Astro site and newsletter endpoints | keep                     |
 | `apps/admin`       | Astro admin app for `admin.anipotts.com`   | keep                     |
-| `apps/admin-solid` | transitional Solid admin rollback surface  | archive/remove next      |
+| `apps/admin-solid` | legacy Solid admin rollback surface        | archive/remove next      |
 | `apps/labs`        | legacy Next.js labs surface                | archive/delete candidate |
 
 ### workers


### PR DESCRIPTION
## Summary\n- update Astro admin app metadata after the canonical admin.anipotts.com cutover\n- remove stale legacy-admin/admin-solid-as-canonical labels from health, overview, nav, repo rows, and active docs\n- keep Cloudflare Access and passkey behavior unchanged\n\n## Verification\n- git diff --check\n- rg stale current-state admin labels in apps/admin, CLAUDE.md, docs/platform-architecture.md\n- pnpm turbo typecheck --filter=@anipotts/admin...\n- pnpm turbo build --filter=@anipotts/admin...\n- pnpm exec wrangler --cwd apps/admin deploy --dry-run\n\n## Live impact\nAdmin-only presentation/metadata update. Expected deploy target: admin only. No Cloudflare Access policy, DNS, env, secret, D1 data, write-path, worker, public www, newsletter, ingest, or labs mutation.