### PR TITLE
Archive stale personal cloud plan

### DIFF
--- a/docs/archive/personal-cloud-architecture-2026-05-13.md
+++ b/docs/archive/personal-cloud-architecture-2026-05-13.md
@@ -1,5 +1,12 @@
 # Personal Cloud Architecture
 
+Archived: 2026-06-27.
+
+This is a historical May 2026 direction document. It predates the June Astro
+admin cutover and still references SolidStart, `apps/admin-solid`, and PR #30 as
+future direction. Current source truth is `docs/platform-architecture.md` plus
+`docs/admin-v2-architecture.md` and `docs/newsletter-system.md`.
+
 Multi-month vision doc for the anipotts personal infrastructure. Companion to `docs/archive/cloudflare-infrastructure-2026-05-13.md` (archived deploy substrate snapshot) and `docs/per-project-vercel-migration.md` (project-by-project Vercel exit). This one is the _destination_ the migrations are walking toward.
 
 Last updated: 2026-05-13.

--- a/workers/state/README.md
+++ b/workers/state/README.md
@@ -2,7 +2,10 @@
 
 State worker for the personal cloud. Hosts Durable Objects that hold one fact each (LinkVault, MoneyState, ContentPipeline, etc.) and exposes a Hono REST + WebSocket API at `api.anipotts.com`.
 
-This is **step 1** of the personal-cloud-architecture build (see `docs/personal-cloud-architecture.md`). The first DO is `LinkVault`. More DOs get added one class at a time as they're needed.
+This is the retained state-plane worker for `api.anipotts.com`. The current repo
+architecture lives in `docs/platform-architecture.md`. The older May 2026
+personal-cloud sketch is archived at
+`docs/archive/personal-cloud-architecture-2026-05-13.md`.
 
 ## Quick start
 
@@ -43,4 +46,7 @@ explicit `state=true` deploy target.
 
 ## Architecture
 
-The full vision lives at `docs/personal-cloud-architecture.md` in the same monorepo. TL;DR: this worker is the state plane. Inputs (Rudy, email, webhooks, admin) write here. Outputs (admin, iPhone, Rudy, agents) read here via WebSocket so nothing polls.
+The current source truth is `docs/platform-architecture.md`. This worker is the
+retained state plane for future operator state, fleet state, and WebSocket/DO
+work. Inputs and write paths still need explicit route-level authority before
+they become live controls.


### PR DESCRIPTION
## summary
- move the May personal-cloud plan into `docs/archive`
- mark it as historical because it predates the Astro admin direction
- update `workers/state/README.md` to point at `docs/platform-architecture.md` as current source truth

## verification
- git diff --check
- rg -n "docs/personal-cloud-architecture|personal-cloud-architecture.md" README.md docs workers apps packages .github -S

## deploy scope
- docs only
- no deploy targets
- no workflow, auth, DNS, env, secret, worker, D1, or write-path changes
