### PR TITLE
ci: add state worker deploy target

### DIFF
--- a/.github/workflows/agent-automerge.yml
+++ b/.github/workflows/agent-automerge.yml
@@ -62,6 +62,7 @@ jobs:
           admin_solid=false
           ingest=false
           newsletter=false
+          state=false
           weekly_email=false
 
           while IFS= read -r file; do
@@ -91,6 +92,11 @@ jobs:
                 ;;
             esac
             case "$file" in
+              workers/state/*)
+                state=true
+                ;;
+            esac
+            case "$file" in
               workers/weekly-email/*)
                 weekly_email=true
                 ;;
@@ -103,6 +109,7 @@ jobs:
             echo "admin_solid=$admin_solid"
             echo "ingest=$ingest"
             echo "newsletter=$newsletter"
+            echo "state=$state"
             echo "weekly_email=$weekly_email"
           } >> "$GITHUB_OUTPUT"
 
@@ -119,6 +126,7 @@ jobs:
           steps.targets.outputs.admin_solid == 'true' ||
           steps.targets.outputs.ingest == 'true' ||
           steps.targets.outputs.newsletter == 'true' ||
+          steps.targets.outputs.state == 'true' ||
           steps.targets.outputs.weekly_email == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -132,4 +140,5 @@ jobs:
             -f admin_solid=${{ steps.targets.outputs.admin_solid }} \
             -f ingest=${{ steps.targets.outputs.ingest }} \
             -f newsletter=${{ steps.targets.outputs.newsletter }} \
+            -f state=${{ steps.targets.outputs.state }} \
             -f weekly_email=${{ steps.targets.outputs.weekly_email }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,6 +57,12 @@ on:
         default: "false"
         type: choice
         options: ["false", "true"]
+      state:
+        description: "deploy state worker"
+        required: true
+        default: "false"
+        type: choice
+        options: ["false", "true"]
       weekly_email:
         description: "deploy weekly email worker"
         required: true
@@ -78,6 +84,7 @@ jobs:
       admin-solid: ${{ steps.filter.outputs.admin-solid }}
       ingest: ${{ steps.filter.outputs.ingest }}
       newsletter: ${{ steps.filter.outputs.newsletter }}
+      state: ${{ steps.filter.outputs.state }}
       weekly-email: ${{ steps.filter.outputs.weekly-email }}
     steps:
       - uses: actions/checkout@v4
@@ -105,6 +112,8 @@ jobs:
               - "workers/ingest/**"
             newsletter:
               - "workers/newsletter/**"
+            state:
+              - "workers/state/**"
             weekly-email:
               - "workers/weekly-email/**"
 
@@ -288,6 +297,41 @@ jobs:
         uses: cloudflare/wrangler-action@v3
         with:
           workingDirectory: workers/weekly-email
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+  deploy-state:
+    name: Deploy state worker
+    needs: [changes]
+    if: >
+      (github.event_name == 'workflow_dispatch' && inputs.state == 'true') ||
+      (github.event_name == 'push' && needs.changes.outputs.state == 'true')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: "10.5.2"
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck state worker
+        run: pnpm --filter @anipotts/state typecheck
+
+      - name: Deploy to Cloudflare Workers
+        uses: cloudflare/wrangler-action@v3
+        with:
+          workingDirectory: workers/state
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 

--- a/docs/platform-architecture.md
+++ b/docs/platform-architecture.md
@@ -31,12 +31,12 @@ structured content/state model, and one predictable CI/CD path.
 
 ### workers
 
-| Path                   | Role today               | Classification |
-| ---------------------- | ------------------------ | -------------- |
-| `workers/ingest`       | ingest worker            | review         |
-| `workers/newsletter`   | newsletter queue worker  | review         |
-| `workers/state`        | future fleet state plane | keep candidate |
-| `workers/weekly-email` | weekly email worker      | review         |
+| Path                   | Role today                               | Classification                   |
+| ---------------------- | ---------------------------------------- | -------------------------------- |
+| `workers/ingest`       | ingest worker                            | review                           |
+| `workers/newsletter`   | newsletter queue worker                  | review                           |
+| `workers/state`        | `api.anipotts.com` state plane candidate | keep with explicit deploy target |
+| `workers/weekly-email` | weekly email worker                      | review                           |
 
 ### packages
 

--- a/workers/state/README.md
+++ b/workers/state/README.md
@@ -30,7 +30,9 @@ pnpm --filter @anipotts/state test:cli http://localhost:8787
 pnpm --filter @anipotts/state exec wrangler deploy
 ```
 
-Once deployed, hostname is `https://anipotts-state.<account>.workers.dev`. To bind to `api.anipotts.com`, uncomment the `[[routes]]` block in `wrangler.toml` and re-deploy.
+Production is bound to `api.anipotts.com` by the `[[routes]]` block in
+`wrangler.toml`. Agent PRs that touch `workers/state/**` deploy through the
+explicit `state=true` deploy target.
 
 ## Adding a new DO
 


### PR DESCRIPTION
## summary
- add explicit state worker target to agent automerge target calculation
- add explicit deploy.yml input, path filter, and deploy job for workers/state
- update state worker docs and platform inventory to reflect api.anipotts.com and the state=true deploy target

## deploy impact
- no app or worker deploy expected for this PR because the diff is workflow/docs only
- future workers/state/** changes deploy only the state worker

## verification
- parsed active workflow YAML with Ruby
- pnpm --filter @anipotts/state typecheck
- pnpm exec wrangler --cwd workers/state deploy --dry-run
- pnpm turbo build lint typecheck test --affected --output-logs=errors-only
- git diff --check
- actionlint is not installed locally
