### PR TITLE
ci: typecheck weekly email deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -293,6 +293,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Typecheck weekly email worker
+        run: pnpm --filter anipotts-weekly-email typecheck
+
       - name: Deploy to Cloudflare Workers
         uses: cloudflare/wrangler-action@v3
         with:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -293,6 +293,9 @@ importers:
       '@cloudflare/workers-types':
         specifier: ^4.20260518.1
         version: 4.20260518.1
+      typescript:
+        specifier: ^5
+        version: 5.9.3
       wrangler:
         specifier: ^4.92.0
         version: 4.92.0(@cloudflare/workers-types@4.20260518.1)

--- a/workers/weekly-email/package.json
+++ b/workers/weekly-email/package.json
@@ -4,10 +4,12 @@
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",
-    "dev": "wrangler dev"
+    "dev": "wrangler dev",
+    "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260518.1",
+    "typescript": "^5",
     "wrangler": "^4.92.0"
   }
 }


### PR DESCRIPTION
## summary
- add a weekly-email worker typecheck script and direct TypeScript dev dependency
- run weekly-email typecheck before Cloudflare deploy
- keep this retained worker on the same quality gate pattern as ingest, newsletter, and state

## deploy impact
- weekly_email deploy expected after merge because this touches workers/weekly-email/package.json
- no D1 migration, DNS, auth, secret, env, or outbound-send behavior change

## verification
- parsed active workflow YAML with Ruby
- pnpm install --frozen-lockfile --ignore-scripts
- pnpm --filter anipotts-weekly-email typecheck
- pnpm exec wrangler --cwd workers/weekly-email deploy --dry-run
- pnpm turbo build lint typecheck test --affected --output-logs=errors-only
- git diff --check
