### PR TITLE
feat: preview newsletter drafts in admin

### DIFF
--- a/apps/admin/src/pages/newsletter.astro
+++ b/apps/admin/src/pages/newsletter.astro
@@ -30,6 +30,14 @@ import { newsletterDrafts, newsletterDraftsSource } from "../data/newsletter";
               <h3>draft</h3>
               <p>{draft.summary}</p>
               <p>{draft.dek}</p>
+              <div class="actions">
+                <a class="button" href={`/newsletter/${draft.slug}`}>
+                  review preview
+                </a>
+                <span class="button secondary inert-button">
+                  save/send disabled
+                </span>
+              </div>
               <dl>
                 <div>
                   <dt>subject</dt>

--- a/apps/admin/src/pages/newsletter/[slug].astro
+++ b/apps/admin/src/pages/newsletter/[slug].astro
@@ -1,0 +1,157 @@
+---
+import AdminLayout from "../../layouts/AdminLayout.astro";
+import { newsletterDrafts, newsletterDraftsSource } from "../../data/newsletter";
+
+const { slug } = Astro.params;
+const draft = newsletterDrafts.find((item) => item.slug === slug);
+
+if (!draft) {
+  Astro.response.status = 404;
+}
+---
+
+<AdminLayout
+  title={draft ? `newsletter / ${draft.slug}` : "newsletter / missing"}
+  deck="Read-only issue preview. This route reviews draft shape and public-post aesthetics without D1 writes, archive publishing, sends, or worker controls."
+>
+  {
+    draft ? (
+      <>
+        <section class="meta-strip" aria-label="newsletter preview source">
+          <span>{draft.status}</span>
+          <span>{newsletterDraftsSource.mode}</span>
+          <span>{draft.source_fixture}</span>
+          <span>write path inactive</span>
+        </section>
+
+        <div class="newsletter-preview-layout">
+          <article class="newsletter-article-preview" aria-label="issue preview">
+            <a class="back-link" href="/newsletter">
+              back to issue queue
+            </a>
+            <header class="newsletter-article-head">
+              <p>draft newsletter issue</p>
+              <h2>{draft.title}</h2>
+              <div class="newsletter-media-slot" role="img" aria-label="draft media preview placeholder">
+                <div>
+                  <span>media preview slot</span>
+                  <strong>image, screenshot, or article preview</strong>
+                </div>
+              </div>
+              <p class="newsletter-dek">{draft.dek}</p>
+            </header>
+
+            <p>{draft.hook.body}</p>
+
+            <div class="newsletter-spine">
+              {draft.spine.map((item) => (
+                <span>{item}</span>
+              ))}
+            </div>
+
+            {draft.sections.map((section) => (
+              <section class="newsletter-section">
+                {section.heading && <h3>{section.heading}</h3>}
+                {section.label && <h3>{section.label}</h3>}
+                <p>{section.body}</p>
+                {section.items && (
+                  <ul>
+                    {section.items.map((item) => (
+                      <li>{item}</li>
+                    ))}
+                  </ul>
+                )}
+                {section.thread_beat && <small>{section.thread_beat}</small>}
+              </section>
+            ))}
+
+            <aside class="newsletter-close">
+              <h3>working close</h3>
+              <p>{draft.close.body}</p>
+              <small>{draft.close.cta}</small>
+            </aside>
+          </article>
+
+          <aside class="newsletter-proof-panel" aria-label="draft proof and gates">
+            <section class="table-card">
+              <div class="section-head">
+                <div>
+                  <p>proof</p>
+                  <h2>{draft.claims.length} claims</h2>
+                </div>
+                <span>{newsletterDraftsSource.blocked}</span>
+              </div>
+              <div class="record-list">
+                {draft.claims.map((claim) => (
+                  <article class="compact-row">
+                    <strong>{claim.claim}</strong>
+                    <span>{claim.status}</span>
+                    <small>{claim.source_refs.join(", ")}</small>
+                  </article>
+                ))}
+              </div>
+            </section>
+
+            <section class="table-card">
+              <div class="section-head">
+                <div>
+                  <p>sources</p>
+                  <h2>{draft.source_refs.length} refs</h2>
+                </div>
+                <span>{newsletterDraftsSource.source_doc}</span>
+              </div>
+              <div class="record-list">
+                {draft.source_refs.map((source) => (
+                  <article class="compact-row">
+                    <strong>{source.ref}</strong>
+                    <small>{source.use}</small>
+                  </article>
+                ))}
+              </div>
+            </section>
+
+            <section class="table-card">
+              <div class="section-head">
+                <div>
+                  <p>blocked live actions</p>
+                  <h2>{draft.blocked_actions.length} gates</h2>
+                </div>
+                <span>no controls</span>
+              </div>
+              <div class="record-list">
+                {draft.blocked_actions.map((action) => (
+                  <article class="compact-row">
+                    <strong>{action}</strong>
+                    <small>requires separate authority before implementation</small>
+                  </article>
+                ))}
+              </div>
+            </section>
+
+            <section class="table-card">
+              <div class="section-head">
+                <div>
+                  <p>thread beats</p>
+                  <h2>{draft.x_thread_beats.length} lines</h2>
+                </div>
+                <span>draft only</span>
+              </div>
+              <div class="record-list">
+                {draft.x_thread_beats.map((beat) => (
+                  <article class="compact-row">
+                    <strong>{beat}</strong>
+                  </article>
+                ))}
+              </div>
+            </section>
+          </aside>
+        </div>
+      </>
+    ) : (
+      <section class="notice">
+        Newsletter draft not found. Return to the newsletter queue and select a
+        known draft slug.
+      </section>
+    )
+  }
+</AdminLayout>

--- a/apps/admin/src/styles/admin.css
+++ b/apps/admin/src/styles/admin.css
@@ -225,6 +225,10 @@ th {
   color: var(--text);
 }
 
+.inert-button {
+  color: var(--muted);
+}
+
 .meta-strip {
   display: flex;
   flex-wrap: wrap;
@@ -421,6 +425,159 @@ dd {
   padding: 12px;
 }
 
+.newsletter-preview-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 380px;
+  gap: 18px;
+  margin-top: 24px;
+  align-items: start;
+}
+
+.newsletter-article-preview {
+  border: 1px solid var(--border);
+  background: #f8f5ee;
+  color: #171717;
+  padding: clamp(22px, 4vw, 52px);
+  font-family:
+    ui-serif,
+    Georgia,
+    Cambria,
+    "Times New Roman",
+    serif;
+  line-height: 1.62;
+}
+
+.newsletter-article-preview .back-link {
+  display: inline-flex;
+  min-height: 44px;
+  align-items: center;
+  margin-bottom: 16px;
+  color: #645f56;
+  font:
+    13px/1.2 ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace;
+}
+
+.newsletter-article-head {
+  margin-bottom: 28px;
+}
+
+.newsletter-article-head > p:first-child {
+  margin: 0 0 12px;
+  color: #245f86;
+  font:
+    700 12px/1.2 Inter,
+    ui-sans-serif,
+    system-ui,
+    sans-serif;
+  text-transform: uppercase;
+}
+
+.newsletter-article-head h2 {
+  max-width: 780px;
+  margin: 0;
+  font:
+    600 clamp(38px, 6vw, 72px) / 0.98 Inter,
+    ui-sans-serif,
+    system-ui,
+    sans-serif;
+  letter-spacing: 0;
+}
+
+.newsletter-media-slot {
+  display: grid;
+  min-height: 300px;
+  margin: 24px 0;
+  place-items: center;
+  border: 1px solid #d8d2c7;
+  background:
+    linear-gradient(135deg, rgba(36, 95, 134, 0.12), transparent 42%),
+    #fffdf7;
+}
+
+.newsletter-media-slot div {
+  display: grid;
+  gap: 8px;
+  width: min(82%, 560px);
+  border: 1px solid #d8d2c7;
+  background: #f8f5ee;
+  padding: 20px;
+}
+
+.newsletter-media-slot span,
+.newsletter-section small,
+.newsletter-close small {
+  color: #656159;
+  font:
+    13px/1.4 Inter,
+    ui-sans-serif,
+    system-ui,
+    sans-serif;
+}
+
+.newsletter-dek {
+  max-width: 720px;
+  color: #656159;
+  font-size: 21px;
+  line-height: 1.45;
+}
+
+.newsletter-article-preview > p,
+.newsletter-section p,
+.newsletter-section li,
+.newsletter-close p {
+  max-width: 760px;
+  font-size: 18px;
+}
+
+.newsletter-spine {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 24px 0 34px;
+}
+
+.newsletter-spine span {
+  border: 1px solid #d8d2c7;
+  padding: 7px 11px;
+  color: #656159;
+  font:
+    13px/1 Inter,
+    ui-sans-serif,
+    system-ui,
+    sans-serif;
+}
+
+.newsletter-section {
+  margin-top: 34px;
+}
+
+.newsletter-section h3,
+.newsletter-close h3 {
+  margin: 0 0 12px;
+  color: #171717;
+  font:
+    700 26px/1.15 Inter,
+    ui-sans-serif,
+    system-ui,
+    sans-serif;
+  letter-spacing: 0;
+}
+
+.newsletter-close {
+  margin-top: 36px;
+  border: 1px solid #d8d2c7;
+  background: #fffdf7;
+  padding: 20px;
+}
+
+.newsletter-proof-panel {
+  display: grid;
+  gap: 14px;
+}
+
 @media (max-width: 860px) {
   .shell {
     grid-template-columns: 1fr;
@@ -460,6 +617,7 @@ dd {
   .preview-grid,
   .lane-grid,
   .newsletter-detail,
+  .newsletter-preview-layout,
   .record-row dl,
   .need-row dl,
   .proposal-row dl,

--- a/docs/newsletter-content-structure.md
+++ b/docs/newsletter-content-structure.md
@@ -10,18 +10,19 @@ admin writes, or production d1 changes.
 
 ## existing source inventory
 
-| surface             | current source                                                                  | role                                                                      | lane status                         |
-| ------------------- | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------- | ----------------------------------- |
-| newsletter landing  | `apps/www/src/pages/newsletter.astro`                                           | renders the `news.anipotts.com` landing page from normalized page content | read-only source reference          |
-| subscribe component | `apps/www/src/components/NewsletterSubscribe.astro`                             | shows lede, email form, CTA, success text, and error text                 | copy source only, no send authority |
-| archive shell       | `apps/www/src/pages/newsletter/archive.astro`                                   | placeholder archive until the first-party send path is verified           | read-only public shell              |
-| issue table         | `drizzle/migrations/0005_newsletter_system.sql:newsletter_issues`               | future storage shape for issue rows                                       | schema reference only               |
-| system brief        | `docs/newsletter-system.md`                                                     | infrastructure, resend, compliance, and rollout gates                     | authoritative for live-path gates   |
-| content inventory   | `docs/content-admin-editor-brief.md`                                            | public-site editable-content inventory and newsletter backfill candidates | admin planning source               |
-| shared content      | `packages/content/src/admin/*`                                                  | static inventory, preview rows, and newsletter issue draft data           | preview model only                  |
-| read-only admin     | `apps/admin/src/data/content.ts`                                                | compatibility re-export for current admin routes                          | preview model only                  |
-| newsletter admin    | `apps/admin/src/data/newsletter.ts` and `apps/admin/src/pages/newsletter.astro` | static issue draft review inside canonical Astro admin                    | preview model only                  |
-| newsletter worker   | `workers/newsletter/*`                                                          | async send worker and queue consumer                                      | out of scope for this lane          |
+| surface              | current source                                                                  | role                                                                      | lane status                         |
+| -------------------- | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------- | ----------------------------------- |
+| newsletter landing   | `apps/www/src/pages/newsletter.astro`                                           | renders the `news.anipotts.com` landing page from normalized page content | read-only source reference          |
+| subscribe component  | `apps/www/src/components/NewsletterSubscribe.astro`                             | shows lede, email form, CTA, success text, and error text                 | copy source only, no send authority |
+| archive shell        | `apps/www/src/pages/newsletter/archive.astro`                                   | placeholder archive until the first-party send path is verified           | read-only public shell              |
+| issue table          | `drizzle/migrations/0005_newsletter_system.sql:newsletter_issues`               | future storage shape for issue rows                                       | schema reference only               |
+| system brief         | `docs/newsletter-system.md`                                                     | infrastructure, resend, compliance, and rollout gates                     | authoritative for live-path gates   |
+| content inventory    | `docs/content-admin-editor-brief.md`                                            | public-site editable-content inventory and newsletter backfill candidates | admin planning source               |
+| shared content       | `packages/content/src/admin/*`                                                  | static inventory, preview rows, and newsletter issue draft data           | preview model only                  |
+| read-only admin      | `apps/admin/src/data/content.ts`                                                | compatibility re-export for current admin routes                          | preview model only                  |
+| newsletter admin     | `apps/admin/src/data/newsletter.ts` and `apps/admin/src/pages/newsletter.astro` | static issue draft review inside canonical Astro admin                    | preview model only                  |
+| issue detail preview | `apps/admin/src/pages/newsletter/[slug].astro`                                  | Astro-native protected issue preview with proof, sources, and gates       | preview model only                  |
+| newsletter worker    | `workers/newsletter/*`                                                          | async send worker and queue consumer                                      | out of scope for this lane          |
 
 ## draft issue record
 
@@ -131,6 +132,16 @@ safe slices can add newsletter preview rows with:
 | source refs panel     | `source_refs`, `claims`, and `assets` fields | no private docs or secret values                   |
 | blocked actions panel | `blocked_actions` and `approval_refs` fields | no live controls                                   |
 | archive preview route | static render from fixture                   | no public route publish unless approved            |
+
+current consolidated preview route:
+
+- `/newsletter`: protected admin issue queue.
+- `/newsletter/first-thing-agents-need-control-plane`: protected admin detail
+  preview rendered from `packages/content/src/admin/newsletter.ts`.
+
+older newsletter worktree branches are inputs only. do not merge them wholesale
+because they predate the Astro admin cutover and can reintroduce stale
+admin-solid references or old workflow state.
 
 ## gated work
 

--- a/packages/content/src/admin/newsletter.ts
+++ b/packages/content/src/admin/newsletter.ts
@@ -14,6 +14,12 @@ export type NewsletterSection = {
   thread_beat?: string;
 };
 
+export type NewsletterClose = {
+  kind: "close";
+  body: string;
+  cta: string;
+};
+
 export type NewsletterDraft = {
   id: string;
   slug: string;
@@ -25,8 +31,11 @@ export type NewsletterDraft = {
   audience: string;
   source_refs: { ref: string; use: string }[];
   spine: string[];
+  hook: NewsletterSection;
   sections: NewsletterSection[];
+  close: NewsletterClose;
   claims: NewsletterClaim[];
+  x_thread_beats: string[];
   blocked_actions: string[];
   preview_notes: string;
   source_fixture: string;
@@ -80,14 +89,14 @@ export const newsletterDrafts: NewsletterDraft[] = [
       },
     ],
     spine: ["intent", "authority", "operation", "proof", "state"],
+    hook: {
+      kind: "opening",
+      body: "every coding agent i use eventually runs into the same boring problem: it can make a change, but it needs a system around it for responsibility.",
+      source_refs: ["AGENTS.md", "docs/admin-v2-architecture.md"],
+      thread_beat:
+        "the useful split is simple: safe lanes can move, hard gates come back to me.",
+    },
     sections: [
-      {
-        kind: "opening",
-        body: "every coding agent i use eventually runs into the same boring problem: it can make a change, but it needs a system around it for responsibility.",
-        source_refs: ["AGENTS.md", "docs/admin-v2-architecture.md"],
-        thread_beat:
-          "the useful split is simple: safe lanes can move, hard gates come back to me.",
-      },
       {
         kind: "note",
         heading: "safe lanes versus hard gates",
@@ -131,6 +140,11 @@ export const newsletterDrafts: NewsletterDraft[] = [
           "the control plane maps what i meant to what was allowed to what changed.",
       },
     ],
+    close: {
+      kind: "close",
+      body: "the version of this i want is boring in the best way. agents know what they can do next, what proof they owe, and when the right move is to return one clear decision to me.",
+      cta: "draft only. review for tone, claims, and source refs before any archive or send path.",
+    },
     claims: [
       {
         claim:
@@ -155,6 +169,17 @@ export const newsletterDrafts: NewsletterDraft[] = [
         status: "source_backed",
         source_refs: ["AGENTS.md"],
       },
+    ],
+    x_thread_beats: [
+      "every coding agent i use eventually runs into the same boring problem: it needs a place to put responsibility.",
+      "that is what i mean by a control plane.",
+      "the useful contract is intent -> authority -> operation -> proof -> state.",
+      "safe lanes let agents move without asking me for permission every five minutes.",
+      "hard gates keep dns, auth, secrets, sends, live endpoints, and irreversible actions behind explicit authority.",
+      "proof beats trust because the next agent has to continue from the artifact.",
+      "NEEDS-ANI is my human syscall queue: approval, choice, account action, identity, payment, secret setup, final taste.",
+      "admin.anipotts.com should make state legible before it makes state mutable.",
+      "the system i want is boring: agents know what they can do next.",
     ],
     blocked_actions: [
       "write production d1 issue",


### PR DESCRIPTION
## Summary
- add a protected Astro admin newsletter draft detail route at /newsletter/[slug]
- render the draft issue from @anipotts/content with article-style preview, claims, source refs, thread beats, and blocked live actions
- link the newsletter queue to the detail preview and document why stale newsletter branches should not be merged wholesale

## Verification
- pnpm turbo typecheck --filter=@anipotts/content... --filter=@anipotts/admin...
- pnpm turbo build --filter=@anipotts/content... --filter=@anipotts/admin...
- pnpm turbo lint --filter=@anipotts/admin... --filter=@anipotts/content...
- git diff --check HEAD~1 HEAD
- local dev smoke: /newsletter and /newsletter/first-thing-agents-need-control-plane both returned 302 to /auth/passkey, confirming the routes are registered behind passkey middleware

## Live impact
- no write path
- no D1 writes
- no send/publish/provider/DNS/auth/env changes
- expected deploy target: admin only