### PR TITLE
Test deploy target calculation

### DIFF
--- a/.github/workflows/agent-automerge.yml
+++ b/.github/workflows/agent-automerge.yml
@@ -26,6 +26,8 @@ jobs:
       )
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+
       - name: Wait for required checks
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -52,72 +54,14 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: |
           files="$RUNNER_TEMP/pr-files.txt"
+          targets="$RUNNER_TEMP/deploy-targets.txt"
           pr_number="${PR_URL##*/}"
           gh api "repos/${GITHUB_REPOSITORY}/pulls/${pr_number}/files" \
             --paginate \
             --jq '.[].filename' > "$files"
 
-          www=false
-          admin=false
-          admin_solid=false
-          ingest=false
-          newsletter=false
-          state=false
-          weekly_email=false
-
-          while IFS= read -r file; do
-            case "$file" in
-              *.md|docs/*|.github/ISSUE_TEMPLATE/*|LICENSE)
-                continue
-                ;;
-            esac
-
-            case "$file" in
-              apps/www/*|packages/lib/*|packages/styles/*|packages/types/*)
-                www=true
-                ;;
-            esac
-            case "$file" in
-              apps/admin/*|packages/content/*)
-                admin=true
-                ;;
-            esac
-            case "$file" in
-              apps/admin-solid/*)
-                admin_solid=true
-                ;;
-            esac
-            case "$file" in
-              workers/ingest/*)
-                ingest=true
-                ;;
-            esac
-            case "$file" in
-              workers/newsletter/*)
-                newsletter=true
-                ;;
-            esac
-            case "$file" in
-              workers/state/*)
-                state=true
-                ;;
-            esac
-            case "$file" in
-              workers/weekly-email/*)
-                weekly_email=true
-                ;;
-            esac
-          done < "$files"
-
-          {
-            echo "www=$www"
-            echo "admin=$admin"
-            echo "admin_solid=$admin_solid"
-            echo "ingest=$ingest"
-            echo "newsletter=$newsletter"
-            echo "state=$state"
-            echo "weekly_email=$weekly_email"
-          } >> "$GITHUB_OUTPUT"
+          node scripts/ci/compute-deploy-targets.mjs "$files" | tee "$targets"
+          cat "$targets" >> "$GITHUB_OUTPUT"
 
       - name: Merge PR
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Validate deploy target rules
+        run: pnpm test:deploy-targets
+
       - name: Validate affected packages
         env:
           TURBO_SCM_BASE: origin/${{ github.base_ref }}

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "proof:admin-passkey": "node scripts/admin/passkey-proof.mjs",
     "update-claude-stats": "node scripts/claude/generate-claude-stats.mjs",
     "update-claude-stats:commit": "bash scripts/claude/refresh-claude-stats.sh",
+    "test:deploy-targets": "node scripts/ci/compute-deploy-targets.test.mjs",
     "test:unit": "turbo test",
     "test": "pnpm test:unit",
     "validate": "turbo build && turbo lint && turbo typecheck && turbo test",

--- a/scripts/ci/compute-deploy-targets.mjs
+++ b/scripts/ci/compute-deploy-targets.mjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+
+const TARGETS = [
+  "www",
+  "admin",
+  "admin_solid",
+  "ingest",
+  "newsletter",
+  "state",
+  "weekly_email",
+];
+
+function isIgnoredForDeploy(file) {
+  return (
+    file.endsWith(".md") ||
+    file.startsWith("docs/") ||
+    file.startsWith(".github/ISSUE_TEMPLATE/") ||
+    file === "LICENSE"
+  );
+}
+
+export function computeDeployTargets(files) {
+  const targets = Object.fromEntries(TARGETS.map((target) => [target, false]));
+
+  for (const file of files) {
+    if (!file || isIgnoredForDeploy(file)) continue;
+
+    if (
+      file.startsWith("apps/www/") ||
+      file.startsWith("packages/lib/") ||
+      file.startsWith("packages/styles/") ||
+      file.startsWith("packages/types/")
+    ) {
+      targets.www = true;
+    }
+
+    if (
+      file.startsWith("apps/admin/") ||
+      file.startsWith("packages/content/")
+    ) {
+      targets.admin = true;
+    }
+
+    if (file.startsWith("apps/admin-solid/")) {
+      targets.admin_solid = true;
+    }
+
+    if (file.startsWith("workers/ingest/")) {
+      targets.ingest = true;
+    }
+
+    if (file.startsWith("workers/newsletter/")) {
+      targets.newsletter = true;
+    }
+
+    if (file.startsWith("workers/state/")) {
+      targets.state = true;
+    }
+
+    if (file.startsWith("workers/weekly-email/")) {
+      targets.weekly_email = true;
+    }
+  }
+
+  return targets;
+}
+
+function readFiles(path) {
+  return readFileSync(path, "utf8")
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function printGithubOutput(targets) {
+  for (const target of TARGETS) {
+    console.log(`${target}=${targets[target] ? "true" : "false"}`);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const fileListPath = process.argv[2];
+  if (!fileListPath) {
+    console.error("usage: compute-deploy-targets.mjs <file-list>");
+    process.exit(2);
+  }
+
+  printGithubOutput(computeDeployTargets(readFiles(fileListPath)));
+}

--- a/scripts/ci/compute-deploy-targets.test.mjs
+++ b/scripts/ci/compute-deploy-targets.test.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { computeDeployTargets } from "./compute-deploy-targets.mjs";
+
+const empty = {
+  www: false,
+  admin: false,
+  admin_solid: false,
+  ingest: false,
+  newsletter: false,
+  state: false,
+  weekly_email: false,
+};
+
+function expectTargets(name, files, expected) {
+  assert.deepEqual(
+    computeDeployTargets(files),
+    { ...empty, ...expected },
+    name,
+  );
+}
+
+expectTargets(
+  "docs-only changes under workers and docs do not deploy",
+  [
+    "docs/archive/personal-cloud-architecture-2026-05-13.md",
+    "workers/state/README.md",
+    "apps/admin/README.md",
+    ".github/ISSUE_TEMPLATE/bug.md",
+    "LICENSE",
+  ],
+  {},
+);
+
+expectTargets(
+  "public site source deploys www",
+  ["apps/www/src/pages/index.astro"],
+  {
+    www: true,
+  },
+);
+
+expectTargets(
+  "admin source and content package deploy admin",
+  [
+    "apps/admin/src/pages/content/index.astro",
+    "packages/content/src/admin/content.ts",
+  ],
+  { admin: true },
+);
+
+expectTargets(
+  "admin-solid source deploys only admin-solid",
+  ["apps/admin-solid/src/routes/index.tsx"],
+  {
+    admin_solid: true,
+  },
+);
+
+expectTargets(
+  "worker source deploys exact worker",
+  ["workers/state/src/index.ts"],
+  {
+    state: true,
+  },
+);
+
+expectTargets(
+  "shared runtime packages deploy www only",
+  ["packages/lib/src/cms/index.ts", "packages/styles/src/tokens.css"],
+  { www: true },
+);
+
+expectTargets(
+  "root dependency files do not fan out",
+  ["package.json", "pnpm-lock.yaml"],
+  {},
+);
+
+expectTargets(
+  "mixed app and worker changes preserve exact targets",
+  ["apps/admin/src/pages/proof.astro", "workers/newsletter/src/index.ts"],
+  { admin: true, newsletter: true },
+);


### PR DESCRIPTION
## summary
- move agent deploy-target calculation into `scripts/ci/compute-deploy-targets.mjs`
- add regression tests for docs-only files, app targets, worker targets, shared packages, root dependency files, and mixed diffs
- run the deploy-target test in CI before affected package validation
- make `agent-automerge.yml` call the helper instead of duplicating path logic inline

## verification
- pnpm test:deploy-targets
- node scripts/ci/compute-deploy-targets.mjs /tmp/deploy-target-files.txt
- git diff --check
- pnpm exec prettier --check .github/workflows/agent-automerge.yml .github/workflows/ci.yml package.json scripts/ci/compute-deploy-targets.mjs scripts/ci/compute-deploy-targets.test.mjs

## deploy scope
- CI/workflow hardening only
- no app runtime, worker source, D1, DNS, auth, env, secret, or write-path changes
- expected deploy target: none
