### PR TITLE
chore: add admin passkey proof script

### DIFF
--- a/docs/platform-architecture.md
+++ b/docs/platform-architecture.md
@@ -87,6 +87,12 @@ Required proof before removing Access:
 | unauthenticated block     | protected admin routes redirect to app-native auth    |
 | rollback                  | previous Access app or policy can be restored         |
 
+Use `pnpm --silent proof:admin-passkey` before and after enrollment. It reads
+the remote `anipotts-db` passkey tables and probes protected admin routes
+without printing Cloudflare Access tokens. The proof is not complete until it
+shows at least one active credential, an app-native session, logout proof in
+audit rows, and app-native route blocking after Access removal.
+
 ## ci/cd target
 
 Primary workflows:

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "clean": "turbo clean && rm -rf node_modules",
     "format": "prettier --write \"**/*.{ts,tsx,md,json}\"",
     "dev:www": "turbo dev --filter=@anipotts/www",
+    "proof:admin-passkey": "node scripts/admin/passkey-proof.mjs",
     "update-claude-stats": "node scripts/claude/generate-claude-stats.mjs",
     "update-claude-stats:commit": "bash scripts/claude/refresh-claude-stats.sh",
     "test:unit": "turbo test",

--- a/scripts/admin/passkey-proof.mjs
+++ b/scripts/admin/passkey-proof.mjs
@@ -1,0 +1,196 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+
+const ADMIN_ORIGIN =
+  process.env.ADMIN_ORIGIN?.replace(/\/$/, "") ?? "https://admin.anipotts.com";
+const D1_DATABASE = process.env.ADMIN_D1_DATABASE ?? "anipotts-db";
+const ROUTES = [
+  "/auth/passkey",
+  "/",
+  "/content",
+  "/content/review",
+  "/content/preview",
+  "/needs-ani",
+  "/newsletter",
+  "/proof",
+  "/repos",
+  "/handoffs",
+  "/fleet",
+  "/mutations",
+  "/ops/destructive",
+];
+
+const tableSql = `
+SELECT name
+FROM sqlite_master
+WHERE type='table' AND name LIKE 'admin_passkey_%'
+ORDER BY name;
+`;
+
+const countSql = `
+SELECT 'credentials' AS table_name, COUNT(*) AS count
+FROM admin_passkey_credentials
+WHERE revoked_at IS NULL
+UNION ALL
+SELECT 'sessions', COUNT(*)
+FROM admin_passkey_sessions
+WHERE revoked_at IS NULL AND expires_at > datetime('now')
+UNION ALL
+SELECT 'audit', COUNT(*)
+FROM admin_passkey_audit;
+`;
+
+const auditSql = `
+SELECT event_type, COUNT(*) AS count
+FROM admin_passkey_audit
+GROUP BY event_type
+ORDER BY event_type;
+`;
+
+const expectedTables = [
+  "admin_passkey_audit",
+  "admin_passkey_challenges",
+  "admin_passkey_credentials",
+  "admin_passkey_sessions",
+];
+
+const tables = runD1(tableSql).map((row) => String(row.name));
+const counts = Object.fromEntries(
+  runD1(countSql).map((row) => [String(row.table_name), Number(row.count)]),
+);
+const auditEvents = Object.fromEntries(
+  runD1(auditSql).map((row) => [String(row.event_type), Number(row.count)]),
+);
+const routes = await Promise.all(ROUTES.map(probeRoute));
+
+const schemaReady = expectedTables.every((table) => tables.includes(table));
+const credentialCount = counts.credentials ?? 0;
+const sessionCount = counts.sessions ?? 0;
+const auditCount = counts.audit ?? 0;
+const routeBoundary = summarizeBoundary(routes);
+
+const proof = {
+  checked_at: new Date().toISOString(),
+  admin_origin: ADMIN_ORIGIN,
+  d1_database: D1_DATABASE,
+  schema_ready: schemaReady,
+  tables,
+  counts: {
+    active_credentials: credentialCount,
+    active_sessions: sessionCount,
+    audit_events: auditCount,
+  },
+  audit_events: auditEvents,
+  routes,
+  route_boundary: routeBoundary,
+  next_safe_action: nextSafeAction({
+    schemaReady,
+    credentialCount,
+    sessionCount,
+    routeBoundary,
+  }),
+};
+
+console.log(JSON.stringify(proof, null, 2));
+
+function runD1(command) {
+  const output = execFileSync(
+    "pnpm",
+    [
+      "exec",
+      "wrangler",
+      "d1",
+      "execute",
+      D1_DATABASE,
+      "--remote",
+      "--json",
+      "--command",
+      command,
+    ],
+    {
+      cwd: new URL("../../", import.meta.url),
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+  const payload = JSON.parse(output);
+  const firstResult = payload[0];
+  if (!firstResult?.success) {
+    throw new Error(`D1 proof query failed for ${D1_DATABASE}`);
+  }
+  return firstResult.results ?? [];
+}
+
+async function probeRoute(path) {
+  const response = await fetch(`${ADMIN_ORIGIN}${path}`, {
+    method: "HEAD",
+    redirect: "manual",
+  });
+  const location = response.headers.get("location");
+  return {
+    path,
+    status: response.status,
+    boundary: classifyBoundary(location),
+    location: safeLocation(location),
+  };
+}
+
+function classifyBoundary(location) {
+  if (!location) return "rendered_or_blocked_without_location";
+  if (location.startsWith("/auth/passkey")) return "app_native_passkey";
+  try {
+    const url = new URL(location);
+    if (url.hostname.endsWith("cloudflareaccess.com")) {
+      return "cloudflare_access";
+    }
+    if (url.pathname.startsWith("/auth/passkey")) {
+      return "app_native_passkey";
+    }
+    return "external_redirect";
+  } catch {
+    return "unknown_redirect";
+  }
+}
+
+function safeLocation(location) {
+  if (!location) return null;
+  if (location.startsWith("/")) return location;
+  try {
+    const url = new URL(location);
+    return `${url.origin}${url.pathname}`;
+  } catch {
+    return "unparseable";
+  }
+}
+
+function summarizeBoundary(routes) {
+  const boundaries = new Set(routes.map((route) => route.boundary));
+  if (boundaries.has("cloudflare_access")) return "cloudflare_access";
+  if (boundaries.has("app_native_passkey")) return "app_native_passkey";
+  return "unknown";
+}
+
+function nextSafeAction({
+  schemaReady,
+  credentialCount,
+  sessionCount,
+  routeBoundary,
+}) {
+  if (!schemaReady) {
+    return "apply drizzle/migrations/0006_admin_passkeys.sql before enrollment";
+  }
+  if (credentialCount === 0) {
+    return "open /auth/passkey behind Cloudflare Access and register the first platform passkey";
+  }
+  if (sessionCount === 0) {
+    return "authenticate with the registered passkey and prove a durable app-native session";
+  }
+  if (routeBoundary === "cloudflare_access") {
+    return "prove logout and failure paths, then remove Cloudflare Access and rerun this proof";
+  }
+  if (routeBoundary === "app_native_passkey") {
+    return "record app-native unauthenticated block and authenticated route render proof";
+  }
+  return "inspect route boundary before changing Access";
+}


### PR DESCRIPTION
## summary
- add `pnpm --silent proof:admin-passkey` for read-only production passkey proof
- checks remote `anipotts-db` passkey table readiness, active credential/session/audit counts, and admin route boundary state
- sanitizes Cloudflare Access redirect locations so proof does not print Access tokens
- documents the proof command in `docs/platform-architecture.md`

## verification
- `node --check scripts/admin/passkey-proof.mjs`
- `pnpm --silent proof:admin-passkey`
- `pnpm exec prettier --check scripts/admin/passkey-proof.mjs docs/platform-architecture.md package.json`
- `git diff --check`
- `pnpm turbo typecheck --filter=@anipotts/admin...`
- `pnpm turbo build --filter=@anipotts/admin...`

## current proof result
- `schema_ready: true`
- `active_credentials: 0`
- `active_sessions: 0`
- `route_boundary: cloudflare_access`
- next safe action: register the first platform passkey behind Cloudflare Access

## scope
- no deploy expected
- no D1 writes
- no DNS, Access, env, secret, endpoint, worker, or auth policy mutation
