### PR TITLE
ci: smoke new admin routes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -218,7 +218,7 @@ jobs:
       - name: Smoke admin unauthenticated block
         run: |
           set -euo pipefail
-          for path in /auth/passkey / /content /content/review /content/preview /needs-ani /repos /fleet; do
+          for path in /auth/passkey / /content /content/review /content/preview /newsletter /needs-ani /proof /repos /fleet; do
             ok=false
             for _ in $(seq 1 6); do
               code="$(curl -sS -o /dev/null -w '%{http_code}' "https://admin.anipotts.com${path}")"

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -43,7 +43,7 @@ jobs:
         if: inputs.target == 'admin'
         run: |
           set -euo pipefail
-          for path in /auth/passkey / /content /content/review /content/preview /needs-ani /repos /fleet; do
+          for path in /auth/passkey / /content /content/review /content/preview /newsletter /needs-ani /proof /repos /fleet; do
             code="$(curl -sS -o /dev/null -w '%{http_code}' "https://admin.anipotts.com${path}")"
             echo "https://admin.anipotts.com${path} -> ${code}"
             case "$path:$code" in


### PR DESCRIPTION
## summary
- add `/newsletter` and `/proof` to admin deploy smoke route coverage
- add the same routes to manual `smoke.yml` admin route coverage

## verification
- `pnpm exec prettier --check .github/workflows/deploy.yml .github/workflows/smoke.yml`
- `git diff --check`

## scope
- workflow smoke coverage only
- no app deploy target expected from this PR
- no DNS, Access, env, secret, endpoint, worker, D1, or auth policy mutation
