### PR TITLE
chore: cover newsletter preview in admin proof

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -213,7 +213,7 @@ jobs:
       - name: Smoke admin unauthenticated block
         run: |
           set -euo pipefail
-          for path in /auth/passkey / /content /content/review /content/preview /content/operations /newsletter /needs-ani /proof /repos /fleet; do
+          for path in /auth/passkey / /content /content/review /content/preview /content/operations /newsletter /newsletter/first-thing-agents-need-control-plane /needs-ani /proof /repos /fleet; do
             ok=false
             for _ in $(seq 1 6); do
               code="$(curl -sS -o /dev/null -w '%{http_code}' "https://admin.anipotts.com${path}")"

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -43,7 +43,7 @@ jobs:
         if: inputs.target == 'admin'
         run: |
           set -euo pipefail
-          for path in /auth/passkey / /content /content/review /content/preview /content/operations /newsletter /needs-ani /proof /repos /fleet; do
+          for path in /auth/passkey / /content /content/review /content/preview /content/operations /newsletter /newsletter/first-thing-agents-need-control-plane /needs-ani /proof /repos /fleet; do
             code="$(curl -sS -o /dev/null -w '%{http_code}' "https://admin.anipotts.com${path}")"
             echo "https://admin.anipotts.com${path} -> ${code}"
             case "$path:$code" in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,7 +85,9 @@ For `admin.anipotts.com`, use this order:
 4. prove passkey register, login, logout, session persistence, and blocked
    failure paths
 5. prove `/auth/passkey`, `/`, `/content`, `/content/review`,
-   `/content/preview`, `/content/operations`, and `/needs-ani`
+   `/content/preview`, `/content/operations`, `/newsletter`,
+   `/newsletter/first-thing-agents-need-control-plane`, `/needs-ani`, and
+   `/proof`
 6. remove Cloudflare Access only after proof passes
 7. verify app-native unauthenticated block and authenticated passkey access
 8. rollback by restoring the previous Access app or policy if proof fails

--- a/apps/admin/src/data/proof.ts
+++ b/apps/admin/src/data/proof.ts
@@ -20,14 +20,14 @@ export const proofSource = {
 
 export const proofEntries: ProofEntry[] = [
   {
-    id: "proof.site.pr112.deploy",
+    id: "proof.site.pr121.deploy",
     kind: "deploy",
     status: "verified",
-    title: "PR #112 deployed scoped targets",
+    title: "PR #121 deployed admin only",
     summary:
-      "Deploy run 28304347479 completed for www, admin, and admin-solid. Ingest, newsletter, weekly-email, and state workers were skipped.",
+      "Deploy run 28305779971 completed for admin. Www, admin-solid, ingest, newsletter, weekly-email, and state workers were skipped.",
     evidence_uri:
-      "https://github.com/anipotts/anipotts.com/actions/runs/28304347479",
+      "https://github.com/anipotts/anipotts.com/actions/runs/28305779971",
     redaction: "public_metadata",
     next_safe_action:
       "Keep deploy proof attached to route-level changes until proof rows move into D1.",
@@ -50,7 +50,7 @@ export const proofEntries: ProofEntry[] = [
     status: "verified",
     title: "admin unauthenticated block holds",
     summary:
-      "Unauthenticated probes returned 302 for /auth/passkey, /, /content, /content/review, /content/preview, /content/operations, /needs-ani, /repos, and /fleet.",
+      "Unauthenticated probes returned 302 for /auth/passkey, /, /content, /content/review, /content/preview, /content/operations, /newsletter, the newsletter detail preview, /needs-ani, /proof, /repos, and /fleet.",
     evidence_uri: "https://admin.anipotts.com/auth/passkey",
     redaction: "protected_route",
     next_safe_action:
@@ -62,7 +62,7 @@ export const proofEntries: ProofEntry[] = [
     status: "verified",
     title: "no open site PRs",
     summary:
-      "GitHub PR list returned no open pull requests after PR #112 merged.",
+      "GitHub PR list returned no open pull requests after PR #121 merged.",
     evidence_uri: "https://github.com/anipotts/anipotts.com/pulls",
     redaction: "public_metadata",
     next_safe_action:
@@ -75,7 +75,7 @@ export const proofEntries: ProofEntry[] = [
     title: "passkey enrollment proof missing",
     summary:
       "Access removal remains blocked until biometric passkey registration, login, logout, persistence, and revoked-credential denial are proven.",
-    evidence_uri: "drizzle/migrations/0006_admin_passkeys.sql",
+    evidence_uri: "pnpm --silent proof:admin-passkey",
     redaction: "metadata_only",
     next_safe_action:
       "Register the first passkey behind Cloudflare Access, then record D1 credential, session, and audit evidence.",

--- a/docs/admin-v2-architecture.md
+++ b/docs/admin-v2-architecture.md
@@ -17,45 +17,48 @@ The current control-plane model remains the backbone:
 
 Live baseline:
 
-- app: `apps/admin-solid`
-- worker: `anipotts-admin-solid`
+- app: `apps/admin`
+- worker: `anipotts-admin`
 - host: `admin.anipotts.com`
-- protection: Cloudflare Access
-- deployed state: read-only admin feed shell
-- latest proven queue: `/needs-ani`
+- protection: Cloudflare Access plus staged app-native passkey middleware
+- deployed state: Astro admin operator and content shell
+- latest proven routes: `/newsletter` and
+  `/newsletter/first-thing-agents-need-control-plane`
 
 Current strengths:
 
-- dense operational pages already exist
-- `NEEDS-ANI` is rendered as typed human syscalls
-- static Infra feed and local-dev runtime overlays are wired
-- deploy workflow can target only admin-solid
-- unauthenticated users are blocked by Cloudflare Access
+- Astro admin is canonical for `admin.anipotts.com`
+- `NEEDS-ANI`, content inventory, content review, operations, newsletter,
+  proof, repos, handoffs, fleet, mutations, and destructive ops have protected
+  routes
+- deploy workflow can target only admin
+- unauthenticated users are blocked by Cloudflare Access before app content
+  renders
+- passkey tables and app middleware are deployed
 
 Current gaps:
 
-- app framework is separate from the Astro public site direction
-- route components and data adapters are still tightly coupled
-- content editing is modeled in docs but not represented in the live admin nav
-- no formal read model for public-site editable content
-- no disabled preview for future save or publish workflows
+- no active passkey credential exists yet
+- Cloudflare Access is still the outer boundary until passkey proof is complete
+- admin proof rows are still static source data, not durable D1 records
+- content operations are modeled and queryable, but publish writes remain inert
+- `apps/admin-solid` remains as a legacy rollback surface
 
 ## recommended v2 shape
 
-Build v2 as an Astro-aligned Cloudflare app with a sidebar-first operator shell.
-Use Astro for routing, layout, and server-rendered read views. Use Solid islands
-only where live state, filters, optimistic previews, or stream updates need
-client-side state.
+Continue with `apps/admin` as the canonical Astro admin app. Do not create a
+second admin app unless it removes more complexity than it adds.
 
-Recommended app options:
+Keep the sidebar-first operator shell. Use Astro for routing, layout, and
+server-rendered read views. Add islands only where live state, filters,
+optimistic previews, or stream updates need client-side state.
 
-- short term: keep improving `apps/admin-solid` while v2 is documented
-- medium term: create `apps/admin-v2` as an Astro app and port read-only routes
-- final target: move `admin.anipotts.com` to the Astro-aligned app after proof
+The next architecture milestone is proof, not another framework migration:
 
-Do not rewrite only for framework symmetry. Rewrite when the v2 shell can reduce
-deployment surface, make content editing easier, and share site-rendering
-patterns with `apps/www`.
+- enroll the first passkey while Access still protects the app
+- prove app-native login, logout, persistence, and denial paths
+- remove Access only after the proof script and browser proof both pass
+- then archive or remove `apps/admin-solid`
 
 ## information architecture
 
@@ -200,7 +203,8 @@ Auth boundary note:
 
 ## smallest first implementation slice
 
-First slice: add a read-only `/content` route to the current admin shell.
+First slice completed: add a read-only `/content` route to the current admin
+shell.
 
 Scope:
 
@@ -228,33 +232,26 @@ Why this slice:
 - it helps separate content data from source-code deploy habit
 - it can ship on the current app without waiting for Astro migration
 
-Second slice:
+Current next slice:
 
-- extract shared admin view-model types
-- add content operation preview objects
-- render disabled save/publish affordances with required authority labels
-- keep every button inert
+- complete passkey enrollment proof
+- rerun `pnpm --silent proof:admin-passkey`
+- remove Cloudflare Access only after proof passes
+- archive or remove `apps/admin-solid`
 
-Third slice:
+Follow-up content slice:
 
-- decide whether to keep `apps/admin-solid` or introduce `apps/admin-v2` Astro
-- port shell layout if Astro gives lower complexity
-- only then propose approved write APIs
+- move proof records into D1-backed read models
+- make content draft operations visible from D1
+- keep save, publish, send, and live controls inert until audit proof exists
 
 ## verification expectations
 
-For read-only admin slices:
+For admin slices:
 
 ```bash
-pnpm turbo typecheck --filter=@anipotts/admin-solid...
-pnpm turbo build --filter=@anipotts/admin-solid...
-```
-
-For future Astro v2 slices:
-
-```bash
-pnpm turbo typecheck --filter=<admin-v2-package>...
-pnpm turbo build --filter=<admin-v2-package>...
+pnpm turbo typecheck --filter=@anipotts/admin...
+pnpm turbo build --filter=@anipotts/admin...
 ```
 
 For deploy proof after approved merge:

--- a/docs/platform-architecture.md
+++ b/docs/platform-architecture.md
@@ -55,22 +55,23 @@ The Astro admin replacement covers these live admin-solid routes. Keep them
 covered while passkey proof and Access removal are completed, then remove
 `apps/admin-solid`:
 
-| Route                 | Purpose                              |
-| --------------------- | ------------------------------------ |
-| `/`                   | operator overview                    |
-| `/auth/passkey`       | app-native passkey auth              |
-| `/content`            | content inventory                    |
-| `/content/review`     | content proposal queue               |
-| `/content/preview`    | draft preview                        |
-| `/content/operations` | read-only D1 content operation state |
-| `/newsletter`         | newsletter issue draft preview       |
-| `/needs-ani`          | typed human decision queue           |
-| `/proof`              | deploy, auth, and route proof log    |
-| `/repos`              | repo and worktree state              |
-| `/handoffs`           | handoff freshness                    |
-| `/fleet`              | machine and agent state              |
-| `/mutations`          | mutation queue                       |
-| `/ops/destructive`    | gated destructive-operation register |
+| Route                                               | Purpose                              |
+| --------------------------------------------------- | ------------------------------------ |
+| `/`                                                 | operator overview                    |
+| `/auth/passkey`                                     | app-native passkey auth              |
+| `/content`                                          | content inventory                    |
+| `/content/review`                                   | content proposal queue               |
+| `/content/preview`                                  | draft preview                        |
+| `/content/operations`                               | read-only D1 content operation state |
+| `/newsletter`                                       | newsletter issue queue               |
+| `/newsletter/first-thing-agents-need-control-plane` | newsletter issue detail preview      |
+| `/needs-ani`                                        | typed human decision queue           |
+| `/proof`                                            | deploy, auth, and route proof log    |
+| `/repos`                                            | repo and worktree state              |
+| `/handoffs`                                         | handoff freshness                    |
+| `/fleet`                                            | machine and agent state              |
+| `/mutations`                                        | mutation queue                       |
+| `/ops/destructive`                                  | gated destructive-operation register |
 
 ## auth target
 
@@ -94,7 +95,9 @@ the remote `anipotts-db` passkey tables and probes protected admin routes
 without printing Cloudflare Access tokens. The proof is not complete until it
 shows at least one active credential, an app-native session, logout proof in
 audit rows, and app-native route blocking after Access removal. The route probe
-set must include the content inventory, review, preview, and operations routes.
+set must include content inventory, review, preview, operations, newsletter
+queue, newsletter detail preview, needs-ani, proof, repos, handoffs, fleet,
+mutations, and destructive-ops routes.
 
 ## ci/cd target
 

--- a/scripts/admin/passkey-proof.mjs
+++ b/scripts/admin/passkey-proof.mjs
@@ -14,6 +14,7 @@ const ROUTES = [
   "/content/operations",
   "/needs-ani",
   "/newsletter",
+  "/newsletter/first-thing-agents-need-control-plane",
   "/proof",
   "/repos",
   "/handoffs",


### PR DESCRIPTION
## Summary
- add the newsletter detail preview route to admin deploy smoke, manual smoke, and passkey proof probes
- refresh the static admin proof log with PR #121 deploy evidence and the expanded unauthenticated route set
- update current admin architecture docs so apps/admin is canonical and passkey enrollment remains the Access removal gate

## Verification
- pnpm turbo typecheck --filter=@anipotts/admin...
- pnpm turbo build --filter=@anipotts/admin...
- pnpm turbo lint --filter=@anipotts/admin...
- pnpm --silent proof:admin-passkey
- pnpm exec prettier --check .github/workflows/deploy.yml .github/workflows/smoke.yml CLAUDE.md apps/admin/src/data/proof.ts docs/admin-v2-architecture.md docs/platform-architecture.md scripts/admin/passkey-proof.mjs
- git diff --check HEAD~1 HEAD

## Live impact
- no auth policy change
- no D1 mutation
- no secret or env change
- expected deploy target: admin only, because this updates apps/admin static proof data