### PR TITLE
chore: cover operations in admin proof

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,8 @@ For `admin.anipotts.com`, use this order:
 3. deploy `admin=true` only
 4. prove passkey register, login, logout, session persistence, and blocked
    failure paths
-5. prove `/auth/passkey`, `/`, `/content`, `/content/review`, and `/needs-ani`
+5. prove `/auth/passkey`, `/`, `/content`, `/content/review`,
+   `/content/preview`, `/content/operations`, and `/needs-ani`
 6. remove Cloudflare Access only after proof passes
 7. verify app-native unauthenticated block and authenticated passkey access
 8. rollback by restoring the previous Access app or policy if proof fails

--- a/apps/admin/src/data/proof.ts
+++ b/apps/admin/src/data/proof.ts
@@ -50,7 +50,7 @@ export const proofEntries: ProofEntry[] = [
     status: "verified",
     title: "admin unauthenticated block holds",
     summary:
-      "Unauthenticated probes returned 302 for /auth/passkey, /, /content, /content/review, /content/preview, /needs-ani, /repos, and /fleet.",
+      "Unauthenticated probes returned 302 for /auth/passkey, /, /content, /content/review, /content/preview, /content/operations, /needs-ani, /repos, and /fleet.",
     evidence_uri: "https://admin.anipotts.com/auth/passkey",
     redaction: "protected_route",
     next_safe_action:
@@ -86,7 +86,7 @@ export const proofEntries: ProofEntry[] = [
     status: "pending",
     title: "admin write paths remain inert",
     summary:
-      "Content preview, review, mutation, and destructive-operation routes expose no save, publish, send, or live-control endpoint.",
+      "Content preview, review, operations, mutation, and destructive-operation routes expose no save, publish, send, or live-control endpoint.",
     evidence_uri: "apps/admin/src/pages",
     redaction: "metadata_only",
     next_safe_action:

--- a/docs/admin-auth-content-adr.md
+++ b/docs/admin-auth-content-adr.md
@@ -287,7 +287,7 @@ Required before writes:
 Implementation order:
 
 1. Continue read-only admin routes: `/content`, `/content/preview`,
-   `/content/review`.
+   `/content/review`, and `/content/operations`.
 2. Add a typed draft operation model with static samples only.
 3. Add a disabled write affordance that names the required authority.
 4. Design the content store schema and migration.

--- a/docs/admin-passkey-auth-plan.md
+++ b/docs/admin-passkey-auth-plan.md
@@ -126,7 +126,7 @@ Before removing Cloudflare Access:
 
 1. keep the existing Cloudflare Access app and policy config documented
 2. prove passkey auth on `/auth/passkey`, `/`, `/content`, `/content/review`,
-   and `/needs-ani`
+   `/content/preview`, `/content/operations`, and `/needs-ani`
 3. remove Access only in a single reviewed change
 4. if app-native auth blocks Ani or exposes an unexpected gap, restore the
    previous Access app/policy for `admin.anipotts.com` and leave passkey auth as

--- a/docs/platform-architecture.md
+++ b/docs/platform-architecture.md
@@ -55,21 +55,22 @@ The Astro admin replacement covers these live admin-solid routes. Keep them
 covered while passkey proof and Access removal are completed, then remove
 `apps/admin-solid`:
 
-| Route              | Purpose                              |
-| ------------------ | ------------------------------------ |
-| `/`                | operator overview                    |
-| `/auth/passkey`    | app-native passkey auth              |
-| `/content`         | content inventory                    |
-| `/content/review`  | content proposal queue               |
-| `/content/preview` | draft preview                        |
-| `/newsletter`      | newsletter issue draft preview       |
-| `/needs-ani`       | typed human decision queue           |
-| `/proof`           | deploy, auth, and route proof log    |
-| `/repos`           | repo and worktree state              |
-| `/handoffs`        | handoff freshness                    |
-| `/fleet`           | machine and agent state              |
-| `/mutations`       | mutation queue                       |
-| `/ops/destructive` | gated destructive-operation register |
+| Route                 | Purpose                              |
+| --------------------- | ------------------------------------ |
+| `/`                   | operator overview                    |
+| `/auth/passkey`       | app-native passkey auth              |
+| `/content`            | content inventory                    |
+| `/content/review`     | content proposal queue               |
+| `/content/preview`    | draft preview                        |
+| `/content/operations` | read-only D1 content operation state |
+| `/newsletter`         | newsletter issue draft preview       |
+| `/needs-ani`          | typed human decision queue           |
+| `/proof`              | deploy, auth, and route proof log    |
+| `/repos`              | repo and worktree state              |
+| `/handoffs`           | handoff freshness                    |
+| `/fleet`              | machine and agent state              |
+| `/mutations`          | mutation queue                       |
+| `/ops/destructive`    | gated destructive-operation register |
 
 ## auth target
 
@@ -92,7 +93,8 @@ Use `pnpm --silent proof:admin-passkey` before and after enrollment. It reads
 the remote `anipotts-db` passkey tables and probes protected admin routes
 without printing Cloudflare Access tokens. The proof is not complete until it
 shows at least one active credential, an app-native session, logout proof in
-audit rows, and app-native route blocking after Access removal.
+audit rows, and app-native route blocking after Access removal. The route probe
+set must include the content inventory, review, preview, and operations routes.
 
 ## ci/cd target
 

--- a/scripts/admin/passkey-proof.mjs
+++ b/scripts/admin/passkey-proof.mjs
@@ -11,6 +11,7 @@ const ROUTES = [
   "/content",
   "/content/review",
   "/content/preview",
+  "/content/operations",
   "/needs-ani",
   "/newsletter",
   "/proof",


### PR DESCRIPTION
## Summary
- add /content/operations to the passkey proof route set
- update the admin proof docs and static proof copy so route coverage matches the current Astro admin surface

## Safety
- proof/docs/admin-copy only
- no auth policy change
- no D1 mutation
- no env, secret, DNS, or write path change

## Verification
- pnpm --silent proof:admin-passkey
- pnpm turbo typecheck --filter=@anipotts/admin...
- pnpm turbo build --filter=@anipotts/admin...
- git diff --check
