### PR TITLE
Align content inventory with CMS source

### DIFF
--- a/docs/content-admin-editor-brief.md
+++ b/docs/content-admin-editor-brief.md
@@ -11,26 +11,26 @@ or any live write path.
 
 ## current inventory
 
-| surface               | source                                                                    | current shape                                                                                                    | notes                                                         |
-| --------------------- | ------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
-| homepage hero         | `apps/www/src/data/site.ts`, rendered in `apps/www/src/pages/index.astro` | heading, summary, proof cards, press mention, inline links                                                       | now framed around startup engineering proof                   |
-| project cards         | `apps/www/src/content/projects/*.md`                                      | title, subtitle, description, year, category, role, duration, status, featured, visible, sort order, links, tags | source is already markdown-backed and editor-ready            |
-| project detail pages  | same project markdown body plus optional `technical` and `roadmap` arrays | overview, technical blocks, next steps                                                                           | only quantercise has meaningful body sections today           |
-| writing previews      | `apps/www/src/content/writing/*.md`                                       | title, slug, summary, tags, status, published date, body                                                         | five published posts, mostly claude code and ai workflow      |
-| newsletter block      | `apps/www/src/components/NewsletterSubscribe.astro`                       | static label, lede, email form, status messages                                                                  | copy now makes the promise specific without inventing cadence |
-| archived making notes | `docs/archive/labs/content/**`                                            | old weekly digests and experiments                                                                               | reference only, not an active public-site content source      |
+| surface               | source                                                                                                     | current shape                                                                                                    | notes                                                                    |
+| --------------------- | ---------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| homepage hero         | D1 `page_content:home`, fallback `apps/www/src/data/site.ts`, rendered in `apps/www/src/pages/index.astro` | heading, summary, proof cards, press mention, inline links                                                       | reader path exists; source fallback renders until a published row exists |
+| project cards         | `apps/www/src/content/projects/*.md`                                                                       | title, subtitle, description, year, category, role, duration, status, featured, visible, sort order, links, tags | source is already markdown-backed and editor-ready                       |
+| project detail pages  | same project markdown body plus optional `technical` and `roadmap` arrays                                  | overview, technical blocks, next steps                                                                           | only quantercise has meaningful body sections today                      |
+| writing previews      | `apps/www/src/content/writing/*.md`                                                                        | title, slug, summary, tags, status, published date, body                                                         | five published posts, mostly claude code and ai workflow                 |
+| newsletter block      | D1 `page_content:newsletter`, fallback `@anipotts/lib/cms` defaults and `NewsletterSubscribe` props        | headline, deck, CTA label, success text, error text, footer, email form                                          | reader path exists; source fallback renders until a published row exists |
+| archived making notes | `docs/archive/labs/content/**`                                                                             | old weekly digests and experiments                                                                               | reference only, not an active public-site content source                 |
 
 ## highest-leverage cleanup batch
 
-| priority | cleanup                                                 | why it matters                                                           | owner fit                     |
-| -------- | ------------------------------------------------------- | ------------------------------------------------------------------------ | ----------------------------- |
-| p0       | expose homepage proof cards in admin                    | above-fold credibility now depends on four concrete engineering receipts | admin editor                  |
-| p0       | expose project card fields in admin                     | shipping cards still carry the browsable proof trail                     | admin editor                  |
-| p0       | add `body` editing for project detail pages             | several projects have no narrative beyond a card                         | admin editor                  |
-| p1       | add writing preview controls                            | titles and summaries are the actual newsletter backfill queue            | admin editor                  |
-| p1       | add newsletter headline, deck, cta, and status messages | the subscribe module should be editable without code                     | admin editor                  |
-| p2       | decide canonical project source                         | markdown and `packages/lib/src/data/projects.ts` duplicate similar facts | admin editor plus site thread |
-| p2       | classify old posts before publishing to the newsletter  | current writing can seed the newsletter, but should not be auto-sent     | newsletter thread             |
+| priority | cleanup                                                 | why it matters                                                                           | owner fit                     |
+| -------- | ------------------------------------------------------- | ---------------------------------------------------------------------------------------- | ----------------------------- |
+| p0       | expose homepage proof cards in admin                    | above-fold credibility now depends on four concrete engineering receipts                 | admin editor                  |
+| p0       | expose project card fields in admin                     | shipping cards still carry the browsable proof trail                                     | admin editor                  |
+| p0       | add `body` editing for project detail pages             | several projects have no narrative beyond a card                                         | admin editor                  |
+| p1       | add writing preview controls                            | titles and summaries are the actual newsletter backfill queue                            | admin editor                  |
+| p1       | add newsletter headline, deck, cta, and status messages | these fields now have a D1 page-content source and need audited operations before writes | admin editor                  |
+| p2       | decide canonical project source                         | markdown and `packages/lib/src/data/projects.ts` duplicate similar facts                 | admin editor plus site thread |
+| p2       | classify old posts before publishing to the newsletter  | current writing can seed the newsletter, but should not be auto-sent                     | newsletter thread             |
 
 ## first read-only admin slice
 
@@ -105,6 +105,16 @@ hidden admin write endpoints.
 | `error_message`   | string |      yes | current message: `could not subscribe. try again in a minute.`              |
 | `buttondown_url`  |    url |       no | legacy field name; current value points to `news.anipotts.com`              |
 
+The canonical editable source is D1 `page_content` with `page_key =
+newsletter`, normalized by `@anipotts/lib/cms`. `NewsletterSubscribe.astro`
+remains a rendering component and fallback prop surface, not the long-term
+editable source.
+
+Current production D1 has no published `home` or `newsletter` rows as of this
+inventory refresh, so the public site still renders source defaults. The next
+safe step is a reviewed, audited draft operation that seeds rows without adding
+an untracked save path.
+
 ## newsletter backfill options
 
 do not invent fake archives. these are candidates from existing work and should be published only after ani or the newsletter thread confirms source artifacts.
@@ -135,8 +145,8 @@ do not invent fake archives. these are candidates from existing work and should 
 
 ## open questions
 
-| question                                                                                                     | why it matters                                                                     |
-| ------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------- |
-| should project `subtitle` be renamed to `summary` in the editor while staying mapped to markdown frontmatter | editor copy should match how ani thinks about cards                                |
-| should writing stay file-backed or move into D1 first                                                        | admin currently edits D1 thoughts, while www uses astro content collections        |
-| should newsletter copy live in `page_content` or static site config                                          | this decides whether non-article homepage copy can be edited with the same surface |
+| question                                                                                                      | why it matters                                                                    |
+| ------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| should project `subtitle` be renamed to `summary` in the editor while staying mapped to markdown frontmatter  | editor copy should match how ani thinks about cards                               |
+| should writing stay file-backed or move into D1 first                                                         | admin currently edits D1 thoughts, while www uses astro content collections       |
+| should the first newsletter copy write route require Ani approval every time or only when risk is medium/high | the source is D1 `page_content`; the remaining decision is write authority policy |

--- a/packages/content/src/admin/content.ts
+++ b/packages/content/src/admin/content.ts
@@ -44,7 +44,8 @@ export const contentInventorySource = {
   source_doc: "docs/content-admin-editor-brief.md",
   architecture_doc: "docs/admin-v2-architecture.md",
   mode: "read_only_static_inventory",
-  generated_from: "current tracked apps/www source files",
+  generated_from:
+    "current tracked apps/www source files plus @anipotts/lib/cms page_content reader paths",
 };
 
 export const contentInventory: ContentInventoryItem[] = [
@@ -52,12 +53,13 @@ export const contentInventory: ContentInventoryItem[] = [
     id: "homepage.heading",
     surface: "homepage",
     title: "hero heading",
-    source_ref: "apps/www/src/data/site.ts:homeContent.heading",
+    source_ref:
+      "D1 page_content:home.sections.intro.heading, fallback apps/www/src/data/site.ts:homeContent.heading",
     current_value: "hi, i'm ani",
     editability: "ready",
     risk_level: "low",
     next_safe_action:
-      "Expose as a future content field after the read-only inventory is proven.",
+      "Draft the homepage content record through an audited operation before adding a save path.",
     required_authority: [],
     proof_ids: ["content.homepage.heading.source"],
   },
@@ -65,13 +67,14 @@ export const contentInventory: ContentInventoryItem[] = [
     id: "homepage.summary",
     surface: "homepage",
     title: "hero summary",
-    source_ref: "apps/www/src/data/site.ts:homeContent.summary",
+    source_ref:
+      "D1 page_content:home.sections.intro.subheading, fallback apps/www/src/data/site.ts:homeContent.summary",
     current_value:
-      "Structured AI, Our Bad Habit, Atlantic Records, and agent workflow copy are source-backed in site config.",
+      "Homepage intro copy uses the @anipotts/lib/cms reader path, with source defaults rendering until a published D1 record exists.",
     editability: "ready",
     risk_level: "medium",
     next_safe_action:
-      "Model proposal preview before allowing edits because this is above-fold public copy.",
+      "Use the content operation model before allowing writes because this is above-fold public copy.",
     required_authority: [],
     proof_ids: ["content.homepage.summary.source"],
   },
@@ -191,15 +194,19 @@ export const contentInventory: ContentInventoryItem[] = [
     id: "newsletter.subscribe_copy",
     surface: "newsletter",
     title: "subscribe block copy",
-    source_ref: "apps/www/src/components/NewsletterSubscribe.astro",
+    source_ref:
+      "D1 page_content:newsletter, fallback @anipotts/lib/cms DEFAULT_NEWSLETTER_CONTENT and component props",
     current_value:
-      "Default lede, CTA label, success text, error text, and newsletter link live in the component props.",
-    editability: "needs_schema",
+      "Headline, deck, CTA label, success text, error text, footer text, and archive URL use the @anipotts/lib/cms reader path, with fallback defaults rendering until a published D1 record exists.",
+    editability: "ready",
     risk_level: "medium",
     next_safe_action:
-      "Choose D1 page_content or site config as the editable source before adding save behavior.",
-    required_authority: ["content.newsletter-source.owner-decision"],
-    proof_ids: ["content.newsletter.component.defaults"],
+      "Add an audited draft operation before any save route writes the newsletter content record.",
+    required_authority: [],
+    proof_ids: [
+      "content.newsletter.page-content.source",
+      "content.newsletter.component.defaults",
+    ],
   },
   {
     id: "newsletter.backfill",
@@ -226,9 +233,10 @@ export const contentPreviewItems: ContentPreviewItem[] = [
     title: "tighten homepage summary",
     status: "preview",
     risk_level: "medium",
-    source_ref: "apps/www/src/data/site.ts:homeContent.summary",
+    source_ref:
+      "D1 page_content:home.sections.intro.subheading, fallback apps/www/src/data/site.ts:homeContent.summary",
     current_value:
-      "previously worked on real-time agent i/o at structured ai (YC F25) and our bad habit, an atlantic records venture. every now and then i post about what i'm doing with claude code and codex.",
+      "homepage intro copy as rendered from the published `home` content record or source fallback.",
     proposed_value:
       "previously worked on real-time agent i/o at structured ai (YC F25) and our bad habit, an atlantic records venture. now i write about coding agent workflows and the systems around them.",
     preview_route: "/",
@@ -287,23 +295,26 @@ export const contentPreviewItems: ContentPreviewItem[] = [
     inventory_id: "newsletter.subscribe_copy",
     surface: "newsletter",
     title: "choose newsletter copy source",
-    status: "blocked",
+    status: "preview",
     risk_level: "medium",
-    source_ref: "apps/www/src/components/NewsletterSubscribe.astro",
+    source_ref: "D1 page_content:newsletter",
     current_value:
-      "Newsletter copy defaults are component props, with CMS-normalized copy also used on the homepage.",
+      "Newsletter copy already has a `newsletter` content reader path, with source defaults as fallback.",
     proposed_value:
-      "Move editable newsletter block copy into a typed content record before enabling admin edits.",
+      "Render the newsletter content record in admin and require an audited content operation before writes.",
     preview_route: "/newsletter",
-    authority_state: "needs_source_truth_decision",
-    required_approval_ids: ["content.newsletter-source.owner-decision"],
-    proof_ids: ["content.newsletter.component.defaults"],
+    authority_state: "source_truth_resolved_preview_only",
+    required_approval_ids: [],
+    proof_ids: [
+      "content.newsletter.page-content.source",
+      "content.newsletter.component.defaults",
+    ],
     blocked_actions: [
       "save newsletter copy",
       "sync newsletter provider",
       "send email",
     ],
     next_safe_action:
-      "Keep read-only until the content store decision is recorded.",
+      "Keep read-only until a content operation write route is audited and logged.",
   },
 ];


### PR DESCRIPTION
## summary\n- align the admin content inventory with the existing @anipotts/lib/cms page_content reader paths for home and newsletter\n- record that production D1 currently has no published home/newsletter rows, so source fallbacks still render\n- keep the next step read-only: audited draft operations before any save route or content write\n\n## verification\n- pnpm format:check\n- pnpm turbo typecheck --filter=@anipotts/content... --filter=@anipotts/admin...\n- pnpm turbo build --filter=@anipotts/content... --filter=@anipotts/admin...\n- pnpm test:deploy-targets\n- git diff --check\n- read-only remote D1 query for home/newsletter rows: 0 rows, 0 writes\n- deploy target calculation: admin=true, all other targets=false\n\n## live impact\n- none yet\n- no write path, no migration, no public copy change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the content inventory and editor guidance to reflect D1-backed homepage and newsletter content sources, with clear fallback behavior to existing defaults.
  * Clarified where newsletter copy comes from and how it should be handled during editorial workflows.
  * Revised the cleanup priorities and open questions to focus on audited content changes and approval expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->