### PR TITLE
Refresh homepage project cards

### DIFF
--- a/apps/www/src/pages/index.astro
+++ b/apps/www/src/pages/index.astro
@@ -30,10 +30,10 @@ const work = cmsHome.sections.past_work;
 const writing = cmsHome.sections.latest_thoughts;
 const heading = hasCmsHome ? intro.heading : homeContent.heading;
 const homeMakingSlugs = [
+  "quantercise",
   "quantercise-extension",
   "saeshify",
   "nyu-purity-test",
-  "habittracker-obh",
 ] as const;
 const homeMakingOrder = new Map<string, number>(
   homeMakingSlugs.map((slug, index) => [slug, index]),


### PR DESCRIPTION
## summary
- replace the hidden `habittracker-obh` homepage candidate with visible `quantercise`
- closes the only useful remaining bit from stale public-site cleanup branch #73
- keeps newsletter/worktree consolidation pointed at Astro admin and shared content docs already on main

## verification
- pnpm turbo typecheck --filter=@anipotts/www...
- pnpm turbo build --filter=@anipotts/www...
- git diff --check

## deploy scope
- public site only (`www=true`) after green checks
- no admin, admin-solid, workers, DNS, auth, secrets, env, or write paths
