### PR TITLE
Archive stale admin planning packets

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,6 @@
 #   CLOUDFLARE_API_TOKEN    - Cloudflare API token with Workers deploy permissions
 #   CLOUDFLARE_ACCOUNT_ID   - 0f856093bdcd34a7da1bde5ee4385163
 #   ADMIN_PASSWORD          - Admin UI password
-#   BUTTONDOWN_API_KEY      - Buttondown newsletter API key
 #   RESEND_API_KEY          - Resend API key for newsletter worker deployments
 #   NEWSLETTER_MAILING_ADDRESS - Physical mailing address for newsletter issue footers
 #   TYPEFULLY_API_KEY       - Typefully API key

--- a/apps/admin/src/pages/content/index.astro
+++ b/apps/admin/src/pages/content/index.astro
@@ -7,7 +7,7 @@ const surfaces = ["homepage", "projects", "writing", "newsletter"] as const;
 
 <AdminLayout
   title="content inventory"
-  deck="Current editable public-site surfaces and their source refs. This is read-only static inventory from the proven admin-solid model."
+  deck="Current editable public-site surfaces and their source refs. This is read-only inventory from the shared content model."
 >
   <section class="meta-strip" aria-label="content inventory source">
     <span>{contentInventory.length} rows</span>

--- a/docs/admin-v2-architecture.md
+++ b/docs/admin-v2-architecture.md
@@ -185,21 +185,17 @@ Admin control lane:
 
 Auth boundary note:
 
-- See `docs/admin-auth-content-adr.md` for the proposed design path. The current
-  recommendation is to keep Cloudflare Access as the edge gate, simplify the
-  identity experience first, and treat app-native auth as a future second layer
-  behind Access until it has proof equal to or stronger than the current
-  boundary.
-- See `docs/admin-access-simplification-plan.md` for the metadata-only Access
-  audit result and staged login simplification plan.
-- See `docs/admin-passkey-auth-plan.md` for the design-only path to biometric
-  passkey auth and the criteria for removing Cloudflare Access later.
+- Cloudflare Access remains the outer gate until passkey proof is complete.
+- App-native passkey auth is implemented in the canonical Astro admin and uses
+  D1-backed credentials, sessions, challenges, and audit events.
+- The current unblocker is first passkey enrollment, then proof for register,
+  login, logout, session persistence, revoked credential denial, and
+  unauthenticated app-native blocking after Access removal.
+- Historical auth and Access planning packets live under `docs/archive/`.
 - See `docs/admin-content-draft-operations.md` for the inert content draft
   operation schema that should precede any save or publish path.
-- See `docs/admin-next-step-packet-2026-06-25.md` for current PR status,
-  read-only merge/deploy candidates, and exact approval language.
-- See `docs/admin-newsletter-scope-packet-2026-06-25.md` for the no-mutation
-  admin/content/newsletter operating scope before more PRs.
+- Current merge/deploy policy lives in `CLAUDE.md` and
+  `docs/platform-architecture.md`.
 
 ## smallest first implementation slice
 

--- a/docs/archive/admin-access-simplification-plan-2026-06-25.md
+++ b/docs/archive/admin-access-simplification-plan-2026-06-25.md
@@ -1,5 +1,10 @@
 # admin access simplification plan
 
+Archived: 2026-06-27.
+
+This plan predates the app-native passkey implementation in the canonical Astro
+admin. Current Access removal criteria live in `docs/platform-architecture.md`.
+
 Date: 2026-06-25
 Status: approved for metadata audit and staged design only
 

--- a/docs/archive/admin-auth-content-adr-2026-06-25.md
+++ b/docs/archive/admin-auth-content-adr-2026-06-25.md
@@ -1,5 +1,11 @@
 # adr: admin auth boundary and content editing path
 
+Archived: 2026-06-27.
+
+This ADR was written before the Astro admin cutover. It is historical context
+only. Current source truth is `docs/platform-architecture.md` and
+`docs/admin-v2-architecture.md`.
+
 Date: 2026-06-25
 Status: accepted for design
 Scope: design plus metadata-only audit

--- a/docs/archive/admin-newsletter-scope-packet-2026-06-25.md
+++ b/docs/archive/admin-newsletter-scope-packet-2026-06-25.md
@@ -1,5 +1,11 @@
 # admin and newsletter scope packet: 2026-06-25
 
+Archived: 2026-06-27.
+
+The PR inventory in this packet is stale. Current source truth lives in
+`docs/platform-architecture.md`, `docs/admin-v2-architecture.md`, and
+`docs/newsletter-system.md`.
+
 Status: no-mutation scope packet
 
 ## operating direction

--- a/docs/archive/admin-next-step-packet-2026-06-25.md
+++ b/docs/archive/admin-next-step-packet-2026-06-25.md
@@ -1,5 +1,11 @@
 # admin next-step packet: 2026-06-25
 
+Archived: 2026-06-27.
+
+This packet described old admin-solid PRs that have since been merged,
+superseded, or closed. Current source truth lives in
+`docs/platform-architecture.md`.
+
 Status: no mutation packet
 
 ## current state

--- a/docs/archive/admin-passkey-auth-plan-2026-06-27.md
+++ b/docs/archive/admin-passkey-auth-plan-2026-06-27.md
@@ -1,5 +1,11 @@
 # admin passkey auth plan
 
+Archived: 2026-06-27.
+
+This plan predates the canonical Astro admin passkey route and proof script.
+Current passkey sequencing lives in `docs/platform-architecture.md` and
+`CLAUDE.md`.
+
 Date: 2026-06-27
 Status: implementation staged behind Cloudflare Access
 

--- a/docs/archive/site-open-pr-triage-2026-06-24.md
+++ b/docs/archive/site-open-pr-triage-2026-06-24.md
@@ -1,5 +1,10 @@
 # site open PR triage, 2026-06-24
 
+Archived: 2026-06-27.
+
+This triage packet is historical. The stale branches and PRs it discussed have
+been closed, absorbed, or deleted.
+
 ## PR #72, admin-solid fleet dashboard MVP
 
 PR: https://github.com/anipotts/anipotts.com/pull/72

--- a/docs/content-admin-editor-brief.md
+++ b/docs/content-admin-editor-brief.md
@@ -30,7 +30,7 @@ or any live write path.
 | p1       | add writing preview controls                            | titles and summaries are the actual newsletter backfill queue            | admin editor                  |
 | p1       | add newsletter headline, deck, cta, and status messages | the subscribe module should be editable without code                     | admin editor                  |
 | p2       | decide canonical project source                         | markdown and `packages/lib/src/data/projects.ts` duplicate similar facts | admin editor plus site thread |
-| p2       | classify old posts before publishing to Buttondown      | current writing can seed the newsletter, but should not be auto-sent     | newsletter thread             |
+| p2       | classify old posts before publishing to the newsletter  | current writing can seed the newsletter, but should not be auto-sent     | newsletter thread             |
 
 ## first read-only admin slice
 
@@ -103,7 +103,7 @@ hidden admin write endpoints.
 | `cta_label`       | string |      yes | current label: `subscribe`                                                  |
 | `success_message` | string |      yes | current message: `subscribed. check your inbox.`                            |
 | `error_message`   | string |      yes | current message: `could not subscribe. try again in a minute.`              |
-| `buttondown_url`  |    url |       no | points to `news.anipotts.com` when the newsletter thread exposes it         |
+| `buttondown_url`  |    url |       no | legacy field name; current value points to `news.anipotts.com`              |
 
 ## newsletter backfill options
 

--- a/packages/content/src/admin/content.ts
+++ b/packages/content/src/admin/content.ts
@@ -193,7 +193,7 @@ export const contentInventory: ContentInventoryItem[] = [
     title: "subscribe block copy",
     source_ref: "apps/www/src/components/NewsletterSubscribe.astro",
     current_value:
-      "Default lede, CTA label, success text, error text, and Buttondown link live in the component props.",
+      "Default lede, CTA label, success text, error text, and newsletter link live in the component props.",
     editability: "needs_schema",
     risk_level: "medium",
     next_safe_action:
@@ -280,7 +280,7 @@ export const contentPreviewItems: ContentPreviewItem[] = [
     proof_ids: ["content.writing.orchestrating-link.current"],
     blocked_actions: ["deploy without checks"],
     next_safe_action:
-      "Verify the public writing route and keep stale PR #73 closed.",
+      "Keep the absorbed /orchestrating link as the canonical public-site route.",
   },
   {
     id: "preview.newsletter.copy-source",
@@ -298,7 +298,11 @@ export const contentPreviewItems: ContentPreviewItem[] = [
     authority_state: "needs_source_truth_decision",
     required_approval_ids: ["content.newsletter-source.owner-decision"],
     proof_ids: ["content.newsletter.component.defaults"],
-    blocked_actions: ["save newsletter copy", "sync Buttondown", "send email"],
+    blocked_actions: [
+      "save newsletter copy",
+      "sync newsletter provider",
+      "send email",
+    ],
     next_safe_action:
       "Keep read-only until the content store decision is recorded.",
   },

--- a/workers/state/src/types.ts
+++ b/workers/state/src/types.ts
@@ -1,6 +1,6 @@
 /**
- * Shared types for the state worker. Mirrored on the client so admin-solid
- * can deserialize WebSocket payloads with type safety.
+ * Shared types for the state worker. Mirrored on clients so admin and other
+ * frontends can deserialize WebSocket payloads with type safety.
  */
 
 export type Link = {


### PR DESCRIPTION
## summary
- move superseded June admin/auth/PR planning packets into `docs/archive`
- update active `docs/admin-v2-architecture.md` to describe current Astro admin passkey state
- remove stale admin-solid/Buttondown wording from active admin content inventory copy
- remove dead Buttondown deploy secret comment
- update state worker type comment away from admin-solid

## verification
- pnpm turbo typecheck --filter=@anipotts/admin...
- pnpm turbo build --filter=@anipotts/admin...
- pnpm --filter @anipotts/state typecheck
- pnpm test:deploy-targets
- git diff --check
- pnpm exec prettier --check touched markdown/yaml/typescript files
- active stale-reference scan excluding docs/archive

## deploy scope
- expected deploy target: `admin=true` only because this touches `apps/admin` and `packages/content`
- no www, admin-solid, worker source deploy, D1, DNS, auth, env, secret, or write-path changes
