### PR TITLE
ci: smoke routes after deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -159,6 +159,23 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
+      - name: Smoke www routes
+        run: |
+          set -euo pipefail
+          for path in / /projects /writing /newsletter; do
+            ok=false
+            for _ in $(seq 1 6); do
+              code="$(curl -sS -o /dev/null -w '%{http_code}' "https://anipotts.com${path}")"
+              echo "https://anipotts.com${path} -> ${code}"
+              if [ "$code" = "200" ]; then
+                ok=true
+                break
+              fi
+              sleep 10
+            done
+            test "$ok" = "true"
+          done
+
   deploy-admin:
     name: Deploy admin
     needs: [changes, deploy-admin-solid]
@@ -197,6 +214,29 @@ jobs:
           workingDirectory: apps/admin
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Smoke admin unauthenticated block
+        run: |
+          set -euo pipefail
+          for path in /auth/passkey / /content /content/review /content/preview /needs-ani /repos /fleet; do
+            ok=false
+            for _ in $(seq 1 6); do
+              code="$(curl -sS -o /dev/null -w '%{http_code}' "https://admin.anipotts.com${path}")"
+              echo "https://admin.anipotts.com${path} -> ${code}"
+              case "$path:$code" in
+                /auth/passkey:200|/auth/passkey:302|/auth/passkey:401|/auth/passkey:403)
+                  ok=true
+                  break
+                  ;;
+                *:302|*:401|*:403)
+                  ok=true
+                  break
+                  ;;
+              esac
+              sleep 10
+            done
+            test "$ok" = "true"
+          done
 
   deploy-admin-solid:
     name: Deploy admin-solid

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -43,18 +43,13 @@ jobs:
         if: inputs.target == 'admin'
         run: |
           set -euo pipefail
-          login_code="$(curl -sS -o /dev/null -w '%{http_code}' "https://admin.anipotts.com/auth/passkey")"
-          echo "https://admin.anipotts.com/auth/passkey -> ${login_code}"
-          case "$login_code" in
-            200|302|401|403) ;;
-            *) exit 1 ;;
-          esac
-          for path in / /content /content/review /needs-ani; do
+          for path in /auth/passkey / /content /content/review /content/preview /needs-ani /repos /fleet; do
             code="$(curl -sS -o /dev/null -w '%{http_code}' "https://admin.anipotts.com${path}")"
             echo "https://admin.anipotts.com${path} -> ${code}"
-            case "$code" in
-              302|401|403) ;;
-              *) exit 1 ;;
+            case "$path:$code" in
+              /auth/passkey:200|/auth/passkey:302|/auth/passkey:401|/auth/passkey:403) ;;
+              *:302|*:401|*:403) ;;
+              *) exit 1;;
             esac
           done
           echo "commit_sha=${{ inputs.commit_sha }}"

--- a/docs/platform-architecture.md
+++ b/docs/platform-architecture.md
@@ -93,7 +93,7 @@ Primary workflows:
 | `ci.yml`              | build, lint, typecheck, and test affected packages on PR |
 | `agent-automerge.yml` | merge green agent PRs and dispatch exact deploy targets  |
 | `deploy.yml`          | deploy explicit targets only                             |
-| `smoke.yml`           | post-deploy route proof for public and admin targets     |
+| `smoke.yml`           | manual route proof for public and admin targets          |
 
 Rules:
 
@@ -101,6 +101,7 @@ Rules:
 - lockfile and root package changes never deploy every target by default.
 - public site changes deploy `www` only.
 - admin changes deploy only the affected admin target.
+- `deploy.yml` records route proof inside the `www` and `admin` deploy jobs.
 - D1 migrations run as reviewed migration steps before app deploy.
 - Anthropic and Claude Code API-backed GitHub workflows are disabled for this
   repo.


### PR DESCRIPTION
## summary
- add route smoke proof directly after www deploys
- add unauthenticated admin route smoke proof directly after admin deploys
- keep smoke.yml as a manual route-proof workflow and expand admin route coverage
- update platform docs to reflect deploy-time smoke proof

## deploy impact
- no app or worker deploy expected for this PR because the diff is workflow/docs only
- future www/admin deploys will include route proof in the deploy run itself

## verification
- parsed active workflow YAML with Ruby
- manually checked public routes return 200: /, /projects, /writing, /newsletter
- manually checked admin routes return accepted auth-block status: /auth/passkey, /, /content, /content/review, /content/preview, /needs-ani, /repos, /fleet
- pnpm turbo build lint typecheck test --affected --output-logs=errors-only ran with no package tasks for workflow/docs-only diff
- git diff --check
- actionlint is not installed locally
