### PR TITLE
Ignore docs in automerge deploy targets

### DIFF
--- a/.github/workflows/agent-automerge.yml
+++ b/.github/workflows/agent-automerge.yml
@@ -67,6 +67,12 @@ jobs:
 
           while IFS= read -r file; do
             case "$file" in
+              *.md|docs/*|.github/ISSUE_TEMPLATE/*|LICENSE)
+                continue
+                ;;
+            esac
+
+            case "$file" in
               apps/www/*|packages/lib/*|packages/styles/*|packages/types/*)
                 www=true
                 ;;


### PR DESCRIPTION
## summary
- fix agent-automerge deploy target calculation to ignore docs, markdown, issue templates, and LICENSE before matching app/worker targets
- prevents docs-only files under `workers/**` or `apps/**` from dispatching production deploys
- preserves real worker deploy behavior for source changes

## why
- PR #124 was docs-only but touched `workers/state/README.md`
- automerge dispatched `deploy.yml` with `state=true`, so the state worker deployed even though the change was documentation only

## verification
- git diff --check
- pnpm exec prettier --check .github/workflows/agent-automerge.yml
- local target simulation: docs-only worker README => `state=false`
- local target simulation: `workers/state/src/index.ts` => `state=true`

## deploy scope
- workflow-only fix
- no app, worker, D1, DNS, auth, env, secret, or write-path changes
