### PR TITLE
Add Astro admin runtime feed overlay

### DIFF
--- a/apps/admin/src/data/runtime.ts
+++ b/apps/admin/src/data/runtime.ts
@@ -1,0 +1,106 @@
+import type { NeedsAniItem } from "./needs";
+
+export const RUNTIME_FEED_PATH =
+  "/Users/anipotts/Infra/state/runtime/admin/admin-feed.current.json";
+
+export type RuntimeRepoOverlay = {
+  repo_state_id: string;
+  repo: string;
+  repo_root_label: string;
+  machine: string;
+  git_available: boolean;
+  branch: string | null;
+  head_sha: string | null;
+  upstream: string | null;
+  upstream_sha: string | null;
+  ahead: number | null;
+  behind: number | null;
+  dirty_tracked_count: number | null;
+  untracked_count: number | null;
+  deploy_impact: "none" | "local_only" | "preview" | "production" | "unknown";
+  live_runtime_role: string;
+  notes: string;
+};
+
+export type RuntimeSafety = {
+  dirty_filenames_included: boolean;
+  file_contents_included: boolean;
+  health_payloads_included: boolean;
+  mode: string;
+  secret_values_included: boolean;
+};
+
+export type RuntimeOverlayResponse = {
+  available: boolean;
+  mode: "local_dev" | "disabled" | "missing" | "error";
+  generated_at: string | null;
+  machine: string | null;
+  source_path: string;
+  safety: RuntimeSafety | null;
+  overlays: RuntimeRepoOverlay[];
+  needs_ani_queue: NeedsAniItem[];
+  error?: string;
+};
+
+type RuntimeFeedFile = {
+  generated_at?: string;
+  machine?: string;
+  runtime?: {
+    needs_ani_queue?: NeedsAniItem[];
+    repo_state_overlays?: RuntimeRepoOverlay[];
+    safety?: RuntimeSafety;
+  };
+};
+
+export async function loadRuntimeOverlayResponse(): Promise<RuntimeOverlayResponse> {
+  if (!import.meta.env.DEV) {
+    return disabledResponse();
+  }
+
+  try {
+    const nodeFsModule = "node:fs/promises";
+    const { readFile } = (await import(
+      /* @vite-ignore */ nodeFsModule
+    )) as typeof import("node:fs/promises");
+    const raw = await readFile(RUNTIME_FEED_PATH, "utf8");
+    const feed = JSON.parse(raw) as RuntimeFeedFile;
+
+    return {
+      available: true,
+      mode: "local_dev",
+      generated_at: feed.generated_at ?? null,
+      machine: feed.machine ?? null,
+      source_path: RUNTIME_FEED_PATH,
+      safety: feed.runtime?.safety ?? null,
+      overlays: feed.runtime?.repo_state_overlays ?? [],
+      needs_ani_queue: feed.runtime?.needs_ani_queue ?? [],
+    };
+  } catch (error) {
+    const code =
+      typeof error === "object" && error && "code" in error
+        ? String(error.code)
+        : "";
+
+    return {
+      ...disabledResponse(),
+      mode: code === "ENOENT" ? "missing" : "error",
+      error:
+        error instanceof Error
+          ? error.message
+          : "unknown runtime feed read failure",
+    };
+  }
+}
+
+export function disabledResponse(): RuntimeOverlayResponse {
+  return {
+    available: false,
+    mode: "disabled",
+    generated_at: null,
+    machine: null,
+    source_path: RUNTIME_FEED_PATH,
+    safety: null,
+    overlays: [],
+    needs_ani_queue: [],
+  };
+}

--- a/apps/admin/src/pages/api/admin/runtime-feed.ts
+++ b/apps/admin/src/pages/api/admin/runtime-feed.ts
@@ -1,0 +1,5 @@
+import { loadRuntimeOverlayResponse } from "../../../data/runtime";
+
+export async function GET() {
+  return Response.json(await loadRuntimeOverlayResponse());
+}

--- a/apps/admin/src/pages/repos.astro
+++ b/apps/admin/src/pages/repos.astro
@@ -2,8 +2,106 @@
 import AdminTable from "../components/AdminTable.astro";
 import AdminLayout from "../layouts/AdminLayout.astro";
 import { repoRows } from "../data/admin";
+import { loadRuntimeOverlayResponse } from "../data/runtime";
+
+const runtime = await loadRuntimeOverlayResponse();
 ---
 
-<AdminLayout title="repos" deck="Repo state and deploy impact summary.">
+<AdminLayout
+  title="repos"
+  deck="Repo state, deploy impact, and local-dev runtime overlays."
+>
   <AdminTable rows={repoRows} />
+
+  <section class="runtime-panel" aria-labelledby="runtime-overlays">
+    <div class="section-header">
+      <div>
+        <p>local-dev runtime</p>
+        <h2 id="runtime-overlays">repo overlays</h2>
+      </div>
+      <span>
+        {
+          runtime.available
+            ? `${runtime.overlays.length} overlays / ${runtime.machine ?? "unknown machine"}`
+            : runtime.mode
+        }
+      </span>
+    </div>
+
+    {
+      runtime.available ? (
+        <>
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>repo</th>
+                  <th>machine</th>
+                  <th>git</th>
+                  <th>branch</th>
+                  <th>head</th>
+                  <th>ahead / behind</th>
+                  <th>dirty</th>
+                  <th>untracked</th>
+                  <th>deploy</th>
+                  <th>role</th>
+                </tr>
+              </thead>
+              <tbody>
+                {runtime.overlays.map((overlay) => (
+                  <tr>
+                    <td>
+                      <strong>{overlay.repo}</strong>
+                      <br />
+                      <span class="muted">{overlay.repo_root_label}</span>
+                    </td>
+                    <td>{overlay.machine}</td>
+                    <td>{overlay.git_available ? "available" : "unavailable"}</td>
+                    <td>{overlay.branch ?? "not a git tree"}</td>
+                    <td>{overlay.head_sha ?? "none"}</td>
+                    <td>
+                      {overlay.ahead ?? "n/a"} / {overlay.behind ?? "n/a"}
+                    </td>
+                    <td>{overlay.dirty_tracked_count ?? "n/a"}</td>
+                    <td>{overlay.untracked_count ?? "n/a"}</td>
+                    <td>{overlay.deploy_impact}</td>
+                    <td>
+                      {overlay.live_runtime_role}
+                      <br />
+                      <span class="muted">{overlay.notes}</span>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <div class="meta-strip runtime-safety">
+            <span>generated_at: {runtime.generated_at ?? "not available"}</span>
+            <span>source_path: {runtime.source_path}</span>
+            <span>safety_mode: {runtime.safety?.mode ?? "not available"}</span>
+            <span>
+              secret_values:{" "}
+              {String(runtime.safety?.secret_values_included ?? false)}
+            </span>
+            <span>
+              file_contents:{" "}
+              {String(runtime.safety?.file_contents_included ?? false)}
+            </span>
+            <span>
+              health_payloads:{" "}
+              {String(runtime.safety?.health_payloads_included ?? false)}
+            </span>
+          </div>
+        </>
+      ) : (
+        <p class="notice">
+          Runtime overlay unavailable: {runtime.error ?? runtime.mode}.
+          source_path: {runtime.source_path}. This loader is local-dev only and
+          exposes metadata counts, not filenames, file contents, health
+          payloads, or secrets.
+        </p>
+      )
+    }
+  </section>
 </AdminLayout>

--- a/apps/admin/src/styles/admin.css
+++ b/apps/admin/src/styles/admin.css
@@ -259,6 +259,37 @@ th {
   margin-top: 24px;
 }
 
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: end;
+}
+
+.section-header h2,
+.section-header p {
+  margin: 0;
+}
+
+.section-header p {
+  color: var(--muted);
+  font-size: 12px;
+  text-transform: uppercase;
+}
+
+.section-header span,
+.muted {
+  color: var(--muted);
+}
+
+.runtime-panel {
+  margin-top: 28px;
+}
+
+.runtime-safety {
+  margin-top: 12px;
+}
+
 .preview-grid {
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }
@@ -438,12 +469,7 @@ dd {
   background: #f8f5ee;
   color: #171717;
   padding: clamp(22px, 4vw, 52px);
-  font-family:
-    ui-serif,
-    Georgia,
-    Cambria,
-    "Times New Roman",
-    serif;
+  font-family: ui-serif, Georgia, Cambria, "Times New Roman", serif;
   line-height: 1.62;
 }
 
@@ -493,8 +519,7 @@ dd {
   place-items: center;
   border: 1px solid #d8d2c7;
   background:
-    linear-gradient(135deg, rgba(36, 95, 134, 0.12), transparent 42%),
-    #fffdf7;
+    linear-gradient(135deg, rgba(36, 95, 134, 0.12), transparent 42%), #fffdf7;
 }
 
 .newsletter-media-slot div {

--- a/docs/admin-v2-architecture.md
+++ b/docs/admin-v2-architecture.md
@@ -31,6 +31,8 @@ Current strengths:
 - `NEEDS-ANI`, content inventory, content review, operations, newsletter,
   proof, repos, handoffs, fleet, mutations, and destructive ops have protected
   routes
+- `/repos` can render the local-dev Infra runtime repo overlay metadata through
+  `/api/admin/runtime-feed`
 - deploy workflow can target only admin
 - unauthenticated users are blocked by Cloudflare Access before app content
   renders
@@ -131,6 +133,10 @@ Never include secret values, dirty filenames, file contents, private messages,
 health payload rows, message ids, signed document bodies, or dollar amounts in
 admin feed payloads unless a future authority explicitly permits that exact
 field.
+
+The runtime feed remains local-dev only in `apps/admin`. Production returns a
+disabled metadata response until a reviewed collector and redaction contract are
+approved.
 
 ## content editing model
 

--- a/docs/platform-architecture.md
+++ b/docs/platform-architecture.md
@@ -72,6 +72,7 @@ covered while passkey proof and Access removal are completed, then remove
 | `/fleet`                                            | machine and agent state              |
 | `/mutations`                                        | mutation queue                       |
 | `/ops/destructive`                                  | gated destructive-operation register |
+| `/api/admin/runtime-feed`                           | local-dev metadata overlay endpoint  |
 
 ## auth target
 
@@ -123,6 +124,8 @@ Rules:
 - D1 migrations run as reviewed migration steps before app deploy.
 - Anthropic and Claude Code API-backed GitHub workflows are disabled for this
   repo.
+- `/api/admin/runtime-feed` is disabled in production and reads only the local
+  Infra runtime metadata file during development.
 
 ## cleanup sequence
 


### PR DESCRIPTION
## summary
- add a local-dev-only runtime feed adapter to canonical Astro admin
- add protected `/api/admin/runtime-feed` with production disabled metadata response
- render runtime repo overlays on `/repos` when local Infra runtime metadata is available
- document that this is not a production collector and includes metadata only

## deploy target
- expected: admin=true only
- computed locally: www=false, admin=true, admin_solid=false, ingest=false, newsletter=false, state=false, weekly_email=false

## verification
- pnpm turbo typecheck --filter=@anipotts/admin...
- pnpm turbo build --filter=@anipotts/admin...
- pnpm test:deploy-targets
- git diff --check
- rg found no node:fs references in apps/admin/dist
- local dev smoke: unauthenticated `/repos` and `/api/admin/runtime-feed` both redirected to `/auth/passkey`