### PR TITLE
feat: add admin newsletter proof surfaces

### DIFF
--- a/apps/admin/src/data/admin.ts
+++ b/apps/admin/src/data/admin.ts
@@ -23,7 +23,9 @@ export const navItems: NavItem[] = [
   { href: "/content", label: "content", status: "live-source" },
   { href: "/content/review", label: "review", status: "live-source" },
   { href: "/content/preview", label: "preview", status: "live-source" },
+  { href: "/newsletter", label: "newsletter", status: "live-source" },
   { href: "/needs-ani", label: "needs ani", status: "live-source" },
+  { href: "/proof", label: "proof", status: "live-source" },
   { href: "/repos", label: "repos", status: "migrating" },
   { href: "/handoffs", label: "handoffs", status: "migrating" },
   { href: "/fleet", label: "fleet", status: "migrating" },
@@ -49,6 +51,18 @@ export const overviewCards: DashboardCard[] = [
     status: "read-only inventory",
     risk: "medium",
     next: "move editable fields into D1-backed draft records",
+  },
+  {
+    title: "proof log",
+    status: "static route proof",
+    risk: "low",
+    next: "move deploy and passkey proof into durable records",
+  },
+  {
+    title: "newsletter drafts",
+    status: "static preview model",
+    risk: "medium",
+    next: "review issue structure in admin before any D1 write or send path",
   },
   {
     title: "legacy cleanup",

--- a/apps/admin/src/data/newsletter.ts
+++ b/apps/admin/src/data/newsletter.ts
@@ -1,0 +1,173 @@
+export type NewsletterClaim = {
+  claim: string;
+  status: "source_backed" | "needs_proof";
+  source_refs: string[];
+};
+
+export type NewsletterSection = {
+  kind: "opening" | "note" | "receipt" | "worklog" | "close";
+  heading?: string;
+  label?: string;
+  body: string;
+  items?: string[];
+  source_refs?: string[];
+  thread_beat?: string;
+};
+
+export type NewsletterDraft = {
+  id: string;
+  slug: string;
+  status: "idea" | "draft" | "preview" | "ready_for_review" | "blocked";
+  title: string;
+  subject: string;
+  summary: string;
+  dek: string;
+  audience: string;
+  source_refs: { ref: string; use: string }[];
+  spine: string[];
+  sections: NewsletterSection[];
+  claims: NewsletterClaim[];
+  blocked_actions: string[];
+  preview_notes: string;
+  source_fixture: string;
+  preview_fixture: string;
+};
+
+export const newsletterDraftsSource = {
+  source_doc: "docs/newsletter-content-structure.md",
+  system_doc: "docs/newsletter-system.md",
+  mode: "read_only_static_draft_preview",
+  blocked:
+    "No D1 write, archive publish, send, schedule, worker, endpoint, DNS, auth, env, or secret mutation.",
+};
+
+export const newsletterDrafts: NewsletterDraft[] = [
+  {
+    id: "newsletter-draft-first-thing-agents-need-control-plane",
+    slug: "first-thing-agents-need-control-plane",
+    status: "idea",
+    title: "the first thing your agents need is a control plane",
+    subject: "the first thing your agents need is a control plane",
+    summary:
+      "every coding agent gets more useful when it knows what it is allowed to do, what proof it owes, and when it needs to come back to me.",
+    dek: "what i am learning from turning admin.anipotts.com into a read-only operator dashboard first, then a content review surface, then a guarded write path.",
+    audience:
+      "builders running coding agents across real repos, live sites, and operational state",
+    source_fixture:
+      "docs/newsletter-drafts/first-thing-agents-need-control-plane.json",
+    preview_fixture:
+      "docs/newsletter-drafts/first-thing-agents-need-control-plane.preview.html",
+    source_refs: [
+      {
+        ref: "AGENTS.md",
+        use: "repo authority model, safe lanes, hard gates, NEEDS-ANI rules, and proof expectations",
+      },
+      {
+        ref: "docs/admin-v2-architecture.md",
+        use: "admin v2 direction and control-plane framing",
+      },
+      {
+        ref: "docs/content-admin-editor-brief.md",
+        use: "read-only content inventory and admin editing progression",
+      },
+      {
+        ref: "apps/admin/src/data/content.ts",
+        use: "Astro admin static content inventory and preview-only model",
+      },
+      {
+        ref: "docs/newsletter-content-structure.md",
+        use: "newsletter draft issue contract and gated work list",
+      },
+    ],
+    spine: ["intent", "authority", "operation", "proof", "state"],
+    sections: [
+      {
+        kind: "opening",
+        body: "every coding agent i use eventually runs into the same boring problem: it can make a change, but it needs a system around it for responsibility.",
+        source_refs: ["AGENTS.md", "docs/admin-v2-architecture.md"],
+        thread_beat:
+          "the useful split is simple: safe lanes can move, hard gates come back to me.",
+      },
+      {
+        kind: "note",
+        heading: "safe lanes versus hard gates",
+        body: "i want agents to move quickly when the blast radius is small. if the work is safe, the agent should inspect, edit, verify, commit, push, and open a PR without waiting on me. if the work touches dns, auth, secrets, env, production content, outbound sends, live endpoints, payments, or destructive cleanup, it needs explicit authority. the control plane makes that split obvious before anything gets touched.",
+        source_refs: ["AGENTS.md"],
+        thread_beat:
+          "safe lanes let agents move without asking me for permission every five minutes.",
+      },
+      {
+        kind: "receipt",
+        label: "proof beats trust",
+        body: "if a decision only lives in chat, it barely exists. i want the useful state in commits, PRs, handoff docs, deploy runs, screenshots, and blocked-action lists. the next agent should be able to continue from the artifact instead of guessing what happened in the previous conversation.",
+        source_refs: ["AGENTS.md", "docs/content-admin-editor-brief.md"],
+        thread_beat:
+          "proof is what lets the next agent continue without inheriting chat memory.",
+      },
+      {
+        kind: "note",
+        heading: "NEEDS-ANI as a human syscall queue",
+        body: "the human queue should be tiny. i do not want a dashboard full of agent homework. i want the few calls only i can make: approve this, choose between these options, do this account-side action, provide this secret, decide whether this public copy sounds like me.",
+        source_refs: ["AGENTS.md", "docs/admin-v2-architecture.md"],
+        thread_beat:
+          "a good human queue is small enough to answer from my phone.",
+      },
+      {
+        kind: "worklog",
+        heading: "admin as the control plane",
+        body: "this is why admin.anipotts.com starts read-only. i need one place where content, fleet state, handoffs, approvals, and proof are legible. only after that is boring do i want write buttons. live controls come after the foundation.",
+        items: [
+          "read-only operator dashboard first",
+          "content inventory and preview states next",
+          "guarded writes only after the authority model is real",
+          "live gates visible before live controls exist",
+        ],
+        source_refs: [
+          "docs/admin-v2-architecture.md",
+          "docs/content-admin-editor-brief.md",
+          "apps/admin/src/data/content.ts",
+        ],
+        thread_beat:
+          "the control plane maps what i meant to what was allowed to what changed.",
+      },
+    ],
+    claims: [
+      {
+        claim:
+          "agents in this repo can complete safe lanes end to end but must stop at true gates",
+        status: "source_backed",
+        source_refs: ["AGENTS.md"],
+      },
+      {
+        claim: "NEEDS-ANI is defined as a narrow human syscall queue",
+        status: "source_backed",
+        source_refs: ["AGENTS.md"],
+      },
+      {
+        claim:
+          "admin content work should move from read-only inventory to previews before publish paths",
+        status: "source_backed",
+        source_refs: ["AGENTS.md", "docs/content-admin-editor-brief.md"],
+      },
+      {
+        claim:
+          "admin.anipotts.com should become the practical web surface for editing public-site text, previewing changes, reviewing fleet state, and returning decisions",
+        status: "source_backed",
+        source_refs: ["AGENTS.md"],
+      },
+    ],
+    blocked_actions: [
+      "write production d1 issue",
+      "publish archive page",
+      "send test email",
+      "broadcast to subscribers",
+      "change DNS",
+      "change auth or Cloudflare Access",
+      "modify env or secrets",
+      "change workers or endpoints",
+      "add admin write path",
+    ],
+    preview_notes:
+      "newsletter-first outline with thread-compatible beats. keep practical, source-backed, and specific to anipotts-com/admin.",
+  },
+];

--- a/apps/admin/src/data/proof.ts
+++ b/apps/admin/src/data/proof.ts
@@ -1,0 +1,102 @@
+export type ProofStatus = "verified" | "blocked" | "pending";
+export type ProofKind = "deploy" | "route" | "auth" | "repo" | "gate";
+
+export type ProofEntry = {
+  id: string;
+  kind: ProofKind;
+  status: ProofStatus;
+  title: string;
+  summary: string;
+  evidence_uri: string;
+  redaction: "public_metadata" | "metadata_only" | "protected_route";
+  next_safe_action: string;
+};
+
+export const proofSource = {
+  mode: "read_only_static_proof_log",
+  generated_from: "GitHub runs, route probes, PR state, and D1-safe metadata",
+  live_writes: "disabled",
+};
+
+export const proofEntries: ProofEntry[] = [
+  {
+    id: "proof.site.pr112.deploy",
+    kind: "deploy",
+    status: "verified",
+    title: "PR #112 deployed scoped targets",
+    summary:
+      "Deploy run 28304347479 completed for www, admin, and admin-solid. Ingest, newsletter, weekly-email, and state workers were skipped.",
+    evidence_uri:
+      "https://github.com/anipotts/anipotts.com/actions/runs/28304347479",
+    redaction: "public_metadata",
+    next_safe_action:
+      "Keep deploy proof attached to route-level changes until proof rows move into D1.",
+  },
+  {
+    id: "proof.site.public-routes",
+    kind: "route",
+    status: "verified",
+    title: "public content routes answer",
+    summary:
+      "Live probes returned 200 for /writing/saturdays-are-for-claude-code and /orchestrating. The legacy /claude path returned 301.",
+    evidence_uri: "https://anipotts.com/orchestrating",
+    redaction: "public_metadata",
+    next_safe_action:
+      "Keep public smoke coverage on the stable route set before expanding content from D1.",
+  },
+  {
+    id: "proof.admin.unauth-block",
+    kind: "auth",
+    status: "verified",
+    title: "admin unauthenticated block holds",
+    summary:
+      "Unauthenticated probes returned 302 for /auth/passkey, /, /content, /content/review, /content/preview, /needs-ani, /repos, and /fleet.",
+    evidence_uri: "https://admin.anipotts.com/auth/passkey",
+    redaction: "protected_route",
+    next_safe_action:
+      "After passkey enrollment, prove app-native login and then remove Cloudflare Access.",
+  },
+  {
+    id: "proof.repo.open-prs",
+    kind: "repo",
+    status: "verified",
+    title: "no open site PRs",
+    summary:
+      "GitHub PR list returned no open pull requests after PR #112 merged.",
+    evidence_uri: "https://github.com/anipotts/anipotts.com/pulls",
+    redaction: "public_metadata",
+    next_safe_action:
+      "Continue branch-per-slice work with ready PRs as the default.",
+  },
+  {
+    id: "proof.admin.passkey-enrollment",
+    kind: "gate",
+    status: "blocked",
+    title: "passkey enrollment proof missing",
+    summary:
+      "Access removal remains blocked until biometric passkey registration, login, logout, persistence, and revoked-credential denial are proven.",
+    evidence_uri: "drizzle/migrations/0006_admin_passkeys.sql",
+    redaction: "metadata_only",
+    next_safe_action:
+      "Register the first passkey behind Cloudflare Access, then record D1 credential, session, and audit evidence.",
+  },
+  {
+    id: "proof.admin.write-paths",
+    kind: "gate",
+    status: "pending",
+    title: "admin write paths remain inert",
+    summary:
+      "Content preview, review, mutation, and destructive-operation routes expose no save, publish, send, or live-control endpoint.",
+    evidence_uri: "apps/admin/src/pages",
+    redaction: "metadata_only",
+    next_safe_action:
+      "Before adding writes, require audited D1 operation records, rollback, and route proof.",
+  },
+];
+
+export const proofCounts = {
+  total: proofEntries.length,
+  verified: proofEntries.filter((entry) => entry.status === "verified").length,
+  blocked: proofEntries.filter((entry) => entry.status === "blocked").length,
+  pending: proofEntries.filter((entry) => entry.status === "pending").length,
+};

--- a/apps/admin/src/pages/newsletter.astro
+++ b/apps/admin/src/pages/newsletter.astro
@@ -1,0 +1,124 @@
+---
+import AdminLayout from "../layouts/AdminLayout.astro";
+import { newsletterDrafts, newsletterDraftsSource } from "../data/newsletter";
+---
+
+<AdminLayout
+  title="newsletter"
+  deck="Read-only issue drafts and source-backed preview structure. No D1 writes, archive publishing, sends, or worker controls."
+>
+  <section class="meta-strip" aria-label="newsletter source">
+    <span>{newsletterDrafts.length} draft</span>
+    <span>{newsletterDraftsSource.source_doc}</span>
+    <span>{newsletterDraftsSource.mode}</span>
+  </section>
+
+  <div class="newsletter-grid">
+    {
+      newsletterDrafts.map((draft) => (
+        <article class="table-card">
+          <div class="section-head">
+            <div>
+              <p>{draft.status}</p>
+              <h2>{draft.title}</h2>
+            </div>
+            <span>{draft.slug}</span>
+          </div>
+
+          <div class="newsletter-detail">
+            <section>
+              <h3>draft</h3>
+              <p>{draft.summary}</p>
+              <p>{draft.dek}</p>
+              <dl>
+                <div>
+                  <dt>subject</dt>
+                  <dd>{draft.subject}</dd>
+                </div>
+                <div>
+                  <dt>audience</dt>
+                  <dd>{draft.audience}</dd>
+                </div>
+                <div>
+                  <dt>spine</dt>
+                  <dd>{draft.spine.join(" -> ")}</dd>
+                </div>
+                <div>
+                  <dt>fixture</dt>
+                  <dd>{draft.source_fixture}</dd>
+                </div>
+              </dl>
+            </section>
+
+            <section>
+              <h3>source refs</h3>
+              <div class="record-list">
+                {draft.source_refs.map((source) => (
+                  <article class="compact-row">
+                    <strong>{source.ref}</strong>
+                    <small>{source.use}</small>
+                  </article>
+                ))}
+              </div>
+            </section>
+          </div>
+
+          <div class="newsletter-detail">
+            <section>
+              <h3>sections</h3>
+              <div class="record-list">
+                {draft.sections.map((section) => (
+                  <article class="compact-row">
+                    <span>{section.kind}</span>
+                    <strong>{section.heading ?? section.label ?? "opening"}</strong>
+                    <small>{section.thread_beat ?? section.body}</small>
+                    {section.items && (
+                      <ul class="compact-list">
+                        {section.items.map((item) => (
+                          <li>{item}</li>
+                        ))}
+                      </ul>
+                    )}
+                  </article>
+                ))}
+              </div>
+            </section>
+
+            <section>
+              <h3>blocked live actions</h3>
+              <div class="record-list">
+                {draft.blocked_actions.map((action) => (
+                  <article class="compact-row">
+                    <strong>{action}</strong>
+                    <small>{newsletterDraftsSource.blocked}</small>
+                  </article>
+                ))}
+              </div>
+            </section>
+          </div>
+
+          <div class="newsletter-detail">
+            <section>
+              <h3>claims</h3>
+              <div class="record-list">
+                {draft.claims.map((claim) => (
+                  <article class="compact-row">
+                    <span>{claim.status}</span>
+                    <strong>{claim.claim}</strong>
+                    <small>{claim.source_refs.join(", ")}</small>
+                  </article>
+                ))}
+              </div>
+            </section>
+
+            <section>
+              <h3>preview note</h3>
+              <p>{draft.preview_notes}</p>
+              <p>{draft.preview_fixture}</p>
+            </section>
+          </div>
+        </article>
+      ))
+    }
+  </div>
+</AdminLayout>

--- a/apps/admin/src/pages/proof.astro
+++ b/apps/admin/src/pages/proof.astro
@@ -1,0 +1,72 @@
+---
+import AdminLayout from "../layouts/AdminLayout.astro";
+import { proofCounts, proofEntries, proofSource } from "../data/proof";
+
+const groups = ["verified", "blocked", "pending"] as const;
+---
+
+<AdminLayout
+  title="proof log"
+  deck="Read-only proof records for deploys, route probes, auth gates, and repo state. This page does not write audit records yet."
+>
+  <section class="meta-strip" aria-label="proof log source">
+    <span>{proofCounts.total} proof rows</span>
+    <span>{proofCounts.verified} verified</span>
+    <span>{proofCounts.blocked} blocked</span>
+    <span>{proofCounts.pending} pending</span>
+    <span>{proofSource.mode}</span>
+  </section>
+
+  <div class="proof-grid">
+    {
+      groups.map((status) => {
+        const rows = proofEntries.filter((entry) => entry.status === status);
+
+        return (
+          <section class="table-card">
+            <div class="section-head">
+              <div>
+                <p>{status}</p>
+                <h2>{rows.length} records</h2>
+              </div>
+              <span>{proofSource.live_writes}</span>
+            </div>
+            <div class="record-list">
+              {rows.map((entry) => (
+                <article class="record-row">
+                  <div>
+                    <p>{entry.kind} / {entry.redaction}</p>
+                    <h3>{entry.title}</h3>
+                  </div>
+                  <dl>
+                    <div>
+                      <dt>summary</dt>
+                      <dd>{entry.summary}</dd>
+                    </div>
+                    <div>
+                      <dt>evidence</dt>
+                      <dd>{entry.evidence_uri}</dd>
+                    </div>
+                    <div>
+                      <dt>proof id</dt>
+                      <dd>{entry.id}</dd>
+                    </div>
+                    <div>
+                      <dt>next</dt>
+                      <dd>{entry.next_safe_action}</dd>
+                    </div>
+                  </dl>
+                </article>
+              ))}
+            </div>
+          </section>
+        );
+      })
+    }
+  </div>
+
+  <div class="notice">
+    The final target is D1-backed proof records. This route is a static bridge so
+    admin can show what is already verified while write paths remain inactive.
+  </div>
+</AdminLayout>

--- a/apps/admin/src/styles/admin.css
+++ b/apps/admin/src/styles/admin.css
@@ -243,7 +243,9 @@ th {
 .surface-grid,
 .review-board,
 .needs-grid,
-.preview-grid {
+.preview-grid,
+.proof-grid,
+.newsletter-grid {
   display: grid;
   gap: 14px;
   margin-top: 24px;
@@ -359,6 +361,39 @@ dd {
   margin: 0 0 12px;
 }
 
+.newsletter-detail {
+  display: grid;
+  grid-template-columns: minmax(260px, 0.9fr) minmax(0, 1.1fr);
+  gap: 0;
+  border-top: 1px solid var(--border);
+}
+
+.newsletter-detail > section {
+  padding: 16px;
+}
+
+.newsletter-detail > section + section {
+  border-left: 1px solid var(--border);
+}
+
+.newsletter-detail h3 {
+  margin: 0 0 12px;
+  letter-spacing: 0;
+}
+
+.newsletter-detail p {
+  color: var(--muted);
+  line-height: 1.55;
+}
+
+.compact-list {
+  margin: 10px 0 0;
+  padding-left: 18px;
+  color: var(--muted);
+  line-height: 1.5;
+  font-size: 13px;
+}
+
 .compact-row {
   display: grid;
   gap: 5px;
@@ -420,6 +455,7 @@ dd {
 
   .preview-grid,
   .lane-grid,
+  .newsletter-detail,
   .record-row dl,
   .need-row dl,
   .proposal-row dl,
@@ -428,6 +464,11 @@ dd {
   }
 
   .lane-grid > div + div {
+    border-left: 0;
+    border-top: 1px solid var(--border);
+  }
+
+  .newsletter-detail > section + section {
     border-left: 0;
     border-top: 1px solid var(--border);
   }

--- a/docs/newsletter-content-structure.md
+++ b/docs/newsletter-content-structure.md
@@ -10,55 +10,55 @@ admin writes, or production d1 changes.
 
 ## existing source inventory
 
-| surface | current source | role | lane status |
-| --- | --- | --- | --- |
-| newsletter landing | `apps/www/src/pages/newsletter.astro` | renders the `news.anipotts.com` landing page from normalized page content | read-only source reference |
-| subscribe component | `apps/www/src/components/NewsletterSubscribe.astro` | shows lede, email form, CTA, success text, and error text | copy source only, no send authority |
-| archive shell | `apps/www/src/pages/newsletter/archive.astro` | placeholder archive until the first-party send path is verified | read-only public shell |
-| issue table | `drizzle/migrations/0005_newsletter_system.sql:newsletter_issues` | future storage shape for issue rows | schema reference only |
-| system brief | `docs/newsletter-system.md` | infrastructure, resend, compliance, and rollout gates | authoritative for live-path gates |
-| content inventory | `docs/content-admin-editor-brief.md` | public-site editable-content inventory and newsletter backfill candidates | admin planning source |
-| read-only admin | `apps/admin-solid/src/data/content-inventory.ts` | static inventory and preview rows for current content surfaces | preview model only |
-| legacy admin | `apps/admin/src/app/content/[id]/buttondown-*` and related files | old Buttondown draft controls | out of scope for this lane |
-| newsletter worker | `workers/newsletter/*` | async send worker and queue consumer | out of scope for this lane |
+| surface             | current source                                                                  | role                                                                      | lane status                         |
+| ------------------- | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------- | ----------------------------------- |
+| newsletter landing  | `apps/www/src/pages/newsletter.astro`                                           | renders the `news.anipotts.com` landing page from normalized page content | read-only source reference          |
+| subscribe component | `apps/www/src/components/NewsletterSubscribe.astro`                             | shows lede, email form, CTA, success text, and error text                 | copy source only, no send authority |
+| archive shell       | `apps/www/src/pages/newsletter/archive.astro`                                   | placeholder archive until the first-party send path is verified           | read-only public shell              |
+| issue table         | `drizzle/migrations/0005_newsletter_system.sql:newsletter_issues`               | future storage shape for issue rows                                       | schema reference only               |
+| system brief        | `docs/newsletter-system.md`                                                     | infrastructure, resend, compliance, and rollout gates                     | authoritative for live-path gates   |
+| content inventory   | `docs/content-admin-editor-brief.md`                                            | public-site editable-content inventory and newsletter backfill candidates | admin planning source               |
+| read-only admin     | `apps/admin/src/data/content.ts`                                                | static inventory and preview rows for current content surfaces            | preview model only                  |
+| newsletter admin    | `apps/admin/src/data/newsletter.ts` and `apps/admin/src/pages/newsletter.astro` | static issue draft review inside canonical Astro admin                    | preview model only                  |
+| newsletter worker   | `workers/newsletter/*`                                                          | async send worker and queue consumer                                      | out of scope for this lane          |
 
 ## draft issue record
 
 these fields are enough for ani to draft into and enough for admin to preview
 later without writing production content.
 
-| field | type | required | source mapping | note |
-| --- | --- | ---: | --- | --- |
-| `id` | string | yes | local fixture or future `newsletter_issues.id` | stable draft id, not a provider id |
-| `slug` | string | yes | future `newsletter_issues.slug` | url-safe archive slug |
-| `status` | enum | yes | future `newsletter_issues.status` | `idea`, `draft`, `preview`, `ready_for_review`, `blocked`, `published` |
-| `title` | string | yes | future `newsletter_issues.title` | public archive title |
-| `subject` | string | yes | future `newsletter_issues.subject` | inbox subject, can differ from title |
-| `summary` | string | yes | future `newsletter_issues.summary` | one-line archive and admin preview |
-| `dek` | string | no | future `metadata.dek` | short setup under the title |
-| `audience` | string | yes | future `metadata.audience` | who this note is for |
-| `source_refs` | array | yes | future `metadata.source_refs` | file paths, commits, posts, screenshots, or docs |
-| `claims` | array | yes | future `metadata.claims` | factual claims that need proof before publish |
-| `sections` | array | yes | render source for `html` and `text` | ordered content blocks |
-| `links` | array | no | future `metadata.links` | public links only, no private docs |
-| `assets` | array | no | future `metadata.assets` | screenshots or images, with approval status |
-| `preview_notes` | string | no | future `metadata.preview_notes` | editor context for admin preview |
-| `blocked_actions` | array | yes | future `metadata.blocked_actions` | send, publish, schedule, import, or store actions still gated |
-| `approval_refs` | array | no | future `metadata.approval_refs` | authority ids only after ani grants them |
+| field             | type   | required | source mapping                                 | note                                                                   |
+| ----------------- | ------ | -------: | ---------------------------------------------- | ---------------------------------------------------------------------- |
+| `id`              | string |      yes | local fixture or future `newsletter_issues.id` | stable draft id, not a provider id                                     |
+| `slug`            | string |      yes | future `newsletter_issues.slug`                | url-safe archive slug                                                  |
+| `status`          | enum   |      yes | future `newsletter_issues.status`              | `idea`, `draft`, `preview`, `ready_for_review`, `blocked`, `published` |
+| `title`           | string |      yes | future `newsletter_issues.title`               | public archive title                                                   |
+| `subject`         | string |      yes | future `newsletter_issues.subject`             | inbox subject, can differ from title                                   |
+| `summary`         | string |      yes | future `newsletter_issues.summary`             | one-line archive and admin preview                                     |
+| `dek`             | string |       no | future `metadata.dek`                          | short setup under the title                                            |
+| `audience`        | string |      yes | future `metadata.audience`                     | who this note is for                                                   |
+| `source_refs`     | array  |      yes | future `metadata.source_refs`                  | file paths, commits, posts, screenshots, or docs                       |
+| `claims`          | array  |      yes | future `metadata.claims`                       | factual claims that need proof before publish                          |
+| `sections`        | array  |      yes | render source for `html` and `text`            | ordered content blocks                                                 |
+| `links`           | array  |       no | future `metadata.links`                        | public links only, no private docs                                     |
+| `assets`          | array  |       no | future `metadata.assets`                       | screenshots or images, with approval status                            |
+| `preview_notes`   | string |       no | future `metadata.preview_notes`                | editor context for admin preview                                       |
+| `blocked_actions` | array  |      yes | future `metadata.blocked_actions`              | send, publish, schedule, import, or store actions still gated          |
+| `approval_refs`   | array  |       no | future `metadata.approval_refs`                | authority ids only after ani grants them                               |
 
 ## issue sections
 
 use these block kinds so draft issues can render to html, plain text, and an
 admin preview without custom code per issue.
 
-| block kind | fields | use |
-| --- | --- | --- |
-| `opening` | `body`, `source_refs` | sets context in ani's voice without a fake hook |
-| `worklog` | `heading`, `items`, `source_refs` | explains what changed or what was built |
-| `receipt` | `label`, `body`, `source_refs` | shows proof behind a claim |
-| `note` | `heading`, `body`, `links` | regular prose section |
-| `link_list` | `heading`, `links` | compact pointers to posts, repos, docs, or demos |
-| `close` | `body`, `cta` | optional signoff or pointer back to the site |
+| block kind  | fields                            | use                                              |
+| ----------- | --------------------------------- | ------------------------------------------------ |
+| `opening`   | `body`, `source_refs`             | sets context in ani's voice without a fake hook  |
+| `worklog`   | `heading`, `items`, `source_refs` | explains what changed or what was built          |
+| `receipt`   | `label`, `body`, `source_refs`    | shows proof behind a claim                       |
+| `note`      | `heading`, `body`, `links`        | regular prose section                            |
+| `link_list` | `heading`, `links`                | compact pointers to posts, repos, docs, or demos |
+| `close`     | `body`, `cta`                     | optional signoff or pointer back to the site     |
 
 avoid making source material sound more finished than it is. if a claim is not
 proved by a public source ref, keep it in `claims` with `status: needs_proof`
@@ -83,7 +83,7 @@ do not load it into d1 or an admin write endpoint without separate authority.
     "AGENTS.md",
     "docs/content-admin-editor-brief.md",
     "docs/newsletter-system.md",
-    "apps/admin-solid/src/data/content-inventory.ts"
+    "apps/admin/src/data/content.ts"
   ],
   "claims": [
     {
@@ -120,31 +120,31 @@ do not load it into d1 or an admin write endpoint without separate authority.
 
 ## read-only admin preview needs
 
-the current `apps/admin-solid` content route can stay static and read-only. a
-future safe slice can add newsletter preview rows with:
+the current `apps/admin` Astro admin route can stay static and read-only. future
+safe slices can add newsletter preview rows with:
 
-| admin need | source | gated action |
-| --- | --- | --- |
-| issue list | docs or static fixture files | no production d1 reads required for first slice |
-| issue detail preview | draft issue record plus markdown renderer | no save button, no queue button, no provider calls |
-| source refs panel | `source_refs`, `claims`, and `assets` fields | no private docs or secret values |
-| blocked actions panel | `blocked_actions` and `approval_refs` fields | no live controls |
-| archive preview route | static render from fixture | no public route publish unless approved |
+| admin need            | source                                       | gated action                                       |
+| --------------------- | -------------------------------------------- | -------------------------------------------------- |
+| issue list            | docs or static fixture files                 | no production d1 reads required for first slice    |
+| issue detail preview  | draft issue record plus markdown renderer    | no save button, no queue button, no provider calls |
+| source refs panel     | `source_refs`, `claims`, and `assets` fields | no private docs or secret values                   |
+| blocked actions panel | `blocked_actions` and `approval_refs` fields | no live controls                                   |
+| archive preview route | static render from fixture                   | no public route publish unless approved            |
 
 ## gated work
 
 these remain outside this lane:
 
-| gate | why |
-| --- | --- |
-| production d1 writes | creates or mutates real newsletter issue state |
-| admin save APIs | creates a write path into public content or newsletter records |
-| test sends and broadcasts | outbound action with compliance and reputation risk |
-| resend setup | requires secrets, verified domain state, webhooks, and dns proof |
-| worker or queue changes | touches live-path infrastructure and endpoints |
-| archive publishing | changes public content state for `news.anipotts.com` |
-| buttondown migration | needs source export review and explicit import decision |
-| mailing address config | protected compliance value, never hardcoded in repo source |
+| gate                      | why                                                              |
+| ------------------------- | ---------------------------------------------------------------- |
+| production d1 writes      | creates or mutates real newsletter issue state                   |
+| admin save APIs           | creates a write path into public content or newsletter records   |
+| test sends and broadcasts | outbound action with compliance and reputation risk              |
+| resend setup              | requires secrets, verified domain state, webhooks, and dns proof |
+| worker or queue changes   | touches live-path infrastructure and endpoints                   |
+| archive publishing        | changes public content state for `news.anipotts.com`             |
+| buttondown migration      | needs source export review and explicit import decision          |
+| mailing address config    | protected compliance value, never hardcoded in repo source       |
 
 ## next safe action
 

--- a/docs/newsletter-drafts/first-thing-agents-need-control-plane.json
+++ b/docs/newsletter-drafts/first-thing-agents-need-control-plane.json
@@ -21,57 +21,40 @@
       "use": "read-only content inventory and admin editing progression"
     },
     {
-      "ref": "apps/admin-solid/src/data/content-inventory.ts",
-      "use": "static content inventory and preview-only admin model"
+      "ref": "apps/admin/src/data/content.ts",
+      "use": "Astro admin static content inventory and preview-only model"
     },
     {
       "ref": "docs/newsletter-content-structure.md",
       "use": "newsletter draft issue contract and gated work list"
     }
   ],
-  "spine": [
-    "intent",
-    "authority",
-    "operation",
-    "proof",
-    "state"
-  ],
+  "spine": ["intent", "authority", "operation", "proof", "state"],
   "hook": {
     "kind": "opening",
     "body": "every coding agent i use eventually runs into the same boring problem: it can make a change, but it needs a system around it for responsibility.",
-    "source_refs": [
-      "AGENTS.md",
-      "docs/admin-v2-architecture.md"
-    ]
+    "source_refs": ["AGENTS.md", "docs/admin-v2-architecture.md"]
   },
   "sections": [
     {
       "kind": "note",
       "heading": "safe lanes versus hard gates",
       "body": "i want agents to move quickly when the blast radius is small. if the work is safe, the agent should inspect, edit, verify, commit, push, and open a PR without waiting on me. if the work touches dns, auth, secrets, env, production content, outbound sends, live endpoints, payments, or destructive cleanup, it needs explicit authority. the control plane makes that split obvious before anything gets touched.",
-      "source_refs": [
-        "AGENTS.md"
-      ],
+      "source_refs": ["AGENTS.md"],
       "thread_beat": "the useful split is simple: safe lanes can move, hard gates come back to me."
     },
     {
       "kind": "receipt",
       "label": "proof beats trust",
       "body": "if a decision only lives in chat, it barely exists. i want the useful state in commits, PRs, handoff docs, deploy runs, screenshots, and blocked-action lists. the next agent should be able to continue from the artifact instead of guessing what happened in the previous conversation.",
-      "source_refs": [
-        "AGENTS.md",
-        "docs/content-admin-editor-brief.md"
-      ],
+      "source_refs": ["AGENTS.md", "docs/content-admin-editor-brief.md"],
       "thread_beat": "proof is what lets the next agent continue without inheriting chat memory."
     },
     {
       "kind": "note",
       "heading": "NEEDS-ANI as a human syscall queue",
       "body": "the human queue should be tiny. i do not want a dashboard full of agent homework. i want the few calls only i can make: approve this, choose between these two options, do this account-side action, provide this secret, decide whether this public copy sounds like me.",
-      "source_refs": [
-        "AGENTS.md",
-        "docs/admin-v2-architecture.md"
-      ],
+      "source_refs": ["AGENTS.md", "docs/admin-v2-architecture.md"],
       "thread_beat": "a good human queue is small enough to answer from my phone."
     },
     {
@@ -87,7 +70,7 @@
       "source_refs": [
         "docs/admin-v2-architecture.md",
         "docs/content-admin-editor-brief.md",
-        "apps/admin-solid/src/data/content-inventory.ts"
+        "apps/admin/src/data/content.ts"
       ],
       "thread_beat": "the control plane maps what i meant to what was allowed to what changed."
     }
@@ -101,31 +84,22 @@
     {
       "claim": "agents in this repo can complete safe lanes end to end but must stop at true gates",
       "status": "source_backed",
-      "source_refs": [
-        "AGENTS.md"
-      ]
+      "source_refs": ["AGENTS.md"]
     },
     {
       "claim": "NEEDS-ANI is defined as a narrow human syscall queue",
       "status": "source_backed",
-      "source_refs": [
-        "AGENTS.md"
-      ]
+      "source_refs": ["AGENTS.md"]
     },
     {
       "claim": "admin content work should move from read-only inventory to previews before publish paths",
       "status": "source_backed",
-      "source_refs": [
-        "AGENTS.md",
-        "docs/content-admin-editor-brief.md"
-      ]
+      "source_refs": ["AGENTS.md", "docs/content-admin-editor-brief.md"]
     },
     {
       "claim": "admin.anipotts.com should become the practical web surface for editing public-site text, previewing changes, reviewing fleet state, and returning decisions",
       "status": "source_backed",
-      "source_refs": [
-        "AGENTS.md"
-      ]
+      "source_refs": ["AGENTS.md"]
     }
   ],
   "x_thread_beats": [

--- a/docs/newsletter-drafts/first-thing-agents-need-control-plane.preview.html
+++ b/docs/newsletter-drafts/first-thing-agents-need-control-plane.preview.html
@@ -7,22 +7,46 @@
     <style>
       :root {
         color-scheme: light dark;
-        --bg: #f7f5f0;
-        --ink: #171717;
-        --muted: #656159;
-        --line: #d8d2c7;
-        --panel: #fffdf7;
-        --accent: #245f86;
+        --sans: "Instrument Sans Variable", "Instrument Sans", -apple-system,
+          BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif;
+        --mono: "JetBrains Mono Variable", "JetBrains Mono", ui-monospace,
+          "SF Mono", Menlo, monospace;
+        --bg: #fbfaf7;
+        --surface: #f3f1ec;
+        --ink: #1a1a1a;
+        --ink-muted: #6b6b6b;
+        --accent: #2563eb;
+        --accent-soft: rgba(37, 99, 235, 0.08);
+        --border: rgba(0, 0, 0, 0.08);
+        --p-h1: clamp(2rem, 4vw, 2.9rem);
+        --p-h2: clamp(1.5rem, 3vw, 2rem);
+        --p-h3: 1.25rem;
+        --p-hero: clamp(2.4rem, 6vw, 4rem);
+        --p-body: clamp(1rem, 0.5vw + 0.9rem, 1.0625rem);
+        --p-small: 0.875rem;
+        --p-mono: 0.85rem;
+        --s-1: 0.5rem;
+        --s-2: 0.75rem;
+        --s-3: 1rem;
+        --s-4: 1.5rem;
+        --s-5: 2rem;
+        --s-6: 3rem;
+        --s-7: 4rem;
+        --s-8: 6rem;
+        --measure: 65ch;
+        --lh-body: 1.65;
+        --lh-tight: 1.1;
       }
 
       @media (prefers-color-scheme: dark) {
         :root {
-          --bg: #141413;
-          --ink: #f2efe8;
-          --muted: #b8b1a7;
-          --line: #39362f;
-          --panel: #1d1c1a;
-          --accent: #8fbee0;
+          --bg: #11111b;
+          --surface: #1e1e2e;
+          --ink: #cdd6f4;
+          --ink-muted: #7f849c;
+          --accent: #89b4fa;
+          --accent-soft: rgba(137, 180, 250, 0.12);
+          --border: rgba(205, 214, 244, 0.08);
         }
       }
 
@@ -34,273 +58,350 @@
         margin: 0;
         background: var(--bg);
         color: var(--ink);
-        font:
-          18px/1.62 ui-serif,
-          Georgia,
-          Cambria,
-          "Times New Roman",
-          serif;
+        font-family: var(--sans);
+        font-size: var(--p-body);
+        line-height: var(--lh-body);
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+        text-rendering: optimizeLegibility;
+        overflow-x: hidden;
       }
 
-      main {
-        max-width: 760px;
-        margin: 0 auto;
-        padding: 56px 24px 88px;
+      .frame {
+        max-width: 64rem;
+        margin-inline: auto;
+        padding-inline: clamp(1.25rem, 5vw, 2.5rem);
       }
 
-      header {
-        margin-bottom: 44px;
+      .nav {
+        display: flex;
+        align-items: center;
+        gap: var(--s-5);
+        padding-block: var(--s-4);
+        margin-bottom: var(--s-3);
       }
 
-      .eyebrow,
-      .label {
-        margin: 0 0 12px;
+      .wordmark {
+        display: inline-flex;
+        align-items: center;
+        min-height: 44px;
+        margin-right: auto;
+        color: var(--ink);
+        font-family: var(--sans);
+        font-size: 1.5rem;
+        font-weight: 600;
+        text-decoration: none;
+      }
+
+      .dot {
         color: var(--accent);
-        font:
-          700 12px/1.2 ui-sans-serif,
-          system-ui,
-          -apple-system,
-          BlinkMacSystemFont,
-          "Segoe UI",
-          sans-serif;
-        letter-spacing: 0.08em;
-        text-transform: uppercase;
+      }
+
+      .nav-links {
+        display: flex;
+        flex-wrap: wrap;
+        column-gap: var(--s-4);
+      }
+
+      .nav-link {
+        display: inline-flex;
+        align-items: center;
+        min-height: 44px;
+        color: var(--ink-muted);
+        font-size: var(--p-small);
+        text-decoration: none;
+        transition: color 0.2s;
+      }
+
+      .nav-link:hover,
+      .nav-link[aria-current="page"] {
+        color: var(--accent);
+      }
+
+      .theme-dot {
+        width: 44px;
+        min-height: 44px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        color: var(--ink-muted);
+        font-size: 1.15rem;
+      }
+
+      .theme-dot::before {
+        content: "";
+        width: 1em;
+        height: 1em;
+        border: 1.5px solid currentColor;
+        border-radius: 999px;
+        box-shadow: inset -0.42em 0 0 currentColor;
+      }
+
+      .page {
+        padding-block: var(--s-3) var(--s-7);
+        display: flex;
+        flex-direction: column;
+      }
+
+      .article {
+        display: flex;
+        flex-direction: column;
+        width: 100%;
+        max-width: 64rem;
+        margin-inline: auto;
+        gap: var(--s-3);
+      }
+
+      .head {
+        display: flex;
+        flex-direction: column;
+        gap: var(--s-2);
+        width: 100%;
+        max-width: none;
+        min-width: 0;
+      }
+
+      .back-link {
+        display: inline-flex;
+        align-items: center;
+        width: fit-content;
+        min-height: 44px;
+        color: var(--ink-muted);
+        text-decoration: none;
+        transition: color 0.2s;
+        font-family: var(--mono);
+        font-size: var(--p-mono);
+      }
+
+      .back-link:hover {
+        color: var(--accent);
       }
 
       h1 {
-        max-width: 720px;
-        margin: 0 0 18px;
-        font:
-          700 clamp(42px, 7vw, 72px) / 0.98 ui-sans-serif,
-          system-ui,
-          -apple-system,
-          BlinkMacSystemFont,
-          "Segoe UI",
-          sans-serif;
-        letter-spacing: 0;
+        max-width: none;
+        margin: 0;
+        font-family: var(--sans);
+        font-size: var(--p-hero);
+        font-weight: 500;
+        line-height: var(--lh-tight);
+        letter-spacing: -0.02em;
+        text-wrap: pretty;
+        overflow-wrap: break-word;
       }
 
       h2 {
-        margin: 44px 0 12px;
-        font:
-          700 26px/1.15 ui-sans-serif,
-          system-ui,
-          -apple-system,
-          BlinkMacSystemFont,
-          "Segoe UI",
-          sans-serif;
-        letter-spacing: 0;
+        max-width: none;
+        margin: var(--s-4) 0 var(--s-1);
+        font-family: var(--sans);
+        font-size: var(--p-h2);
+        font-weight: 500;
+        line-height: var(--lh-tight);
+        letter-spacing: -0.01em;
       }
 
       h3 {
-        margin: 0 0 10px;
-        font:
-          700 18px/1.25 ui-sans-serif,
-          system-ui,
-          -apple-system,
-          BlinkMacSystemFont,
-          "Segoe UI",
-          sans-serif;
-        letter-spacing: 0;
+        margin: 0 0 var(--s-2);
+        font-family: var(--sans);
+        font-size: var(--p-h3);
+        font-weight: 500;
+        line-height: var(--lh-tight);
+        letter-spacing: -0.01em;
       }
 
       p {
-        margin: 0 0 18px;
+        width: 100%;
+        max-width: none;
+        margin: 0 0 var(--s-2);
+        overflow-wrap: break-word;
       }
 
       .dek {
-        max-width: 680px;
-        color: var(--muted);
-        font-size: 21px;
-        line-height: 1.45;
+        color: var(--ink-muted);
+        font-size: calc(var(--p-body) * 1.1);
+        line-height: var(--lh-body);
       }
 
       .thumbnail-slot {
-        margin: 26px 0 24px;
+        width: 100%;
+        margin: var(--s-2) 0 var(--s-3);
       }
 
       .thumbnail-frame {
         display: grid;
-        min-height: 320px;
-        aspect-ratio: 16 / 9;
+        width: 100%;
+        min-width: 0;
+        padding: 16px;
         place-items: center;
-        border: 1px solid var(--line);
-        border-radius: 8px;
-        background:
-          linear-gradient(135deg, rgba(36, 95, 134, 0.12), transparent 42%),
-          var(--panel);
+        border: 1px solid color-mix(in srgb, var(--border) 72%, var(--accent) 28%);
+        border-radius: 1rem;
+        background: color-mix(in srgb, var(--surface) 82%, var(--bg) 18%);
+        box-shadow: 0 1.5rem 5rem rgba(0, 0, 0, 0.14);
       }
 
-      .thumbnail-inner {
-        width: min(82%, 560px);
-        border: 1px solid var(--line);
-        border-radius: 8px;
-        background: var(--bg);
-        padding: 22px;
-      }
-
-      .thumbnail-bar {
-        display: flex;
-        gap: 6px;
-        margin-bottom: 18px;
-      }
-
-      .thumbnail-dot {
-        width: 9px;
-        height: 9px;
-        border-radius: 999px;
-        background: var(--line);
-      }
-
-      .thumbnail-title {
-        margin: 0 0 10px;
-        font:
-          700 24px/1.12 ui-sans-serif,
-          system-ui,
-          -apple-system,
-          BlinkMacSystemFont,
-          "Segoe UI",
-          sans-serif;
-      }
-
-      .thumbnail-copy {
-        margin: 0;
-        color: var(--muted);
-        font:
-          15px/1.45 ui-sans-serif,
-          system-ui,
-          -apple-system,
-          BlinkMacSystemFont,
-          "Segoe UI",
-          sans-serif;
-      }
-
-      .thumbnail-caption {
-        margin: 10px 0 0;
-        color: var(--muted);
-        font:
-          13px/1.4 ui-sans-serif,
-          system-ui,
-          -apple-system,
-          BlinkMacSystemFont,
-          "Segoe UI",
-          sans-serif;
+      .thumbnail-image {
+        display: block;
+        width: 100%;
+        max-width: 100%;
+        height: auto;
+        object-fit: contain;
+        border-radius: 0.75rem;
       }
 
       .note {
+        max-width: none;
         border-left: 3px solid var(--accent);
-        margin: 28px 0 36px;
-        padding: 2px 0 2px 18px;
-        color: var(--muted);
-        font:
-          16px/1.5 ui-sans-serif,
-          system-ui,
-          -apple-system,
-          BlinkMacSystemFont,
-          "Segoe UI",
-          sans-serif;
-      }
-
-      .spine {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 8px;
-        margin: 20px 0 32px;
-      }
-
-      .spine span {
-        border: 1px solid var(--line);
-        border-radius: 999px;
-        padding: 7px 11px;
-        color: var(--muted);
-        font:
-          13px/1 ui-sans-serif,
-          system-ui,
-          -apple-system,
-          BlinkMacSystemFont,
-          "Segoe UI",
-          sans-serif;
-      }
-
-      .callout,
-      .appendix {
-        border: 1px solid var(--line);
-        border-radius: 8px;
-        background: var(--panel);
-        padding: 20px;
+        margin: 0 0 var(--s-2);
+        padding: 0 0 0 var(--s-4);
+        color: var(--ink-muted);
       }
 
       .callout {
-        margin: 34px 0;
+        max-width: none;
+        border-radius: 0.75rem;
+        background: var(--surface);
+        padding: var(--s-5);
       }
 
-      .callout p:last-child,
-      .appendix p:last-child {
+      .callout {
+        margin: var(--s-3) 0;
+      }
+
+      .callout p:last-child {
         margin-bottom: 0;
       }
 
       ul,
       ol {
-        margin: 0 0 20px;
-        padding-left: 22px;
+        max-width: none;
+        margin: 0 0 var(--s-2);
+        padding-left: 1.25rem;
       }
 
       li {
-        margin: 0 0 9px;
+        margin: 0 0 var(--s-2);
       }
 
-      .appendix {
-        margin-top: 48px;
-        font:
-          15px/1.5 ui-sans-serif,
-          system-ui,
-          -apple-system,
-          BlinkMacSystemFont,
-          "Segoe UI",
-          sans-serif;
+      .site-footer {
+        display: flex;
+        align-items: center;
+        flex-wrap: wrap;
+        justify-content: space-between;
+        gap: var(--s-5);
+        margin-top: var(--s-8);
+        padding-block: var(--s-6);
+        color: var(--ink-muted);
+        font-size: var(--p-small);
       }
 
-      .appendix .label {
-        margin-bottom: 16px;
+      .footer-brand {
+        display: block;
+      }
+
+      .footer-mark {
+        margin: 0;
+        color: var(--ink);
+        font-weight: 600;
+      }
+
+      .footer-links {
+        display: inline-flex;
+        flex-wrap: wrap;
+        justify-content: flex-end;
+        gap: var(--s-2) var(--s-4);
+        margin: 0;
+        padding: 0;
+        list-style: none;
+      }
+
+      .footer-links a {
+        display: inline-flex;
+        align-items: center;
+        min-height: 44px;
+        color: var(--ink-muted);
+        text-decoration: none;
+        transition: color 0.2s;
+      }
+
+      .footer-links a:hover {
+        color: var(--accent);
       }
 
       code {
-        font-family:
-          ui-monospace,
-          SFMono-Regular,
-          Menlo,
-          monospace;
+        font-family: var(--mono);
         font-size: 0.92em;
+      }
+
+      @media (max-width: 720px) {
+        .nav {
+          flex-wrap: wrap;
+          gap: var(--s-2);
+          padding-block: var(--s-3);
+          margin-bottom: var(--s-2);
+        }
+
+        .wordmark {
+          font-size: 1.25rem;
+        }
+
+        .nav-links {
+          order: 3;
+          width: 100%;
+          column-gap: var(--s-3);
+        }
+
+        .theme-dot {
+          margin-left: auto;
+        }
+
+        .page {
+          padding-block: var(--s-2) var(--s-6);
+        }
+
+        h1 {
+          font-size: clamp(1.85rem, 7.4vw, 2.45rem);
+        }
+
+        .footer-brand {
+          width: 100%;
+        }
+
+        .footer-links {
+          justify-content: flex-start;
+        }
+
+        .thumbnail-frame {
+          padding: 10px;
+        }
       }
     </style>
   </head>
   <body>
-    <main>
-      <header>
-        <p class="eyebrow">draft newsletter issue</p>
+    <header class="frame nav">
+      <a href="https://anipotts.com/" class="wordmark">ani potts<span class="dot">.</span></a>
+      <nav class="nav-links" aria-label="primary">
+        <a class="nav-link" aria-current="page" href="https://anipotts.com/writing">writing</a>
+        <a class="nav-link" href="https://anipotts.com/making">making</a>
+        <a class="nav-link" href="https://anipotts.com/orchestrating">orchestrating</a>
+      </nav>
+      <span class="theme-dot" aria-hidden="true"></span>
+    </header>
+    <main class="frame page">
+      <article class="article">
+      <header class="head">
+        <a class="back-link" href="https://anipotts.com/writing">back to all posts</a>
         <h1>the first thing your agents need is a control plane</h1>
         <figure class="thumbnail-slot">
-          <div class="thumbnail-frame" role="img" aria-label="thumbnail or video preview placeholder">
-            <div class="thumbnail-inner">
-              <div class="thumbnail-bar" aria-hidden="true">
-                <span class="thumbnail-dot"></span>
-                <span class="thumbnail-dot"></span>
-                <span class="thumbnail-dot"></span>
-              </div>
-              <p class="thumbnail-title">media preview slot</p>
-              <p class="thumbnail-copy">
-                image, video, screenshot, or article preview goes here.
-              </p>
-            </div>
+          <div class="thumbnail-frame">
+            <img
+              class="thumbnail-image"
+              src="/media-thumbnail"
+              alt="screenshot of a coding-agent workflow preview"
+            />
           </div>
-          <figcaption class="thumbnail-caption">
-            placeholder for the visual asset tied to this issue.
-          </figcaption>
         </figure>
         <p class="dek">
-          what i am learning from turning admin.anipotts.com into a read-only
-          operator dashboard first, then a content review surface, then a
-          guarded write path.
+          every coding agent gets more useful when it knows what it is allowed
+          to do, what proof it owes, and when it needs to come back to me.
         </p>
       </header>
 
@@ -308,13 +409,6 @@
         every coding agent i use eventually runs into the same boring problem:
         it can make a change, but it needs a system around it for
         responsibility.
-      </p>
-
-      <p>
-        the control plane should make the important parts obvious: what i asked
-        it to do, who approved it, what it touched, what proof it left, and what
-        state changed after. if the answer only lives in the chat, the system is
-        too soft.
       </p>
 
       <p>
@@ -343,14 +437,6 @@
         cleanup all need explicit authority. the point of the control plane is
         to make that split visible before the agent touches the thing.
       </p>
-
-      <div class="spine">
-        <span>intent</span>
-        <span>authority</span>
-        <span>operation</span>
-        <span>proof</span>
-        <span>state</span>
-      </div>
 
       <h2>proof beats trust</h2>
 
@@ -401,58 +487,17 @@
           return one clear decision to me.
         </p>
       </div>
-
-      <section class="appendix">
-        <p class="label">x-thread compatible version</p>
-        <ol>
-          <li>
-            every coding agent i use eventually runs into the same boring
-            problem: it needs a place to put responsibility.
-          </li>
-          <li>
-            that is what i mean by a control plane.
-          </li>
-          <li>
-            the useful contract is
-            <code>intent -> authority -> operation -> proof -> state</code>.
-          </li>
-          <li>
-            safe lanes let agents move without asking me for permission every
-            five minutes.
-          </li>
-          <li>
-            hard gates keep dns, auth, secrets, sends, live endpoints, and
-            irreversible actions behind explicit authority.
-          </li>
-          <li>
-            proof beats trust because the next agent has to continue from the
-            artifact.
-          </li>
-          <li>
-            NEEDS-ANI is my human syscall queue: approval, choice, account-side
-            action, identity, payment, secret setup, final taste.
-          </li>
-          <li>
-            admin.anipotts.com should make state legible before it makes state
-            mutable.
-          </li>
-          <li>
-            the system i want is boring: agents know what they can do next.
-          </li>
-        </ol>
-      </section>
-
-      <section class="appendix">
-        <p class="label">blocked actions</p>
-        <ul>
-          <li>write production d1 issue</li>
-          <li>publish archive page</li>
-          <li>send test email or broadcast</li>
-          <li>change dns, auth, env, secrets, access, workers, or endpoints</li>
-          <li>add admin write path</li>
-          <li>merge to main</li>
-        </ul>
-      </section>
+      </article>
     </main>
+    <footer class="frame site-footer">
+      <div class="footer-brand">
+        <p class="footer-mark">ani potts</p>
+      </div>
+      <ul class="footer-links">
+        <li><a href="https://anipotts.com/writing">writing</a></li>
+        <li><a href="https://anipotts.com/making">making</a></li>
+        <li><a href="https://anipotts.com/orchestrating">orchestrating</a></li>
+      </ul>
+    </footer>
   </body>
 </html>

--- a/docs/platform-architecture.md
+++ b/docs/platform-architecture.md
@@ -61,7 +61,9 @@ covered while passkey proof and Access removal are completed, then remove
 | `/content`         | content inventory                    |
 | `/content/review`  | content proposal queue               |
 | `/content/preview` | draft preview                        |
+| `/newsletter`      | newsletter issue draft preview       |
 | `/needs-ani`       | typed human decision queue           |
+| `/proof`           | deploy, auth, and route proof log    |
 | `/repos`           | repo and worktree state              |
 | `/handoffs`        | handoff freshness                    |
 | `/fleet`           | machine and agent state              |


### PR DESCRIPTION
## summary
- add read-only Astro admin /newsletter route backed by static newsletter draft data
- add read-only /proof route for deploy/auth/content proof records
- absorb the newsletter preview worktree draft artifacts and update docs toward canonical apps/admin

## verification
- git diff --check
- pnpm turbo typecheck --filter=@anipotts/admin...
- pnpm turbo build --filter=@anipotts/admin...
- local dev smoke: /auth/passkey 200, /newsletter 302 to passkey auth, /proof 302 to passkey auth

## scope
- admin read-only UI/docs only
- no D1 write, send, publish, DNS, Access, env, secret, endpoint, or worker mutation

## note
- workflow route-smoke list updates were intentionally excluded because the current git push credential cannot update .github/workflows/*; apps/admin path changes should still trigger the admin deploy lane.