### PR TITLE
feat: add content operation schema

### DIFF
--- a/apps/admin/src/pages/content/review.astro
+++ b/apps/admin/src/pages/content/review.astro
@@ -3,6 +3,9 @@ import AdminLayout from "../../layouts/AdminLayout.astro";
 import {
   contentInventory,
   contentInventorySource,
+  contentOperationSchemaSource,
+  contentOperationTables,
+  contentOperationTemplates,
   contentPreviewItems,
 } from "../../data/content";
 
@@ -16,7 +19,53 @@ const surfaces = ["homepage", "projects", "writing", "newsletter"] as const;
   <section class="meta-strip" aria-label="content review source">
     <span>{contentInventory.length} sources</span>
     <span>{contentPreviewItems.length} previews</span>
+    <span>{contentOperationTables.length} d1 tables</span>
     <span>{contentInventorySource.architecture_doc}</span>
+  </section>
+
+  <section class="table-card operation-card">
+    <div class="section-head">
+      <div>
+        <p>operation schema</p>
+        <h2>draft model is ready for D1</h2>
+      </div>
+      <span>{contentOperationSchemaSource.mode}</span>
+    </div>
+    <div class="lane-grid">
+      <div>
+        <h3>tables</h3>
+        <div class="record-list">
+          {
+            contentOperationTables.map((table) => (
+              <article class="compact-row">
+                <strong>{table.table}</strong>
+                <span>{table.write_state}</span>
+                <small>{table.purpose}</small>
+              </article>
+            ))
+          }
+        </div>
+      </div>
+      <div>
+        <h3>sample operation</h3>
+        <div class="record-list">
+          {
+            contentOperationTemplates.map((operation) => (
+              <article class="compact-row">
+                <strong>{operation.operation_id}</strong>
+                <span>
+                  {operation.status} / {operation.authority_state}
+                </span>
+                <small>
+                  allowed: {operation.allowed_actions.join(", ")}. blocked:{" "}
+                  {operation.forbidden_actions.join(", ")}.
+                </small>
+              </article>
+            ))
+          }
+        </div>
+      </div>
+    </div>
   </section>
 
   <div class="review-board">

--- a/apps/admin/src/styles/admin.css
+++ b/apps/admin/src/styles/admin.css
@@ -251,6 +251,10 @@ th {
   margin-top: 24px;
 }
 
+.operation-card {
+  margin-top: 24px;
+}
+
 .preview-grid {
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }

--- a/docs/admin-content-draft-operations.md
+++ b/docs/admin-content-draft-operations.md
@@ -1,7 +1,7 @@
 # admin content draft operations
 
-Date: 2026-06-25
-Status: approved for schema and inert design only
+Date: 2026-06-27
+Status: approved for additive schema and inert design only
 
 ## purpose
 
@@ -122,17 +122,19 @@ The first implementation should expose disabled controls only:
 No hidden API routes should exist for disabled controls. A disabled button is
 not enough if an endpoint can still be called directly.
 
-## future storage
+## storage
 
-The eventual content store can use tables shaped like:
+The content store now has an additive D1 schema proposal in
+`drizzle/migrations/0007_content_operations.sql`, mirrored in the canonical
+Drizzle schema at `packages/lib/src/db/schema.ts`.
 
 - `content_records`: published field overrides
 - `content_draft_operations`: draft and preview operations
 - `content_publish_events`: immutable publish proof
 
-Storage design remains gated. This doc does not authorize a D1 migration,
-binding change, Worker route, content write API, public-site runtime read from
-records, or publish action.
+This authorizes the additive schema only. It does not authorize a binding
+change, Worker route, content write API, public-site runtime read from records,
+browser save action, outbound send, or publish action.
 
 ## proof requirements before writes
 

--- a/docs/platform-architecture.md
+++ b/docs/platform-architecture.md
@@ -15,8 +15,8 @@ structured content/state model, and one predictable CI/CD path.
 | legacy admin   | `docs/archive/admin-next-legacy.md` | archived            | no Next admin app remains                                |
 | labs           | `docs/archive/labs`                 | archived            | no app or deploy target remains                          |
 | workers        | `workers/*`                         | review individually | keep only production-required workers                    |
-| shared content | `packages/content`, `packages/lib`  | started             | keep content/editor schema in `packages/content`         |
-| database       | `drizzle`, D1 `anipotts-db`         | keep                | use for content/admin state with reviewed migrations     |
+| shared content | `packages/content`, `packages/lib`  | in progress         | use package contracts plus D1 operation tables           |
+| database       | `drizzle`, D1 `anipotts-db`         | keep                | apply additive content operation schema, then prove it   |
 
 ## current inventory
 
@@ -128,5 +128,6 @@ Rules:
    2026-06-27.
 8. review workers and delete unneeded worker targets.
 9. expand `packages/content` from static content inventory into the durable
-   content schema and D1 adapter layer.
+   operation schema and D1 adapter layer. started with
+   `drizzle/migrations/0007_content_operations.sql`.
 10. reduce deploy workflow inputs to retained production targets.

--- a/drizzle/migrations/0007_content_operations.sql
+++ b/drizzle/migrations/0007_content_operations.sql
@@ -1,0 +1,93 @@
+-- 0007_content_operations.sql
+-- Additive schema for the admin content operation model.
+--
+-- This creates storage for reviewable content records, draft operations, and
+-- publish proof events. It does not add write APIs, publish routes, outbound
+-- sends, triggers, or automatic public-site reads.
+
+CREATE TABLE IF NOT EXISTS content_records (
+  id TEXT PRIMARY KEY,
+  content_key TEXT NOT NULL UNIQUE,
+  surface TEXT NOT NULL,
+  route TEXT NOT NULL,
+  field_path TEXT NOT NULL,
+  value TEXT NOT NULL,
+  value_format TEXT NOT NULL DEFAULT 'text',
+  status TEXT NOT NULL DEFAULT 'draft',
+  version INTEGER NOT NULL DEFAULT 1,
+  source_ref TEXT NOT NULL,
+  proof_ids TEXT NOT NULL DEFAULT '[]',
+  metadata TEXT NOT NULL DEFAULT '{}',
+  published_at TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  updated_by TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_content_records_surface_route
+  ON content_records (surface, route);
+
+CREATE INDEX IF NOT EXISTS idx_content_records_status
+  ON content_records (status, updated_at);
+
+CREATE TABLE IF NOT EXISTS content_draft_operations (
+  operation_id TEXT PRIMARY KEY,
+  kind TEXT NOT NULL DEFAULT 'content_draft',
+  surface TEXT NOT NULL,
+  route TEXT NOT NULL,
+  source_ref TEXT NOT NULL,
+  field_path TEXT NOT NULL,
+  current_value_ref TEXT NOT NULL,
+  proposed_value TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'draft',
+  risk_level TEXT NOT NULL DEFAULT 'low',
+  authority_state TEXT NOT NULL,
+  required_approval_ids TEXT NOT NULL DEFAULT '[]',
+  allowed_actions TEXT NOT NULL DEFAULT '[]',
+  forbidden_actions TEXT NOT NULL DEFAULT '[]',
+  preview_targets TEXT NOT NULL DEFAULT '[]',
+  proof_ids TEXT NOT NULL DEFAULT '[]',
+  evidence_uri TEXT,
+  redaction TEXT NOT NULL,
+  created_by TEXT NOT NULL DEFAULT 'agent',
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  expires_at TEXT,
+  rollback_ref TEXT NOT NULL,
+  reviewer_note TEXT,
+  metadata TEXT NOT NULL DEFAULT '{}'
+);
+
+CREATE INDEX IF NOT EXISTS idx_content_draft_operations_status
+  ON content_draft_operations (status, updated_at);
+
+CREATE INDEX IF NOT EXISTS idx_content_draft_operations_surface_route
+  ON content_draft_operations (surface, route);
+
+CREATE INDEX IF NOT EXISTS idx_content_draft_operations_risk
+  ON content_draft_operations (risk_level, authority_state);
+
+CREATE TABLE IF NOT EXISTS content_publish_events (
+  id TEXT PRIMARY KEY,
+  operation_id TEXT,
+  content_record_id TEXT,
+  event_type TEXT NOT NULL,
+  status TEXT NOT NULL,
+  summary TEXT NOT NULL,
+  proof_ids TEXT NOT NULL DEFAULT '[]',
+  rollback_ref TEXT NOT NULL,
+  created_by TEXT NOT NULL DEFAULT 'agent',
+  created_at TEXT NOT NULL,
+  metadata TEXT NOT NULL DEFAULT '{}',
+  FOREIGN KEY (operation_id) REFERENCES content_draft_operations(operation_id),
+  FOREIGN KEY (content_record_id) REFERENCES content_records(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_content_publish_events_operation
+  ON content_publish_events (operation_id, created_at);
+
+CREATE INDEX IF NOT EXISTS idx_content_publish_events_record
+  ON content_publish_events (content_record_id, created_at);
+
+CREATE INDEX IF NOT EXISTS idx_content_publish_events_type
+  ON content_publish_events (event_type, created_at);

--- a/packages/content/src/admin/index.ts
+++ b/packages/content/src/admin/index.ts
@@ -1,2 +1,3 @@
 export * from "./content";
 export * from "./newsletter";
+export * from "./operations";

--- a/packages/content/src/admin/operations.ts
+++ b/packages/content/src/admin/operations.ts
@@ -1,0 +1,145 @@
+import type { RiskLevel } from "./content";
+
+export type ContentOperationKind =
+  | "content_record"
+  | "content_draft"
+  | "content_publish";
+
+export type ContentOperationStatus =
+  | "draft"
+  | "previewed"
+  | "needs_ani"
+  | "blocked"
+  | "approved"
+  | "publishing"
+  | "published"
+  | "verified"
+  | "reverted";
+
+export type ContentOperationSurface = "public_site" | "newsletter" | "admin";
+
+export type ContentOperation = {
+  operation_id: string;
+  kind: ContentOperationKind;
+  surface: ContentOperationSurface;
+  route: string;
+  source_ref: string;
+  field_path: string;
+  current_value_ref: string;
+  proposed_value: string;
+  status: ContentOperationStatus;
+  risk_level: RiskLevel;
+  authority_state: string;
+  required_approval_ids: string[];
+  allowed_actions: string[];
+  forbidden_actions: string[];
+  preview_targets: string[];
+  proof_ids: string[];
+  evidence_uri?: string;
+  redaction: string;
+  created_by: "agent" | "ani" | "system";
+  created_at: string;
+  updated_at: string;
+  expires_at?: string;
+  rollback_ref: string;
+  reviewer_note?: string;
+};
+
+export type ContentOperationTable = {
+  table:
+    | "content_records"
+    | "content_draft_operations"
+    | "content_publish_events";
+  purpose: string;
+  write_state: "schema_only" | "inert_preview" | "future_publish";
+  blocked_actions: string[];
+};
+
+export const contentOperationSchemaSource = {
+  source_doc: "docs/admin-content-draft-operations.md",
+  migration: "drizzle/migrations/0007_content_operations.sql",
+  schema: "packages/lib/src/db/schema.ts",
+  mode: "d1_schema_no_write_endpoint",
+};
+
+export const contentOperationTables: ContentOperationTable[] = [
+  {
+    table: "content_records",
+    purpose:
+      "future published field overrides for public-site and newsletter copy",
+    write_state: "schema_only",
+    blocked_actions: ["browser save", "public-site runtime read", "publish"],
+  },
+  {
+    table: "content_draft_operations",
+    purpose:
+      "draft and preview operations with authority, proof, rollback, and blocked action metadata",
+    write_state: "inert_preview",
+    blocked_actions: ["hidden api write", "direct source edit", "auto deploy"],
+  },
+  {
+    table: "content_publish_events",
+    purpose:
+      "future immutable proof trail for approved publish and rollback events",
+    write_state: "future_publish",
+    blocked_actions: ["send", "schedule", "publish without proof"],
+  },
+];
+
+export const contentOperationTemplates: ContentOperation[] = [
+  {
+    operation_id: "content-draft-homepage-summary-2026-06-27",
+    kind: "content_draft",
+    surface: "public_site",
+    route: "/",
+    source_ref: "apps/www/src/data/site.ts:homeContent.summary",
+    field_path: "homepage.summary",
+    current_value_ref: "source_default",
+    proposed_value:
+      "previously worked on real-time agent i/o at structured ai (YC F25) and our bad habit, an atlantic records venture. now i write about coding agent workflows and the systems around them.",
+    status: "previewed",
+    risk_level: "medium",
+    authority_state: "preview_only_no_write",
+    required_approval_ids: [],
+    allowed_actions: ["render_preview", "request_review"],
+    forbidden_actions: ["save", "publish", "deploy", "send"],
+    preview_targets: ["/content/preview", "/"],
+    proof_ids: [
+      "content.homepage.summary.source",
+      "admin.content.preview.local",
+    ],
+    evidence_uri: "repo://apps/www/src/data/site.ts",
+    redaction: "public_copy_only",
+    created_by: "agent",
+    created_at: "2026-06-27T00:00:00Z",
+    updated_at: "2026-06-27T00:00:00Z",
+    expires_at: "2026-07-27T00:00:00Z",
+    rollback_ref: "source_default",
+  },
+  {
+    operation_id: "content-draft-newsletter-block-source-2026-06-27",
+    kind: "content_draft",
+    surface: "newsletter",
+    route: "/newsletter",
+    source_ref: "apps/www/src/components/NewsletterSubscribe.astro",
+    field_path: "newsletter.subscribe_copy",
+    current_value_ref: "component_default",
+    proposed_value:
+      "model newsletter headline, deck, CTA, success text, and error text as content records before enabling saves",
+    status: "blocked",
+    risk_level: "medium",
+    authority_state: "needs_source_truth_decision",
+    required_approval_ids: ["content.newsletter-source.owner-decision"],
+    allowed_actions: ["render_preview", "request_review"],
+    forbidden_actions: ["save", "publish", "send", "sync_provider"],
+    preview_targets: ["/content/preview", "/newsletter"],
+    proof_ids: ["content.newsletter.component.defaults"],
+    evidence_uri: "repo://apps/www/src/components/NewsletterSubscribe.astro",
+    redaction: "public_copy_only",
+    created_by: "agent",
+    created_at: "2026-06-27T00:00:00Z",
+    updated_at: "2026-06-27T00:00:00Z",
+    expires_at: "2026-07-27T00:00:00Z",
+    rollback_ref: "component_default",
+  },
+];

--- a/packages/lib/src/db/schema.ts
+++ b/packages/lib/src/db/schema.ts
@@ -779,3 +779,115 @@ export const adminPasskeyAudit = sqliteTable(
     ),
   ],
 );
+
+// ---------------------------------------------------------------------------
+// 26. content editor operation staging
+// ---------------------------------------------------------------------------
+
+export const contentRecords = sqliteTable(
+  "content_records",
+  {
+    id: text("id").primaryKey(),
+    content_key: text("content_key").notNull().unique(),
+    surface: text("surface").notNull(),
+    route: text("route").notNull(),
+    field_path: text("field_path").notNull(),
+    value: text("value").notNull(),
+    value_format: text("value_format").notNull().default("text"),
+    status: text("status").notNull().default("draft"),
+    version: integer("version").notNull().default(1),
+    source_ref: text("source_ref").notNull(),
+    proof_ids: text("proof_ids").notNull().default("[]"),
+    metadata: text("metadata").notNull().default("{}"),
+    published_at: text("published_at"),
+    created_at: text("created_at").notNull(),
+    updated_at: text("updated_at").notNull(),
+    updated_by: text("updated_by"),
+  },
+  (table) => [
+    index("idx_content_records_surface_route").on(table.surface, table.route),
+    index("idx_content_records_status").on(table.status, table.updated_at),
+  ],
+);
+
+export const contentDraftOperations = sqliteTable(
+  "content_draft_operations",
+  {
+    operation_id: text("operation_id").primaryKey(),
+    kind: text("kind").notNull().default("content_draft"),
+    surface: text("surface").notNull(),
+    route: text("route").notNull(),
+    source_ref: text("source_ref").notNull(),
+    field_path: text("field_path").notNull(),
+    current_value_ref: text("current_value_ref").notNull(),
+    proposed_value: text("proposed_value").notNull(),
+    status: text("status").notNull().default("draft"),
+    risk_level: text("risk_level").notNull().default("low"),
+    authority_state: text("authority_state").notNull(),
+    required_approval_ids: text("required_approval_ids")
+      .notNull()
+      .default("[]"),
+    allowed_actions: text("allowed_actions").notNull().default("[]"),
+    forbidden_actions: text("forbidden_actions").notNull().default("[]"),
+    preview_targets: text("preview_targets").notNull().default("[]"),
+    proof_ids: text("proof_ids").notNull().default("[]"),
+    evidence_uri: text("evidence_uri"),
+    redaction: text("redaction").notNull(),
+    created_by: text("created_by").notNull().default("agent"),
+    created_at: text("created_at").notNull(),
+    updated_at: text("updated_at").notNull(),
+    expires_at: text("expires_at"),
+    rollback_ref: text("rollback_ref").notNull(),
+    reviewer_note: text("reviewer_note"),
+    metadata: text("metadata").notNull().default("{}"),
+  },
+  (table) => [
+    index("idx_content_draft_operations_status").on(
+      table.status,
+      table.updated_at,
+    ),
+    index("idx_content_draft_operations_surface_route").on(
+      table.surface,
+      table.route,
+    ),
+    index("idx_content_draft_operations_risk").on(
+      table.risk_level,
+      table.authority_state,
+    ),
+  ],
+);
+
+export const contentPublishEvents = sqliteTable(
+  "content_publish_events",
+  {
+    id: text("id").primaryKey(),
+    operation_id: text("operation_id").references(
+      () => contentDraftOperations.operation_id,
+    ),
+    content_record_id: text("content_record_id").references(
+      () => contentRecords.id,
+    ),
+    event_type: text("event_type").notNull(),
+    status: text("status").notNull(),
+    summary: text("summary").notNull(),
+    proof_ids: text("proof_ids").notNull().default("[]"),
+    rollback_ref: text("rollback_ref").notNull(),
+    created_by: text("created_by").notNull().default("agent"),
+    created_at: text("created_at").notNull(),
+    metadata: text("metadata").notNull().default("{}"),
+  },
+  (table) => [
+    index("idx_content_publish_events_operation").on(
+      table.operation_id,
+      table.created_at,
+    ),
+    index("idx_content_publish_events_record").on(
+      table.content_record_id,
+      table.created_at,
+    ),
+    index("idx_content_publish_events_type").on(
+      table.event_type,
+      table.created_at,
+    ),
+  ],
+);


### PR DESCRIPTION
## Summary
- add additive D1 migration 0007 for content records, draft operations, and publish proof events
- mirror the tables in the canonical Drizzle schema and shared content operation contract
- render the inert operation layer on the Astro admin content review page

## Safety
- no save API
- no publish route
- no outbound send
- no hidden write endpoint
- no env, secret, DNS, or auth change

## Verification
- pnpm turbo typecheck --filter=@anipotts/content... --filter=@anipotts/lib... --filter=@anipotts/admin...
- pnpm turbo build --filter=@anipotts/content... --filter=@anipotts/lib... --filter=@anipotts/admin...
- pnpm turbo lint --filter=@anipotts/admin...
- pnpm turbo test --filter=@anipotts/lib...
- disposable SQLite migration smoke for drizzle/migrations/0007_content_operations.sql
- git diff --check