### PR TITLE
Drop stale Next env ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ yarn-error.log*
 .pnpm-debug.log*
 .vercel
 .turbo
-next-env.d.ts
 *.tsbuildinfo
 .typefully
 .claude/plans


### PR DESCRIPTION
## summary
- remove the root ignore entry for `next-env.d.ts`
- remove local ignored `apps/www/next-env.d.ts` residue from disk
- keep the public app aligned with the Astro-first target

## deploy target
- expected: no deploy
- computed locally: www=false, admin=false, admin_solid=false, ingest=false, newsletter=false, state=false, weekly_email=false

## verification
- pnpm turbo typecheck --filter=@anipotts/www... --force
- pnpm turbo build --filter=@anipotts/www... --force
- pnpm test:deploy-targets
- git diff --check