### PR TITLE
Refresh admin proof log

### DIFF
--- a/apps/admin/src/data/proof.ts
+++ b/apps/admin/src/data/proof.ts
@@ -14,23 +14,49 @@ export type ProofEntry = {
 
 export const proofSource = {
   mode: "read_only_static_proof_log",
-  generated_from: "GitHub runs, route probes, PR state, and D1-safe metadata",
+  generated_from:
+    "GitHub runs, route probes, PR state, and D1-safe passkey metadata",
   live_writes: "disabled",
 };
 
 export const proofEntries: ProofEntry[] = [
   {
-    id: "proof.site.pr121.deploy",
+    id: "proof.admin.pr131.deploy",
     kind: "deploy",
     status: "verified",
-    title: "PR #121 deployed admin only",
+    title: "PR #131 deployed admin only",
     summary:
-      "Deploy run 28305779971 completed for admin. Www, admin-solid, ingest, newsletter, weekly-email, and state workers were skipped.",
+      "Deploy run 28334470855 completed for admin. Www, admin-solid, ingest, newsletter, weekly-email, and state workers were skipped.",
     evidence_uri:
-      "https://github.com/anipotts/anipotts.com/actions/runs/28305779971",
+      "https://github.com/anipotts/anipotts.com/actions/runs/28334470855",
     redaction: "public_metadata",
     next_safe_action:
-      "Keep deploy proof attached to route-level changes until proof rows move into D1.",
+      "Keep deploy proof attached to admin route-level changes until proof rows move into D1.",
+  },
+  {
+    id: "proof.site.pr128.deploy",
+    kind: "deploy",
+    status: "verified",
+    title: "PR #128 deployed public site only",
+    summary:
+      "Deploy run 28334009441 completed for www after removing unused making content collections. Admin, admin-solid, ingest, newsletter, weekly-email, and state workers were skipped.",
+    evidence_uri:
+      "https://github.com/anipotts/anipotts.com/actions/runs/28334009441",
+    redaction: "public_metadata",
+    next_safe_action:
+      "Keep public cleanup deploys scoped to www until content records replace static source edits.",
+  },
+  {
+    id: "proof.repo.cleanup-prs",
+    kind: "repo",
+    status: "verified",
+    title: "cleanup PRs merged without branch residue",
+    summary:
+      "PRs #128, #129, #130, and #131 merged through agent automerge. Local main is aligned with origin/main and no open site PRs or agent branches remain.",
+    evidence_uri: "https://github.com/anipotts/anipotts.com/pulls",
+    redaction: "public_metadata",
+    next_safe_action:
+      "Continue branch-per-slice work and keep main production-reflective.",
   },
   {
     id: "proof.site.public-routes",
@@ -50,23 +76,11 @@ export const proofEntries: ProofEntry[] = [
     status: "verified",
     title: "admin unauthenticated block holds",
     summary:
-      "Unauthenticated probes returned 302 for /auth/passkey, /, /content, /content/review, /content/preview, /content/operations, /newsletter, the newsletter detail preview, /needs-ani, /proof, /repos, and /fleet.",
+      "Unauthenticated probes returned 302 for /auth/passkey, /repos, and /api/admin/runtime-feed after PR #131 deployed. Full proof script still reports Cloudflare Access as the outer boundary for protected admin routes.",
     evidence_uri: "https://admin.anipotts.com/auth/passkey",
     redaction: "protected_route",
     next_safe_action:
       "After passkey enrollment, prove app-native login and then remove Cloudflare Access.",
-  },
-  {
-    id: "proof.repo.open-prs",
-    kind: "repo",
-    status: "verified",
-    title: "no open site PRs",
-    summary:
-      "GitHub PR list returned no open pull requests after PR #121 merged.",
-    evidence_uri: "https://github.com/anipotts/anipotts.com/pulls",
-    redaction: "public_metadata",
-    next_safe_action:
-      "Continue branch-per-slice work with ready PRs as the default.",
   },
   {
     id: "proof.admin.passkey-enrollment",
@@ -74,7 +88,7 @@ export const proofEntries: ProofEntry[] = [
     status: "blocked",
     title: "passkey enrollment proof missing",
     summary:
-      "Access removal remains blocked until biometric passkey registration, login, logout, persistence, and revoked-credential denial are proven.",
+      "Passkey schema exists in D1, but proof on 2026-06-28 showed zero active credentials, zero active sessions, and zero audit events. Access removal remains blocked until registration, login, logout, persistence, and revoked-credential denial are proven.",
     evidence_uri: "pnpm --silent proof:admin-passkey",
     redaction: "metadata_only",
     next_safe_action:


### PR DESCRIPTION
## summary
- update the read-only admin proof log with PR #128 through #131 evidence
- record latest admin deploy run 28334470855 and public www deploy run 28334009441
- keep passkey enrollment blocked based on current D1 proof: zero active credentials, sessions, and audit events

## deploy target
- expected: admin=true only
- computed locally: www=false, admin=true, admin_solid=false, ingest=false, newsletter=false, state=false, weekly_email=false

## verification
- pnpm turbo typecheck --filter=@anipotts/admin...
- pnpm turbo build --filter=@anipotts/admin...
- pnpm test:deploy-targets
- git diff --check