### PR TITLE
docs: remove stale claude review gate

### DIFF
--- a/docs/admin-newsletter-scope-packet-2026-06-25.md
+++ b/docs/admin-newsletter-scope-packet-2026-06-25.md
@@ -180,8 +180,8 @@ Eligible:
   safe shared read-model code
 - PR declares no write path, no auth change, no env/secrets, no DNS, no worker
   service outside admin-solid
-- required checks are green
-- Claude review and security review pass
+- required GitHub checks are green
+- no Claude/API security review workflow is required or allowed for this repo
 - deploy workflow path filter resolves to `admin_solid=true`
 - all unrelated deploy targets are skipped
 

--- a/docs/admin-next-step-packet-2026-06-25.md
+++ b/docs/admin-next-step-packet-2026-06-25.md
@@ -17,14 +17,18 @@ Open admin PRs:
   - Head: `f95d219`
   - State: open draft
   - Merge state: clean
-  - Checks: CI, security, Claude review, CodeRabbit green
+  - Historical checks then: CI and GitHub review signals green
+  - Superseded gate note: Claude/API security review is now disabled and is not
+    required for this repo
   - Scope: read-only `apps/admin-solid` route and styling
 - PR #87: `Add admin auth and content editing ADR`
   - Branch: `codex/pro/admin-auth-content-adr-2026-06-25`
   - Head: `1274d84`
   - State: open draft
   - Merge state: clean
-  - Checks: CI, security, Claude review, CodeRabbit green
+  - Historical checks then: CI and GitHub review signals green
+  - Superseded gate note: Claude/API security review is now disabled and is not
+    required for this repo
   - Scope: docs-only auth/content ADR, Access audit packet, inert draft
     operation schema
 


### PR DESCRIPTION
## Summary\n- remove stale planning-doc references to Claude/API security review as a required gate\n- align dated admin planning docs with the current GitHub-checks-only posture\n- leave workflows, secrets, auth, deploys, and app code unchanged\n\n## Verification\n- git diff --check\n- rg stale Claude/API gate terms across docs, repo guide, workflows, README, and package metadata\n- verified GitHub repo secrets and variables have no Anthropic/Claude/OpenAI/Codex matches\n- verified branch protection only requires Build, lint, typecheck, test\n\nLive impact: none. Docs-only.