### PR TITLE
Seed inert content draft operations

### DIFF
--- a/docs/admin-content-draft-operations.md
+++ b/docs/admin-content-draft-operations.md
@@ -132,9 +132,14 @@ Drizzle schema at `packages/lib/src/db/schema.ts`.
 - `content_draft_operations`: draft and preview operations
 - `content_publish_events`: immutable publish proof
 
-This authorizes the additive schema only. It does not authorize a binding
-change, Worker route, content write API, public-site runtime read from records,
-browser save action, outbound send, or publish action.
+`drizzle/migrations/0008_seed_content_draft_operations.sql` seeds the first two
+inert rows into `content_draft_operations`: homepage summary and newsletter
+copy. These rows exist so admin can review real D1 operation state instead of
+only static templates.
+
+The schema and seed rows do not authorize a binding change, Worker route,
+content write API, public-site runtime read from records, browser save action,
+outbound send, or publish action.
 
 ## proof requirements before writes
 

--- a/docs/platform-architecture.md
+++ b/docs/platform-architecture.md
@@ -16,7 +16,7 @@ structured content/state model, and one predictable CI/CD path.
 | labs           | `docs/archive/labs`                 | archived            | no app or deploy target remains                          |
 | workers        | `workers/*`                         | review individually | keep only production-required workers                    |
 | shared content | `packages/content`, `packages/lib`  | in progress         | use package contracts plus D1 operation tables           |
-| database       | `drizzle`, D1 `anipotts-db`         | keep                | apply additive content operation schema, then prove it   |
+| database       | `drizzle`, D1 `anipotts-db`         | keep                | seed inert content operations, then prove admin reads    |
 
 ## current inventory
 
@@ -140,5 +140,6 @@ Rules:
 8. review workers and delete unneeded worker targets.
 9. expand `packages/content` from static content inventory into the durable
    operation schema and D1 adapter layer. started with
-   `drizzle/migrations/0007_content_operations.sql`.
+   `drizzle/migrations/0007_content_operations.sql` and inert seed rows in
+   `drizzle/migrations/0008_seed_content_draft_operations.sql`.
 10. reduce deploy workflow inputs to retained production targets.

--- a/drizzle/migrations/0008_seed_content_draft_operations.sql
+++ b/drizzle/migrations/0008_seed_content_draft_operations.sql
@@ -1,0 +1,121 @@
+-- 0008_seed_content_draft_operations.sql
+-- Seed inert admin content draft operations.
+--
+-- This inserts reviewable operation rows only. It does not insert published
+-- content records, change public rendering, add save APIs, publish, send,
+-- deploy, or mutate external providers.
+--
+-- Rollback:
+--   DELETE FROM content_draft_operations
+--   WHERE operation_id IN (
+--     'content-draft-homepage-summary-2026-06-28',
+--     'content-draft-newsletter-copy-2026-06-28'
+--   );
+
+INSERT OR IGNORE INTO content_draft_operations (
+  operation_id,
+  kind,
+  surface,
+  route,
+  source_ref,
+  field_path,
+  current_value_ref,
+  proposed_value,
+  status,
+  risk_level,
+  authority_state,
+  required_approval_ids,
+  allowed_actions,
+  forbidden_actions,
+  preview_targets,
+  proof_ids,
+  evidence_uri,
+  redaction,
+  created_by,
+  created_at,
+  updated_at,
+  expires_at,
+  rollback_ref,
+  reviewer_note,
+  metadata
+) VALUES (
+  'content-draft-homepage-summary-2026-06-28',
+  'content_draft',
+  'public_site',
+  '/',
+  'D1 page_content:home.sections.intro.subheading, fallback apps/www/src/data/site.ts:homeContent.summary',
+  'homepage.summary',
+  'source_fallback',
+  'previously worked on real-time agent i/o at structured ai (YC F25) and our bad habit, an atlantic records venture. now i write about coding agent workflows and the systems around them.',
+  'previewed',
+  'medium',
+  'preview_only_no_write',
+  '[]',
+  '["render_preview","request_review"]',
+  '["save","publish","deploy","send"]',
+  '["/content/preview","/"]',
+  '["content.homepage.summary.source","admin.content.preview.local"]',
+  'repo://apps/www/src/pages/index.astro',
+  'public_copy_only',
+  'agent',
+  '2026-06-28T00:00:00Z',
+  '2026-06-28T00:00:00Z',
+  '2026-07-28T00:00:00Z',
+  'source_fallback',
+  'Seeded as an inert review operation. No content record or publish event is created.',
+  '{"source":"drizzle/migrations/0008_seed_content_draft_operations.sql","write_path":"inactive"}'
+);
+
+INSERT OR IGNORE INTO content_draft_operations (
+  operation_id,
+  kind,
+  surface,
+  route,
+  source_ref,
+  field_path,
+  current_value_ref,
+  proposed_value,
+  status,
+  risk_level,
+  authority_state,
+  required_approval_ids,
+  allowed_actions,
+  forbidden_actions,
+  preview_targets,
+  proof_ids,
+  evidence_uri,
+  redaction,
+  created_by,
+  created_at,
+  updated_at,
+  expires_at,
+  rollback_ref,
+  reviewer_note,
+  metadata
+) VALUES (
+  'content-draft-newsletter-copy-2026-06-28',
+  'content_draft',
+  'newsletter',
+  '/newsletter',
+  'D1 page_content:newsletter, fallback @anipotts/lib/cms DEFAULT_NEWSLETTER_CONTENT and component props',
+  'newsletter.subscribe_copy',
+  'source_fallback',
+  'Render headline, deck, CTA, success text, error text, footer text, and archive URL from a newsletter page_content record before any save route exists.',
+  'previewed',
+  'medium',
+  'source_truth_resolved_preview_only',
+  '[]',
+  '["render_preview","request_review"]',
+  '["save","publish","send","sync_provider"]',
+  '["/content/preview","/newsletter"]',
+  '["content.newsletter.page-content.source","content.newsletter.component.defaults"]',
+  'repo://apps/www/src/pages/newsletter.astro',
+  'public_copy_only',
+  'agent',
+  '2026-06-28T00:00:00Z',
+  '2026-06-28T00:00:00Z',
+  '2026-07-28T00:00:00Z',
+  'source_fallback',
+  'Seeded as an inert review operation. No content record, provider sync, send, or publish event is created.',
+  '{"source":"drizzle/migrations/0008_seed_content_draft_operations.sql","write_path":"inactive"}'
+);

--- a/packages/content/src/admin/operations.ts
+++ b/packages/content/src/admin/operations.ts
@@ -57,7 +57,8 @@ export type ContentOperationTable = {
 
 export const contentOperationSchemaSource = {
   source_doc: "docs/admin-content-draft-operations.md",
-  migration: "drizzle/migrations/0007_content_operations.sql",
+  migration:
+    "drizzle/migrations/0007_content_operations.sql + drizzle/migrations/0008_seed_content_draft_operations.sql",
   schema: "packages/lib/src/db/schema.ts",
   mode: "d1_schema_no_write_endpoint",
 };
@@ -88,13 +89,14 @@ export const contentOperationTables: ContentOperationTable[] = [
 
 export const contentOperationTemplates: ContentOperation[] = [
   {
-    operation_id: "content-draft-homepage-summary-2026-06-27",
+    operation_id: "content-draft-homepage-summary-2026-06-28",
     kind: "content_draft",
     surface: "public_site",
     route: "/",
-    source_ref: "apps/www/src/data/site.ts:homeContent.summary",
+    source_ref:
+      "D1 page_content:home.sections.intro.subheading, fallback apps/www/src/data/site.ts:homeContent.summary",
     field_path: "homepage.summary",
-    current_value_ref: "source_default",
+    current_value_ref: "source_fallback",
     proposed_value:
       "previously worked on real-time agent i/o at structured ai (YC F25) and our bad habit, an atlantic records venture. now i write about coding agent workflows and the systems around them.",
     status: "previewed",
@@ -108,38 +110,42 @@ export const contentOperationTemplates: ContentOperation[] = [
       "content.homepage.summary.source",
       "admin.content.preview.local",
     ],
-    evidence_uri: "repo://apps/www/src/data/site.ts",
+    evidence_uri: "repo://apps/www/src/pages/index.astro",
     redaction: "public_copy_only",
     created_by: "agent",
-    created_at: "2026-06-27T00:00:00Z",
-    updated_at: "2026-06-27T00:00:00Z",
-    expires_at: "2026-07-27T00:00:00Z",
-    rollback_ref: "source_default",
+    created_at: "2026-06-28T00:00:00Z",
+    updated_at: "2026-06-28T00:00:00Z",
+    expires_at: "2026-07-28T00:00:00Z",
+    rollback_ref: "source_fallback",
   },
   {
-    operation_id: "content-draft-newsletter-block-source-2026-06-27",
+    operation_id: "content-draft-newsletter-copy-2026-06-28",
     kind: "content_draft",
     surface: "newsletter",
     route: "/newsletter",
-    source_ref: "apps/www/src/components/NewsletterSubscribe.astro",
+    source_ref:
+      "D1 page_content:newsletter, fallback @anipotts/lib/cms DEFAULT_NEWSLETTER_CONTENT and component props",
     field_path: "newsletter.subscribe_copy",
-    current_value_ref: "component_default",
+    current_value_ref: "source_fallback",
     proposed_value:
-      "model newsletter headline, deck, CTA, success text, and error text as content records before enabling saves",
-    status: "blocked",
+      "Render headline, deck, CTA, success text, error text, footer text, and archive URL from a newsletter page_content record before any save route exists.",
+    status: "previewed",
     risk_level: "medium",
-    authority_state: "needs_source_truth_decision",
-    required_approval_ids: ["content.newsletter-source.owner-decision"],
+    authority_state: "source_truth_resolved_preview_only",
+    required_approval_ids: [],
     allowed_actions: ["render_preview", "request_review"],
     forbidden_actions: ["save", "publish", "send", "sync_provider"],
     preview_targets: ["/content/preview", "/newsletter"],
-    proof_ids: ["content.newsletter.component.defaults"],
-    evidence_uri: "repo://apps/www/src/components/NewsletterSubscribe.astro",
+    proof_ids: [
+      "content.newsletter.page-content.source",
+      "content.newsletter.component.defaults",
+    ],
+    evidence_uri: "repo://apps/www/src/pages/newsletter.astro",
     redaction: "public_copy_only",
     created_by: "agent",
-    created_at: "2026-06-27T00:00:00Z",
-    updated_at: "2026-06-27T00:00:00Z",
-    expires_at: "2026-07-27T00:00:00Z",
-    rollback_ref: "component_default",
+    created_at: "2026-06-28T00:00:00Z",
+    updated_at: "2026-06-28T00:00:00Z",
+    expires_at: "2026-07-28T00:00:00Z",
+    rollback_ref: "source_fallback",
   },
 ];


### PR DESCRIPTION
## summary\n- add idempotent D1 migration 0008 to seed two inert content_draft_operations rows\n- align static operation templates with the CMS page_content source decision\n- document that these rows do not create content_records, publish events, save APIs, provider sync, sends, or public rendering changes\n\n## migration\n- reviewed file: drizzle/migrations/0008_seed_content_draft_operations.sql\n- apply target: anipotts-db\n- rollback: delete the two exact operation_id rows listed in the migration header\n\n## verification\n- local D1 apply: 0007 then 0008\n- local D1 readback of both seeded operation rows\n- pnpm format:check\n- pnpm turbo typecheck --filter=@anipotts/content... --filter=@anipotts/admin...\n- pnpm turbo build --filter=@anipotts/content... --filter=@anipotts/admin...\n- pnpm test:deploy-targets\n- git diff --check\n- deploy target calculation: admin=true, all other targets=false\n\n## live impact\n- after migration apply, admin /content/operations can show two real D1 draft operation rows\n- no public content change\n- no write path\n- no outbound action