### PR TITLE
ci: tighten admin deploy targets

### DIFF
--- a/.github/workflows/agent-automerge.yml
+++ b/.github/workflows/agent-automerge.yml
@@ -72,7 +72,7 @@ jobs:
                 ;;
             esac
             case "$file" in
-              apps/admin/*|packages/config/*|packages/content/*|packages/lib/*|packages/services-platform/*|packages/styles/*|packages/types/*|services/*)
+              apps/admin/*|packages/content/*)
                 admin=true
                 ;;
             esac

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -100,13 +100,7 @@ jobs:
               - "packages/types/**"
             admin:
               - "apps/admin/**"
-              - "packages/config/**"
               - "packages/content/**"
-              - "packages/lib/**"
-              - "packages/services-platform/**"
-              - "packages/styles/**"
-              - "packages/types/**"
-              - "services/**"
             admin-solid:
               - "apps/admin-solid/**"
             ingest:

--- a/docs/platform-architecture.md
+++ b/docs/platform-architecture.md
@@ -31,12 +31,12 @@ structured content/state model, and one predictable CI/CD path.
 
 ### workers
 
-| Path                   | Role today                               | Classification                   |
-| ---------------------- | ---------------------------------------- | -------------------------------- |
-| `workers/ingest`       | ingest worker                            | review                           |
-| `workers/newsletter`   | newsletter queue worker                  | review                           |
-| `workers/state`        | `api.anipotts.com` state plane candidate | keep with explicit deploy target |
-| `workers/weekly-email` | weekly email worker                      | review                           |
+| Path                   | Role today                                                   | Classification                        |
+| ---------------------- | ------------------------------------------------------------ | ------------------------------------- |
+| `workers/ingest`       | deployed cron/fetch worker for D1 ingest and event receivers | keep, review writers before expansion |
+| `workers/newsletter`   | deployed queue/fetch worker for newsletter sends             | keep, outbound-send gated             |
+| `workers/state`        | deployed `api.anipotts.com` durable-object state plane       | keep with explicit deploy target      |
+| `workers/weekly-email` | deployed scheduled email worker                              | keep, outbound-send gated             |
 
 ### packages
 
@@ -112,7 +112,10 @@ Rules:
 - docs-only changes deploy nothing.
 - lockfile and root package changes never deploy every target by default.
 - public site changes deploy `www` only.
-- admin changes deploy only the affected admin target.
+- admin changes and `packages/content` changes deploy only the Astro admin
+  target.
+- `packages/lib` and `packages/styles` changes deploy `www` only because
+  `apps/admin` does not depend on them.
 - `deploy.yml` records route proof inside the `www` and `admin` deploy jobs.
 - D1 migrations run as reviewed migration steps before app deploy.
 - Anthropic and Claude Code API-backed GitHub workflows are disabled for this


### PR DESCRIPTION
## Summary
- stop treating packages/lib, packages/styles, packages/types, packages/config, services, and packages/services-platform as admin deploy inputs
- keep admin deploy targeting to apps/admin and packages/content, which matches the current package graph
- replace vague worker review labels with evidence-backed live classifications

## Verification
- local deploy-target mapping smoke:
  - packages/lib -> www=true admin=false
  - packages/content -> www=false admin=true
  - apps/admin -> www=false admin=true
  - apps/www -> www=true admin=false
  - workflow-only -> all false
  - docs-only -> all false
- pnpm exec prettier --write .github/workflows/agent-automerge.yml .github/workflows/deploy.yml docs/platform-architecture.md
- git diff --check

## Notes
- actionlint is not installed locally; GitHub CI is the workflow syntax gate.
- no deploy should be dispatched for this workflow/docs-only PR.
