### PR TITLE
Add Astro formatting support

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,6 +2,17 @@ dist/
 .next/
 node_modules/
 pnpm-lock.yaml
+.turbo/
+.claude/
+.codex/
+.agents/
+**/.astro/
+**/.output/
+**/.vinxi/
+
+# legacy rollback app stays untouched until Astro admin passkey proof lets us
+# remove or archive it.
+apps/admin-solid/
 
 # content collection bodies are data, not code. the markdown -> d1 sync
 # depends on byte fidelity, so no formatter ever touches them.

--- a/.prettierrc
+++ b/.prettierrc
@@ -6,5 +6,6 @@
   "printWidth": 80,
   "bracketSpacing": true,
   "arrowParens": "always",
-  "endOfLine": "lf"
+  "endOfLine": "lf",
+  "plugins": ["prettier-plugin-astro"]
 }

--- a/apps/admin/src/pages/auth/passkey.astro
+++ b/apps/admin/src/pages/auth/passkey.astro
@@ -94,10 +94,10 @@ import AdminLayout from "../../layouts/AdminLayout.astro";
   const sessionLabel = document.querySelector("#passkey-session");
   const nextLabel = document.querySelector("#passkey-next");
   const message = document.querySelector("#passkey-message");
-  const registerButton = document.querySelector<HTMLButtonElement>(
-    "#register-passkey",
-  );
-  const loginButton = document.querySelector<HTMLButtonElement>("#login-passkey");
+  const registerButton =
+    document.querySelector<HTMLButtonElement>("#register-passkey");
+  const loginButton =
+    document.querySelector<HTMLButtonElement>("#login-passkey");
   const logoutButton =
     document.querySelector<HTMLButtonElement>("#logout-passkey");
 

--- a/apps/admin/src/pages/content/index.astro
+++ b/apps/admin/src/pages/content/index.astro
@@ -27,7 +27,9 @@ const surfaces = ["homepage", "projects", "writing", "newsletter"] as const;
                 <p>{surface}</p>
                 <h2>{rows.length} fields</h2>
               </div>
-              <span>{rows.filter((row) => row.editability === "ready").length} ready</span>
+              <span>
+                {rows.filter((row) => row.editability === "ready").length} ready
+              </span>
             </div>
             <div class="record-list">
               {rows.map((row) => (

--- a/apps/admin/src/pages/content/operations.astro
+++ b/apps/admin/src/pages/content/operations.astro
@@ -105,7 +105,9 @@ if (!db) {
       <div class="section-head">
         <div>
           <p>d1 content store</p>
-          <h2>{readState.counts.reduce((sum, row) => sum + row.rows, 0)} rows</h2>
+          <h2>
+            {readState.counts.reduce((sum, row) => sum + row.rows, 0)} rows
+          </h2>
         </div>
         <span>{contentOperationSchemaSource.mode}</span>
       </div>

--- a/apps/admin/src/pages/content/preview.astro
+++ b/apps/admin/src/pages/content/preview.astro
@@ -1,6 +1,9 @@
 ---
 import AdminLayout from "../../layouts/AdminLayout.astro";
-import { contentInventorySource, contentPreviewItems } from "../../data/content";
+import {
+  contentInventorySource,
+  contentPreviewItems,
+} from "../../data/content";
 ---
 
 <AdminLayout
@@ -17,7 +20,9 @@ import { contentInventorySource, contentPreviewItems } from "../../data/content"
     {
       contentPreviewItems.map((item) => (
         <article class="proposal-row">
-          <p>{item.surface} / {item.status}</p>
+          <p>
+            {item.surface} / {item.status}
+          </p>
           <h2>{item.title}</h2>
           <div class="diff-pair">
             <div>

--- a/apps/admin/src/pages/needs-ani.astro
+++ b/apps/admin/src/pages/needs-ani.astro
@@ -16,7 +16,9 @@ import { needsAniBuckets, needsAniItems } from "../data/needs";
   <div class="needs-grid">
     {
       needsAniBuckets.map((group) => {
-        const rows = needsAniItems.filter((item) => item.bucket === group.bucket);
+        const rows = needsAniItems.filter(
+          (item) => item.bucket === group.bucket,
+        );
 
         return (
           <section class="table-card">
@@ -31,7 +33,9 @@ import { needsAniBuckets, needsAniItems } from "../data/needs";
               {rows.map((item) => (
                 <article class="need-row">
                   <div>
-                    <p>{item.owner} / {item.type}</p>
+                    <p>
+                      {item.owner} / {item.type}
+                    </p>
                     <h3>{item.id}</h3>
                     <span>{item.why}</span>
                   </div>

--- a/apps/admin/src/pages/newsletter.astro
+++ b/apps/admin/src/pages/newsletter.astro
@@ -78,7 +78,9 @@ import { newsletterDrafts, newsletterDraftsSource } from "../data/newsletter";
                 {draft.sections.map((section) => (
                   <article class="compact-row">
                     <span>{section.kind}</span>
-                    <strong>{section.heading ?? section.label ?? "opening"}</strong>
+                    <strong>
+                      {section.heading ?? section.label ?? "opening"}
+                    </strong>
                     <small>{section.thread_beat ?? section.body}</small>
                     {section.items && (
                       <ul class="compact-list">

--- a/apps/admin/src/pages/newsletter/[slug].astro
+++ b/apps/admin/src/pages/newsletter/[slug].astro
@@ -1,6 +1,9 @@
 ---
 import AdminLayout from "../../layouts/AdminLayout.astro";
-import { newsletterDrafts, newsletterDraftsSource } from "../../data/newsletter";
+import {
+  newsletterDrafts,
+  newsletterDraftsSource,
+} from "../../data/newsletter";
 
 const { slug } = Astro.params;
 const draft = newsletterDrafts.find((item) => item.slug === slug);
@@ -25,14 +28,21 @@ if (!draft) {
         </section>
 
         <div class="newsletter-preview-layout">
-          <article class="newsletter-article-preview" aria-label="issue preview">
+          <article
+            class="newsletter-article-preview"
+            aria-label="issue preview"
+          >
             <a class="back-link" href="/newsletter">
               back to issue queue
             </a>
             <header class="newsletter-article-head">
               <p>draft newsletter issue</p>
               <h2>{draft.title}</h2>
-              <div class="newsletter-media-slot" role="img" aria-label="draft media preview placeholder">
+              <div
+                class="newsletter-media-slot"
+                role="img"
+                aria-label="draft media preview placeholder"
+              >
                 <div>
                   <span>media preview slot</span>
                   <strong>image, screenshot, or article preview</strong>
@@ -72,7 +82,10 @@ if (!draft) {
             </aside>
           </article>
 
-          <aside class="newsletter-proof-panel" aria-label="draft proof and gates">
+          <aside
+            class="newsletter-proof-panel"
+            aria-label="draft proof and gates"
+          >
             <section class="table-card">
               <div class="section-head">
                 <div>
@@ -122,7 +135,9 @@ if (!draft) {
                 {draft.blocked_actions.map((action) => (
                   <article class="compact-row">
                     <strong>{action}</strong>
-                    <small>requires separate authority before implementation</small>
+                    <small>
+                      requires separate authority before implementation
+                    </small>
                   </article>
                 ))}
               </div>

--- a/apps/admin/src/pages/proof.astro
+++ b/apps/admin/src/pages/proof.astro
@@ -35,7 +35,9 @@ const groups = ["verified", "blocked", "pending"] as const;
               {rows.map((entry) => (
                 <article class="record-row">
                   <div>
-                    <p>{entry.kind} / {entry.redaction}</p>
+                    <p>
+                      {entry.kind} / {entry.redaction}
+                    </p>
                     <h3>{entry.title}</h3>
                   </div>
                   <dl>
@@ -66,7 +68,8 @@ const groups = ["verified", "blocked", "pending"] as const;
   </div>
 
   <div class="notice">
-    The final target is D1-backed proof records. This route is a static bridge so
-    admin can show what is already verified while write paths remain inactive.
+    The final target is D1-backed proof records. This route is a static bridge
+    so admin can show what is already verified while write paths remain
+    inactive.
   </div>
 </AdminLayout>

--- a/apps/admin/src/pages/repos.astro
+++ b/apps/admin/src/pages/repos.astro
@@ -56,7 +56,9 @@ const runtime = await loadRuntimeOverlayResponse();
                       <span class="muted">{overlay.repo_root_label}</span>
                     </td>
                     <td>{overlay.machine}</td>
-                    <td>{overlay.git_available ? "available" : "unavailable"}</td>
+                    <td>
+                      {overlay.git_available ? "available" : "unavailable"}
+                    </td>
                     <td>{overlay.branch ?? "not a git tree"}</td>
                     <td>{overlay.head_sha ?? "none"}</td>
                     <td>

--- a/apps/www/src/components/Footer.astro
+++ b/apps/www/src/components/Footer.astro
@@ -28,10 +28,7 @@ import { Icon } from "astro-icon/components";
       target="_blank"
       rel="noopener noreferrer"><Icon name="ph:linkedin-logo" /></a
     >
-    <a
-      href="https://news.anipotts.com"
-      class="glyph"
-      aria-label="newsletter"
+    <a href="https://news.anipotts.com" class="glyph" aria-label="newsletter"
       ><Icon name="ph:envelope-open" /></a
     >
     <a href="/feed.xml" class="glyph" aria-label="rss feed"

--- a/apps/www/src/components/InlineMention.astro
+++ b/apps/www/src/components/InlineMention.astro
@@ -36,10 +36,7 @@ const markClass = [
 ]
   .filter(Boolean)
   .join(" ");
-const logoClass = [
-  "logo",
-  logoTone === "white" ? "logo-white" : "",
-]
+const logoClass = ["logo", logoTone === "white" ? "logo-white" : ""]
   .filter(Boolean)
   .join(" ");
 ---
@@ -51,7 +48,33 @@ const logoClass = [
   rel={href ? "noopener noreferrer" : undefined}
   aria-label={label}
 >
-  {hasVisual && <span class={markClass} aria-hidden="true">{logoSrc && <img src={logoSrc} alt="" class={logoClass} loading="lazy" decoding="async" />}{icon && <Icon name={icon} />}{mark && <span class="mark">{mark}</span>}</span>}<span class="text">{label}{suffix}</span>{badgeSrc && <img src={badgeSrc} alt={badgeAlt ?? ""} class="logo badge" loading="lazy" decoding="async" />}
+  {
+    hasVisual && (
+      <span class={markClass} aria-hidden="true">
+        {logoSrc && (
+          <img
+            src={logoSrc}
+            alt=""
+            class={logoClass}
+            loading="lazy"
+            decoding="async"
+          />
+        )}
+        {icon && <Icon name={icon} />}
+        {mark && <span class="mark">{mark}</span>}
+      </span>
+    )
+  }<span class="text">{label}{suffix}</span>{
+    badgeSrc && (
+      <img
+        src={badgeSrc}
+        alt={badgeAlt ?? ""}
+        class="logo badge"
+        loading="lazy"
+        decoding="async"
+      />
+    )
+  }
 </Tag>
 
 <style>

--- a/apps/www/src/components/Nav.astro
+++ b/apps/www/src/components/Nav.astro
@@ -9,7 +9,12 @@ const current = Astro.url.pathname;
   <a href="/" class="wordmark" aria-label="home">
     ani potts<span class="dot">.</span>
   </a>
-  <nav id="primary-nav" class="primary-nav" aria-label="primary" data-open="false">
+  <nav
+    id="primary-nav"
+    class="primary-nav"
+    aria-label="primary"
+    data-open="false"
+  >
     <span class="nav-links">
       {
         navItems.map((item) => (

--- a/apps/www/src/components/NewsletterSubscribe.astro
+++ b/apps/www/src/components/NewsletterSubscribe.astro
@@ -50,7 +50,9 @@ const {
             aria-label="email address"
             required
           />
-          <button class="fill" type="submit">{ctaLabel}</button>
+          <button class="fill" type="submit">
+            {ctaLabel}
+          </button>
         </form>
         <p class="status mono" id="subscribe-status" aria-live="polite" />
       </>
@@ -186,40 +188,41 @@ const {
   }
 </style>
 
-{
-  mode === "form" && (
-    <script>
-      const form = document.getElementById("subscribe-form") as HTMLFormElement;
-      const status = document.getElementById("subscribe-status")!;
-      form?.addEventListener("submit", async (e) => {
-        e.preventDefault();
-        const email = (
-          form.elements.namedItem("email") as HTMLInputElement
-        ).value.trim();
-        if (!email) return;
-        status.textContent = "subscribing...";
-        status.classList.remove("ok");
-        try {
-          const website = (
-            form.elements.namedItem("website") as HTMLInputElement
-          ).value;
-          const res = await fetch("/api/newsletter/subscribe", {
-            method: "POST",
-            headers: { "content-type": "application/json" },
-            body: JSON.stringify({ email, website }),
-          });
-          if (!res.ok) throw new Error(String(res.status));
-          status.textContent =
-            form.dataset.successMessage ?? "subscribed. check your inbox.";
-          status.classList.add("ok");
-          form.reset();
-          (window as any).posthog?.capture("newsletter_subscribed");
-        } catch {
-          status.textContent =
-            form.dataset.errorMessage ??
-            "could not subscribe. try again in a minute.";
-        }
-      });
-    </script>
-  )
-}
+<script>
+  const form = document.getElementById("subscribe-form");
+  const status = document.getElementById("subscribe-status");
+
+  if (form instanceof HTMLFormElement && status) {
+    form.addEventListener("submit", async (e) => {
+      e.preventDefault();
+      const emailInput = form.elements.namedItem("email");
+      if (!(emailInput instanceof HTMLInputElement)) return;
+
+      const email = emailInput.value.trim();
+      if (!email) return;
+      status.textContent = "subscribing...";
+      status.classList.remove("ok");
+
+      try {
+        const websiteInput = form.elements.namedItem("website");
+        const website =
+          websiteInput instanceof HTMLInputElement ? websiteInput.value : "";
+        const res = await fetch("/api/newsletter/subscribe", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ email, website }),
+        });
+        if (!res.ok) throw new Error(String(res.status));
+        status.textContent =
+          form.dataset.successMessage ?? "subscribed. check your inbox.";
+        status.classList.add("ok");
+        form.reset();
+        window.posthog?.capture?.("newsletter_subscribed");
+      } catch {
+        status.textContent =
+          form.dataset.errorMessage ??
+          "could not subscribe. try again in a minute.";
+      }
+    });
+  }
+</script>

--- a/apps/www/src/components/ProjectCard.astro
+++ b/apps/www/src/components/ProjectCard.astro
@@ -11,7 +11,11 @@ const slug = projectSlug(project);
 const { title, subtitle, year, status, category, tags } = project.data;
 ---
 
-<a href={`/projects/${slug}`} class="card project-card" data-category={category}>
+<a
+  href={`/projects/${slug}`}
+  class="card project-card"
+  data-category={category}
+>
   <span class="head">
     <span class="title">{title}</span>
     <Icon name="ph:arrow-bend-right-up" class="affordance" />

--- a/apps/www/src/env.d.ts
+++ b/apps/www/src/env.d.ts
@@ -22,6 +22,12 @@ type CfEnv = {
 
 type Runtime = import("@astrojs/cloudflare").Runtime<CfEnv>;
 
+interface Window {
+  posthog?: {
+    capture?: (event: string, properties?: Record<string, unknown>) => void;
+  };
+}
+
 declare namespace App {
   interface Locals extends Runtime {}
 }

--- a/apps/www/src/layouts/Shell.astro
+++ b/apps/www/src/layouts/Shell.astro
@@ -55,17 +55,31 @@ const personLd = {
     <link rel="canonical" href={canonical} />
     <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
     <link rel="alternate" type="application/rss+xml" href="/feed.xml" />
-    <meta name="theme-color" media="(prefers-color-scheme: light)" content="#fbfaf7" />
-    <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#11111b" />
+    <meta
+      name="theme-color"
+      media="(prefers-color-scheme: light)"
+      content="#fbfaf7"
+    />
+    <meta
+      name="theme-color"
+      media="(prefers-color-scheme: dark)"
+      content="#11111b"
+    />
     <meta property="og:title" content={fullTitle} />
     <meta property="og:description" content={description} />
     <meta property="og:type" content={ogType} />
     <meta property="og:url" content={canonical} />
-    <meta property="og:image" content={`${siteConfig.url}${siteConfig.ogImage}`} />
+    <meta
+      property="og:image"
+      content={`${siteConfig.url}${siteConfig.ogImage}`}
+    />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content={fullTitle} />
     <meta name="twitter:description" content={description} />
-    <meta name="twitter:image" content={`${siteConfig.url}${siteConfig.ogImage}`} />
+    <meta
+      name="twitter:image"
+      content={`${siteConfig.url}${siteConfig.ogImage}`}
+    />
     <script is:inline>
       (() => {
         const stored = localStorage.getItem("theme");
@@ -89,8 +103,20 @@ const personLd = {
         localStorage.setItem("font", font);
       })();
     </script>
-    <script is:inline type="application/ld+json" set:html={JSON.stringify(personLd)} />
-    {jsonLd && <script is:inline type="application/ld+json" set:html={JSON.stringify(jsonLd)} />}
+    <script
+      is:inline
+      type="application/ld+json"
+      set:html={JSON.stringify(personLd)}
+    />
+    {
+      jsonLd && (
+        <script
+          is:inline
+          type="application/ld+json"
+          set:html={JSON.stringify(jsonLd)}
+        />
+      )
+    }
     {
       posthogKey && (
         <script

--- a/apps/www/src/pages/index.astro
+++ b/apps/www/src/pages/index.astro
@@ -42,8 +42,7 @@ const projects = (await visibleProjects())
   .filter((project) => homeMakingOrder.has(project.slug))
   .sort(
     (a, b) =>
-      (homeMakingOrder.get(a.slug) ?? 0) -
-      (homeMakingOrder.get(b.slug) ?? 0),
+      (homeMakingOrder.get(a.slug) ?? 0) - (homeMakingOrder.get(b.slug) ?? 0),
   )
   .slice(0, work.limit ?? 4);
 const writingEntries = (await publishedWriting()).slice(0, writing.limit ?? 3);
@@ -52,51 +51,54 @@ const workHref = "/making";
 const ycMention = homeContent.mentions.yCombinatorF25;
 ---
 
-<Shell
-  title="ani potts"
-  description={homeContent.summary}
-  path="/"
->
+<Shell title="ani potts" description={homeContent.summary} path="/">
   <section data-rise>
     <h1 class="home-hero">
       {heading}<span class="spark">.</span>
     </h1>
     <p class="hero-summary hero-line">
-      {hasCmsHome ? (
-        intro.subheading ?? homeContent.summary
-      ) : (
-        <>
-          <span class="hero-sentence">
-            previously worked on real-time agent i/o at{" "}
-            <span class="mention-cluster"
-              ><InlineMention {...homeContent.mentions.structuredAi} />
-              <span class="brand-parens"
-                ><span>(</span><InlineMention {...ycMention} /><span
-                  >)</span
-                ></span
-              ></span
-            >{" "}
-            and{" "}
-            <span class="mention-cluster"
-              ><InlineMention {...homeContent.mentions.badHabit} suffix="," />
-              <span>an</span>
-              <InlineMention {...homeContent.mentions.atlanticRecords} />
-              <span>venture.</span></span
-            >
-          </span>
-          <span class="hero-break" aria-hidden="true"></span>
-          <span class="hero-sentence">
-            every now and then i post about what i'm doing with claude code and
-            codex, as featured on{" "}
-            <InlineMention
-              {...homeContent.mentions.businessInsider}
-              suffix="."
-            />
-          </span>
-        </>
-      )}
+      {
+        hasCmsHome ? (
+          (intro.subheading ?? homeContent.summary)
+        ) : (
+          <>
+            <span class="hero-sentence">
+              previously worked on real-time agent i/o at{" "}
+              <span class="mention-cluster">
+                <InlineMention {...homeContent.mentions.structuredAi} />
+                <span class="brand-parens">
+                  <>
+                    <span>(</span>
+                    <InlineMention {...ycMention} />
+                    <span>)</span>
+                  </>
+                </span>
+              </span>{" "}
+              and{" "}
+              <span class="mention-cluster">
+                <InlineMention {...homeContent.mentions.badHabit} suffix="," />
+                <span>an</span>
+                <InlineMention {...homeContent.mentions.atlanticRecords} />
+                <span>venture.</span>
+              </span>
+            </span>
+            <span class="hero-break" aria-hidden="true" />
+            <span class="hero-sentence">
+              every now and then i post about what i'm doing with claude code
+              and codex, as featured on{" "}
+              <InlineMention
+                {...homeContent.mentions.businessInsider}
+                suffix="."
+              />
+            </span>
+          </>
+        )
+      }
     </p>
-    <div class="proof-grid mobile-carousel" aria-label="selected engineering proof">
+    <div
+      class="proof-grid mobile-carousel"
+      aria-label="selected engineering proof"
+    >
       {
         homeContent.proof.map((item) => (
           <a href={item.href} class="proof-card">
@@ -109,29 +111,46 @@ const ycMention = homeContent.mentions.yCombinatorF25;
     </div>
   </section>
 
-  {work.visible && <section data-rise class="stack">
-    <span class="head-row">
-      <h2 class="section-label">{workLabel}</h2>
-      <a href={workHref} class="quiet-link mono view-all"
-        >{work.links?.[0]?.label ?? "view all"}<Icon name="ph:arrow-bend-right-up" /></a
-      >
-    </span>
-    <div class="grid mobile-carousel">
-      {projects.map((project) => <ProjectCard project={project} />)}
-    </div>
-  </section>}
+  {
+    work.visible && (
+      <section data-rise class="stack">
+        <span class="head-row">
+          <h2 class="section-label">{workLabel}</h2>
+          <a href={workHref} class="quiet-link mono view-all">
+            {work.links?.[0]?.label ?? "view all"}
+            <Icon name="ph:arrow-bend-right-up" />
+          </a>
+        </span>
+        <div class="grid mobile-carousel">
+          {projects.map((project) => (
+            <ProjectCard project={project} />
+          ))}
+        </div>
+      </section>
+    )
+  }
 
-  {writing.visible && <section data-rise class="stack">
-    <span class="head-row">
-      <h2 class="section-label">{writing.label}</h2>
-      <a href={writing.view_all ?? "/writing"} class="quiet-link mono view-all"
-        >{writing.links?.[0]?.label ?? "view all"}<Icon name="ph:arrow-bend-right-up" /></a
-      >
-    </span>
-    <div class="list">
-      {writingEntries.map((item) => <WritingRow item={item} />)}
-    </div>
-  </section>}
+  {
+    writing.visible && (
+      <section data-rise class="stack">
+        <span class="head-row">
+          <h2 class="section-label">{writing.label}</h2>
+          <a
+            href={writing.view_all ?? "/writing"}
+            class="quiet-link mono view-all"
+          >
+            {writing.links?.[0]?.label ?? "view all"}
+            <Icon name="ph:arrow-bend-right-up" />
+          </a>
+        </span>
+        <div class="list">
+          {writingEntries.map((item) => (
+            <WritingRow item={item} />
+          ))}
+        </div>
+      </section>
+    )
+  }
 
   <section data-rise>
     <NewsletterSubscribe

--- a/apps/www/src/pages/making.astro
+++ b/apps/www/src/pages/making.astro
@@ -81,7 +81,9 @@ const buckets: Array<{
           .map((bucket) => (
             <section class="bucket" aria-labelledby={`bucket-${bucket.id}`}>
               <span class="bucket-head">
-                <h3 id={`bucket-${bucket.id}`} class="bucket-title">{bucket.label}</h3>
+                <h3 id={`bucket-${bucket.id}`} class="bucket-title">
+                  {bucket.label}
+                </h3>
                 <span class="mono muted">{bucket.note}</span>
               </span>
               <div class="grid mobile-carousel">
@@ -90,7 +92,7 @@ const buckets: Array<{
                 ))}
               </div>
             </section>
-        ))
+          ))
       }
     </div>
   </section>

--- a/apps/www/src/pages/newsletter.astro
+++ b/apps/www/src/pages/newsletter.astro
@@ -1,7 +1,10 @@
 ---
 import Shell from "../layouts/Shell.astro";
 import NewsletterSubscribe from "../components/NewsletterSubscribe.astro";
-import { fetchPageContent, normalizeNewsletterContent } from "@anipotts/lib/cms";
+import {
+  fetchPageContent,
+  normalizeNewsletterContent,
+} from "@anipotts/lib/cms";
 import { setDB } from "@anipotts/lib/db";
 import type { D1Database } from "@anipotts/lib/db";
 
@@ -40,12 +43,8 @@ const copy = normalizeNewsletterContent(page?.content);
 
   <section data-rise class="stack">
     <h2 class="section-label">archive</h2>
-    <p class="copy">
-      published notes live here as the archive fills in.
-    </p>
-    <a href={archiveUrl} class="quiet-link archive">
-      read the archive
-    </a>
+    <p class="copy">published notes live here as the archive fills in.</p>
+    <a href={archiveUrl} class="quiet-link archive"> read the archive </a>
   </section>
 </Shell>
 

--- a/apps/www/src/pages/orchestrating.astro
+++ b/apps/www/src/pages/orchestrating.astro
@@ -193,7 +193,9 @@ const fmtSessionTime = (iso: string) =>
     <aside class="hero-panel" aria-label="live session totals">
       <span class="mono panel-label">machine noise</span>
       <span class="panel-number">{fmt(stats.totals.toolCalls)}</span>
-      <span class="panel-copy">tool calls captured from local session logs.</span>
+      <span class="panel-copy"
+        >tool calls captured from local session logs.</span
+      >
     </aside>
   </section>
 
@@ -249,7 +251,11 @@ const fmtSessionTime = (iso: string) =>
       <span class="mono muted">tool calls + file mutations</span>
     </span>
     <div class="chart-card">
-      <div class="chart" role="img" aria-label="daily tool calls and file mutations, last 90 days">
+      <div
+        class="chart"
+        role="img"
+        aria-label="daily tool calls and file mutations, last 90 days"
+      >
         {
           stats.daily.map((d) => (
             <span
@@ -305,12 +311,22 @@ const fmtSessionTime = (iso: string) =>
   <section data-rise class="stack" id="hooks">
     <span class="split-head">
       <h2 class="section-label">safety rails</h2>
-      <a href={TIPS_REPO} class="quiet-link mono" target="_blank" rel="noopener noreferrer">tips repo</a>
+      <a
+        href={TIPS_REPO}
+        class="quiet-link mono"
+        target="_blank"
+        rel="noopener noreferrer">tips repo</a
+      >
     </span>
     <div class="grid-2 mobile-carousel">
       {
         hooks.map((hook) => (
-          <a href={hook.href} class="hook-card" target="_blank" rel="noopener noreferrer">
+          <a
+            href={hook.href}
+            class="hook-card"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             <span class="hook-head">
               <span class="mono hook-name">{hook.name}</span>
               <span class="pill">{hook.event}</span>
@@ -325,12 +341,22 @@ const fmtSessionTime = (iso: string) =>
   <section data-rise class="stack" id="playbooks">
     <span class="split-head">
       <h2 class="section-label">notes</h2>
-      <a href={MINE_REPO} class="quiet-link mono" target="_blank" rel="noopener noreferrer">mine repo</a>
+      <a
+        href={MINE_REPO}
+        class="quiet-link mono"
+        target="_blank"
+        rel="noopener noreferrer">mine repo</a
+      >
     </span>
     <div class="grid-2 mobile-carousel">
       {
         docs.map((doc) => (
-          <a href={doc.href} class="doc-card" target="_blank" rel="noopener noreferrer">
+          <a
+            href={doc.href}
+            class="doc-card"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             <span class="row-title">{doc.name}</span>
             <span class="dek">{doc.desc}</span>
           </a>

--- a/apps/www/src/pages/projects/[slug].astro
+++ b/apps/www/src/pages/projects/[slug].astro
@@ -48,21 +48,29 @@ const cmsParagraphs = project.body
       <span>duration: {d.duration}</span>
     </p>
     <p class="meta mono muted">
-      {d.tags.map((t) => (
-        <span>{t.toLowerCase()}</span>
-      ))}
+      {d.tags.map((t) => <span>{t.toLowerCase()}</span>)}
     </p>
     <span class="links mono">
       {
         d.link_live && (
-          <a href={d.link_live} class="accent-link ext" target="_blank" rel="noopener noreferrer">
+          <a
+            href={d.link_live}
+            class="accent-link ext"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             live site <Icon name="ph:arrow-bend-right-up" />
           </a>
         )
       }
       {
         d.link_repo && (
-          <a href={d.link_repo} class="quiet-link ext" target="_blank" rel="noopener noreferrer">
+          <a
+            href={d.link_repo}
+            class="quiet-link ext"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             source <Icon name="ph:arrow-bend-right-up" />
           </a>
         )

--- a/apps/www/src/pages/writing/[slug].astro
+++ b/apps/www/src/pages/writing/[slug].astro
@@ -70,7 +70,12 @@ const articleLd = {
       }
       {
         d.artifact_url && (
-          <a href={d.artifact_url} class="accent-link mono artifact" target="_blank" rel="noopener noreferrer">
+          <a
+            href={d.artifact_url}
+            class="accent-link mono artifact"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             proof artifact ({d.artifact_type ?? "link"})
             <Icon name="ph:arrow-bend-right-up" />
           </a>
@@ -79,7 +84,13 @@ const articleLd = {
     </header>
 
     <div data-rise class="article-body">
-      {Content ? <Content /> : cmsParagraphs.map((paragraph) => <p>{paragraph}</p>)}
+      {
+        Content ? (
+          <Content />
+        ) : (
+          cmsParagraphs.map((paragraph) => <p>{paragraph}</p>)
+        )
+      }
     </div>
   </article>
 </Shell>

--- a/apps/www/src/pages/writing/index.astro
+++ b/apps/www/src/pages/writing/index.astro
@@ -20,9 +20,7 @@ const writingEntries = await publishedWriting();
 >
   <section data-rise>
     <h1 class="hero-title">writing</h1>
-    <p class="hero-summary">
-      stuff i've figured out and wanted to write down.
-    </p>
+    <p class="hero-summary">stuff i've figured out and wanted to write down.</p>
   </section>
 
   <section data-rise class="stack">

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "lint": "turbo lint",
     "typecheck": "turbo typecheck",
     "clean": "turbo clean && rm -rf node_modules",
-    "format": "prettier --write \"**/*.{ts,tsx,md,json}\"",
+    "format": "prettier --write \"**/*.{astro,ts,tsx,md,json}\"",
+    "format:check": "prettier --check \"**/*.{astro,ts,tsx,md,json}\"",
     "dev:www": "turbo dev --filter=@anipotts/www",
     "proof:admin-passkey": "node scripts/admin/passkey-proof.mjs",
     "update-claude-stats": "node scripts/claude/generate-claude-stats.mjs",
@@ -32,10 +33,10 @@
     "prepare": "husky"
   },
   "lint-staged": {
-    "apps/www/**/*.{ts,tsx}": [
+    "apps/www/**/*.{astro,ts,tsx}": [
       "prettier --write"
     ],
-    "apps/admin/**/*.{ts,tsx}": [
+    "apps/admin/**/*.{astro,ts,tsx}": [
       "prettier --write"
     ],
     "workers/**/*.ts": [
@@ -66,6 +67,7 @@
     "husky": "^9.1.7",
     "lint-staged": "^16.3.3",
     "prettier": "^3.8.3",
+    "prettier-plugin-astro": "^0.14.1",
     "turbo": "^2.9.14",
     "typescript": "^5.7.0",
     "wrangler": "^4.92.0"

--- a/packages/lib/src/validation/index.ts
+++ b/packages/lib/src/validation/index.ts
@@ -30,7 +30,10 @@ export type ContactPayload = z.infer<typeof contactSchema>;
 
 type ParseContactResult =
   | { success: true; data: ContactPayload }
-  | { success: false; error: { error: string; fields: Record<string, string> } };
+  | {
+      success: false;
+      error: { error: string; fields: Record<string, string> };
+    };
 
 export function parseContactPayload(input: unknown): ParseContactResult {
   const result = contactSchema.safeParse(input);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,9 @@ importers:
       prettier:
         specifier: ^3.8.3
         version: 3.8.3
+      prettier-plugin-astro:
+        specifier: ^0.14.1
+        version: 0.14.1
       turbo:
         specifier: ^2.9.14
         version: 2.9.14
@@ -63,7 +66,7 @@ importers:
     devDependencies:
       '@astrojs/check':
         specifier: ^0.9.4
-        version: 0.9.9(prettier@3.8.3)(typescript@5.9.3)
+        version: 0.9.9(prettier-plugin-astro@0.14.1)(prettier@3.8.3)(typescript@5.9.3)
       typescript:
         specifier: ^5
         version: 5.9.3
@@ -137,7 +140,7 @@ importers:
     devDependencies:
       '@astrojs/check':
         specifier: ^0.9.4
-        version: 0.9.9(prettier@3.8.3)(typescript@5.9.3)
+        version: 0.9.9(prettier-plugin-astro@0.14.1)(prettier@3.8.3)(typescript@5.9.3)
       '@cloudflare/workers-types':
         specifier: ^4.20250523.0
         version: 4.20260518.1
@@ -4859,6 +4862,10 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
+  prettier-plugin-astro@0.14.1:
+    resolution: {integrity: sha512-RiBETaaP9veVstE4vUwSIcdATj6dKmXljouXc/DDNwBSPTp8FRkLGDSGFClKsAFeeg+13SB0Z1JZvbD76bigJw==}
+    engines: {node: ^14.15.0 || >=16.0.0}
+
   prettier@3.8.3:
     resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
     engines: {node: '>=14'}
@@ -5089,6 +5096,9 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
+  s.color@0.0.15:
+    resolution: {integrity: sha512-AUNrbEUHeKY8XsYr/DYpl+qk5+aM+DChopnWOPEzn8YKzOhv4l2zH6LzZms3tOZP3wwdOyc0RmTciyi46HLIuA==}
+
   safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
 
@@ -5097,6 +5107,9 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  sass-formatter@0.7.9:
+    resolution: {integrity: sha512-CWZ8XiSim+fJVG0cFLStwDvft1VI7uvXdCNJYXhDvowiv+DsbD1nXLiQ4zrE5UBvj5DWZJ93cwN0NX5PMsr1Pw==}
 
   sax@1.6.0:
     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
@@ -5315,6 +5328,9 @@ packages:
     resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
     engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
+
+  suf-log@2.5.3:
+    resolution: {integrity: sha512-KvC8OPjzdNOe+xQ4XWJV2whQA0aM1kGVczMQ8+dStAO6KfEB140JEVQ9dE76ONZ0/Ylf67ni4tILPJB41U0eow==}
 
   supports-color@10.2.2:
     resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
@@ -6170,9 +6186,9 @@ snapshots:
 
   '@antfu/utils@8.1.1': {}
 
-  '@astrojs/check@0.9.9(prettier@3.8.3)(typescript@5.9.3)':
+  '@astrojs/check@0.9.9(prettier-plugin-astro@0.14.1)(prettier@3.8.3)(typescript@5.9.3)':
     dependencies:
-      '@astrojs/language-server': 2.16.10(prettier@3.8.3)(typescript@5.9.3)
+      '@astrojs/language-server': 2.16.10(prettier-plugin-astro@0.14.1)(prettier@3.8.3)(typescript@5.9.3)
       chokidar: 4.0.3
       kleur: 4.1.5
       typescript: 5.9.3
@@ -6209,7 +6225,7 @@ snapshots:
 
   '@astrojs/internal-helpers@0.7.6': {}
 
-  '@astrojs/language-server@2.16.10(prettier@3.8.3)(typescript@5.9.3)':
+  '@astrojs/language-server@2.16.10(prettier-plugin-astro@0.14.1)(prettier@3.8.3)(typescript@5.9.3)':
     dependencies:
       '@astrojs/compiler': 2.13.1
       '@astrojs/yaml2ts': 0.2.4
@@ -6231,6 +6247,7 @@ snapshots:
       vscode-uri: 3.1.0
     optionalDependencies:
       prettier: 3.8.3
+      prettier-plugin-astro: 0.14.1
     transitivePeerDependencies:
       - typescript
 
@@ -10718,6 +10735,12 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
+  prettier-plugin-astro@0.14.1:
+    dependencies:
+      '@astrojs/compiler': 2.13.1
+      prettier: 3.8.3
+      sass-formatter: 0.7.9
+
   prettier@3.8.3: {}
 
   pretty-bytes@7.1.0: {}
@@ -11031,11 +11054,17 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
+  s.color@0.0.15: {}
+
   safe-buffer@5.1.2: {}
 
   safe-buffer@5.2.1: {}
 
   safer-buffer@2.1.2: {}
+
+  sass-formatter@0.7.9:
+    dependencies:
+      suf-log: 2.5.3
 
   sax@1.6.0: {}
 
@@ -11316,6 +11345,10 @@ snapshots:
       pirates: 4.0.7
       tinyglobby: 0.2.15
       ts-interface-checker: 0.1.13
+
+  suf-log@2.5.3:
+    dependencies:
+      s.color: 0.0.15
 
   supports-color@10.2.2: {}
 

--- a/scripts/mini/commit-publisher.ts
+++ b/scripts/mini/commit-publisher.ts
@@ -15,15 +15,25 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { mkdirSync, readFileSync, writeFileSync, existsSync, readdirSync, statSync } from "node:fs";
+import {
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  existsSync,
+  readdirSync,
+  statSync,
+} from "node:fs";
 import { dirname, join, basename } from "node:path";
 import { homedir } from "node:os";
 
 const STATE_API = process.env.STATE_API ?? "https://api.anipotts.com";
 const PUBLISH_KEY = process.env.STATE_PUBLISH_KEY;
-const ROOTS = (process.env.COMMIT_ROOTS ?? join(homedir(), "Code/projects")).split(":");
+const ROOTS = (
+  process.env.COMMIT_ROOTS ?? join(homedir(), "Code/projects")
+).split(":");
 const CURSOR_FILE =
-  process.env.CURSOR_FILE ?? join(homedir(), ".anipotts/commit-publisher.cursor.json");
+  process.env.CURSOR_FILE ??
+  join(homedir(), ".anipotts/commit-publisher.cursor.json");
 const MAX_PER_REPO = Number(process.env.MAX_PER_REPO ?? "50");
 const AUTHOR_FILTER = process.env.AUTHOR_FILTER;
 
@@ -66,7 +76,12 @@ function findGitRepos(roots: string[], maxDepth = 4): string[] {
   return repos;
 }
 
-function walk(dir: string, depth: number, maxDepth: number, out: string[]): void {
+function walk(
+  dir: string,
+  depth: number,
+  maxDepth: number,
+  out: string[],
+): void {
   if (depth > maxDepth) return;
   let entries: string[];
   try {
@@ -97,7 +112,9 @@ function git(repo: string, args: string[]): string {
     maxBuffer: 16 * 1024 * 1024,
   });
   if (result.status !== 0) {
-    throw new Error(`git ${args.join(" ")} in ${repo} failed: ${result.stderr.trim()}`);
+    throw new Error(
+      `git ${args.join(" ")} in ${repo} failed: ${result.stderr.trim()}`,
+    );
   }
   return result.stdout;
 }
@@ -134,7 +151,9 @@ function readCommits(repo: string, sinceSha: string | undefined): Commit[] {
       author: (author ?? "").trim(),
       ts: ts.trim(),
       branch: branch || undefined,
-      parentCount: parents ? parents.trim().split(/\s+/).filter(Boolean).length : 0,
+      parentCount: parents
+        ? parents.trim().split(/\s+/).filter(Boolean).length
+        : 0,
     });
   }
   return commits.reverse();


### PR DESCRIPTION
## Summary\n- add the Astro prettier plugin and include .astro files in root formatting plus lint-staged\n- ignore generated/local context folders and legacy admin-solid formatter churn\n- normalize active Astro files in apps/www and apps/admin\n- convert the newsletter subscribe browser script to typed plain JavaScript so Astro prettier can parse it\n\n## Verification\n- pnpm format:check\n- pnpm turbo typecheck --filter=@anipotts/www... --filter=@anipotts/admin...\n- pnpm turbo build --filter=@anipotts/www... --filter=@anipotts/admin...\n- pnpm test:deploy-targets\n- git diff --check\n- node scripts/ci/compute-deploy-targets.mjs for changed files => www=true, admin=true, admin_solid=false, ingest=false, newsletter=false, state=false, weekly_email=false\n\n## Deploy Scope\n- expected: www=true, admin=true\n- skipped: admin_solid, ingest, newsletter, state, weekly_email\n- no auth, secret, D1 write, worker, publish, or Cloudflare Access change