### PR TITLE
Read content review queue from D1

### DIFF
--- a/apps/admin/src/pages/content/operations.astro
+++ b/apps/admin/src/pages/content/operations.astro
@@ -2,92 +2,11 @@
 import AdminLayout from "../../layouts/AdminLayout.astro";
 import {
   contentOperationSchemaSource,
-  contentOperationTables,
   contentOperationTemplates,
+  readContentOperationStore,
 } from "../../data/content";
 
-type CountRow = {
-  table_name: string;
-  rows: number;
-};
-
-type OperationRow = {
-  operation_id: string;
-  kind: string;
-  surface: string;
-  route: string;
-  status: string;
-  risk_level: string;
-  authority_state: string;
-  updated_at: string;
-};
-
-type ReadState =
-  | { mode: "ready"; counts: CountRow[]; operations: OperationRow[] }
-  | { mode: "missing_db"; counts: CountRow[]; operations: OperationRow[] }
-  | {
-      mode: "read_failed";
-      counts: CountRow[];
-      operations: OperationRow[];
-      error: string;
-    };
-
-const fallbackCounts = contentOperationTables.map((table) => ({
-  table_name: table.table,
-  rows: 0,
-}));
-
-const db = Astro.locals.runtime?.env.DB;
-let readState: ReadState;
-
-if (!db) {
-  readState = { mode: "missing_db", counts: fallbackCounts, operations: [] };
-} else {
-  try {
-    const [records, operations, events, recent] = await Promise.all([
-      db.prepare("SELECT COUNT(*) AS count FROM content_records").first<{
-        count: number;
-      }>(),
-      db
-        .prepare("SELECT COUNT(*) AS count FROM content_draft_operations")
-        .first<{ count: number }>(),
-      db.prepare("SELECT COUNT(*) AS count FROM content_publish_events").first<{
-        count: number;
-      }>(),
-      db
-        .prepare(
-          `SELECT operation_id, kind, surface, route, status, risk_level, authority_state, updated_at
-           FROM content_draft_operations
-           ORDER BY updated_at DESC
-           LIMIT 20`,
-        )
-        .all<OperationRow>(),
-    ]);
-
-    readState = {
-      mode: "ready",
-      counts: [
-        { table_name: "content_records", rows: Number(records?.count ?? 0) },
-        {
-          table_name: "content_draft_operations",
-          rows: Number(operations?.count ?? 0),
-        },
-        {
-          table_name: "content_publish_events",
-          rows: Number(events?.count ?? 0),
-        },
-      ],
-      operations: recent.results ?? [],
-    };
-  } catch (error) {
-    readState = {
-      mode: "read_failed",
-      counts: fallbackCounts,
-      operations: [],
-      error: error instanceof Error ? error.message : "unknown read failure",
-    };
-  }
-}
+const readState = await readContentOperationStore(Astro.locals.runtime?.env.DB);
 ---
 
 <AdminLayout

--- a/apps/admin/src/pages/content/review.astro
+++ b/apps/admin/src/pages/content/review.astro
@@ -7,9 +7,25 @@ import {
   contentOperationTables,
   contentOperationTemplates,
   contentPreviewItems,
+  readContentOperationStore,
 } from "../../data/content";
 
 const surfaces = ["homepage", "projects", "writing", "newsletter"] as const;
+const readState = await readContentOperationStore(Astro.locals.runtime?.env.DB);
+const d1Operations = readState.operations;
+
+function operationMatchesSurface(
+  operation: (typeof d1Operations)[number],
+  surface: (typeof surfaces)[number],
+) {
+  if (surface === "homepage")
+    return operation.field_path.startsWith("homepage.");
+  if (surface === "newsletter")
+    return operation.field_path.startsWith("newsletter.");
+  if (surface === "projects")
+    return operation.field_path.startsWith("projects.");
+  return operation.field_path.startsWith("writing.");
+}
 ---
 
 <AdminLayout
@@ -19,6 +35,8 @@ const surfaces = ["homepage", "projects", "writing", "newsletter"] as const;
   <section class="meta-strip" aria-label="content review source">
     <span>{contentInventory.length} sources</span>
     <span>{contentPreviewItems.length} previews</span>
+    <span>{d1Operations.length} d1 operations</span>
+    <span>{readState.mode}</span>
     <span>{contentOperationTables.length} d1 tables</span>
     <span>{contentInventorySource.architecture_doc}</span>
   </section>
@@ -47,10 +65,15 @@ const surfaces = ["homepage", "projects", "writing", "newsletter"] as const;
         </div>
       </div>
       <div>
-        <h3>sample operation</h3>
+        <h3>
+          {d1Operations.length > 0 ? "d1 review queue" : "sample operation"}
+        </h3>
         <div class="record-list">
           {
-            contentOperationTemplates.map((operation) => (
+            (d1Operations.length > 0
+              ? d1Operations
+              : contentOperationTemplates
+            ).map((operation) => (
               <article class="compact-row">
                 <strong>{operation.operation_id}</strong>
                 <span>
@@ -77,13 +100,20 @@ const surfaces = ["homepage", "projects", "writing", "newsletter"] as const;
         const previewRows = contentPreviewItems.filter(
           (row) => row.surface === surface,
         );
+        const operationRows = d1Operations.filter((operation) =>
+          operationMatchesSurface(operation, surface),
+        );
 
         return (
           <section class="table-card">
             <div class="section-head">
               <div>
                 <p>{surface}</p>
-                <h2>{previewRows.length} previews</h2>
+                <h2>
+                  {operationRows.length > 0
+                    ? `${operationRows.length} d1 operations`
+                    : `${previewRows.length} previews`}
+                </h2>
               </div>
               <span>{sourceRows.length} sources</span>
             </div>
@@ -103,38 +133,73 @@ const surfaces = ["homepage", "projects", "writing", "newsletter"] as const;
               </div>
 
               <div>
-                <h3>inert proposal</h3>
+                <h3>
+                  {operationRows.length > 0
+                    ? "d1 draft operation"
+                    : "static preview"}
+                </h3>
                 <div class="record-list">
-                  {previewRows.map((row) => (
-                    <article class="proposal-row">
-                      <p>{row.status}</p>
-                      <h3>{row.title}</h3>
-                      <div class="diff-pair">
-                        <div>
-                          <span>current</span>
-                          <p>{row.current_value}</p>
-                        </div>
-                        <div>
-                          <span>proposed</span>
-                          <p>{row.proposed_value}</p>
-                        </div>
-                      </div>
-                      <dl>
-                        <div>
-                          <dt>authority</dt>
-                          <dd>{row.authority_state}</dd>
-                        </div>
-                        <div>
-                          <dt>blocked</dt>
-                          <dd>{row.blocked_actions.join(", ")}</dd>
-                        </div>
-                        <div>
-                          <dt>next</dt>
-                          <dd>{row.next_safe_action}</dd>
-                        </div>
-                      </dl>
-                    </article>
-                  ))}
+                  {operationRows.length > 0
+                    ? operationRows.map((operation) => (
+                        <article class="proposal-row">
+                          <p>{operation.status}</p>
+                          <h3>{operation.operation_id}</h3>
+                          <div class="diff-pair">
+                            <div>
+                              <span>current</span>
+                              <p>{operation.current_value_ref}</p>
+                            </div>
+                            <div>
+                              <span>proposed</span>
+                              <p>{operation.proposed_value}</p>
+                            </div>
+                          </div>
+                          <dl>
+                            <div>
+                              <dt>authority</dt>
+                              <dd>{operation.authority_state}</dd>
+                            </div>
+                            <div>
+                              <dt>blocked</dt>
+                              <dd>{operation.forbidden_actions.join(", ")}</dd>
+                            </div>
+                            <div>
+                              <dt>rollback</dt>
+                              <dd>{operation.rollback_ref}</dd>
+                            </div>
+                          </dl>
+                        </article>
+                      ))
+                    : previewRows.map((row) => (
+                        <article class="proposal-row">
+                          <p>{row.status}</p>
+                          <h3>{row.title}</h3>
+                          <div class="diff-pair">
+                            <div>
+                              <span>current</span>
+                              <p>{row.current_value}</p>
+                            </div>
+                            <div>
+                              <span>proposed</span>
+                              <p>{row.proposed_value}</p>
+                            </div>
+                          </div>
+                          <dl>
+                            <div>
+                              <dt>authority</dt>
+                              <dd>{row.authority_state}</dd>
+                            </div>
+                            <div>
+                              <dt>blocked</dt>
+                              <dd>{row.blocked_actions.join(", ")}</dd>
+                            </div>
+                            <div>
+                              <dt>next</dt>
+                              <dd>{row.next_safe_action}</dd>
+                            </div>
+                          </dl>
+                        </article>
+                      ))}
                 </div>
               </div>
             </div>
@@ -143,4 +208,12 @@ const surfaces = ["homepage", "projects", "writing", "newsletter"] as const;
       })
     }
   </div>
+
+  {
+    readState.mode === "read_failed" && (
+      <section class="notice">
+        D1 read failed: {readState.error}. Static previews remained read-only.
+      </section>
+    )
+  }
 </AdminLayout>

--- a/packages/content/src/admin/operations.ts
+++ b/packages/content/src/admin/operations.ts
@@ -45,6 +45,71 @@ export type ContentOperation = {
   reviewer_note?: string;
 };
 
+type D1Result<T = unknown> = {
+  results?: T[];
+  success?: boolean;
+};
+
+type D1PreparedStatement = {
+  bind(...values: unknown[]): D1PreparedStatement;
+  first<T = unknown>(): Promise<T | null>;
+  all<T = unknown>(): Promise<D1Result<T>>;
+};
+
+export type ContentOperationD1Database = {
+  prepare(query: string): D1PreparedStatement;
+};
+
+type ContentOperationRow = {
+  operation_id: string;
+  kind: string;
+  surface: string;
+  route: string;
+  source_ref: string;
+  field_path: string;
+  current_value_ref: string;
+  proposed_value: string;
+  status: string;
+  risk_level: string;
+  authority_state: string;
+  required_approval_ids: string;
+  allowed_actions: string;
+  forbidden_actions: string;
+  preview_targets: string;
+  proof_ids: string;
+  evidence_uri: string | null;
+  redaction: string;
+  created_by: string;
+  created_at: string;
+  updated_at: string;
+  expires_at: string | null;
+  rollback_ref: string;
+  reviewer_note: string | null;
+};
+
+export type ContentOperationCountRow = {
+  table_name: ContentOperationTable["table"];
+  rows: number;
+};
+
+export type ContentOperationReadState =
+  | {
+      mode: "ready";
+      counts: ContentOperationCountRow[];
+      operations: ContentOperation[];
+    }
+  | {
+      mode: "missing_db";
+      counts: ContentOperationCountRow[];
+      operations: ContentOperation[];
+    }
+  | {
+      mode: "read_failed";
+      counts: ContentOperationCountRow[];
+      operations: ContentOperation[];
+      error: string;
+    };
+
 export type ContentOperationTable = {
   table:
     | "content_records"
@@ -86,6 +151,172 @@ export const contentOperationTables: ContentOperationTable[] = [
     blocked_actions: ["send", "schedule", "publish without proof"],
   },
 ];
+
+export function contentOperationFallbackCounts(): ContentOperationCountRow[] {
+  return contentOperationTables.map((table) => ({
+    table_name: table.table,
+    rows: 0,
+  }));
+}
+
+export async function readContentOperationStore(
+  db: ContentOperationD1Database | null | undefined,
+): Promise<ContentOperationReadState> {
+  const fallbackCounts = contentOperationFallbackCounts();
+  if (!db) {
+    return {
+      mode: "missing_db",
+      counts: fallbackCounts,
+      operations: [],
+    };
+  }
+
+  try {
+    const [records, operations, events, recent] = await Promise.all([
+      countRows(db, "content_records"),
+      countRows(db, "content_draft_operations"),
+      countRows(db, "content_publish_events"),
+      db
+        .prepare(
+          `SELECT
+             operation_id,
+             kind,
+             surface,
+             route,
+             source_ref,
+             field_path,
+             current_value_ref,
+             proposed_value,
+             status,
+             risk_level,
+             authority_state,
+             required_approval_ids,
+             allowed_actions,
+             forbidden_actions,
+             preview_targets,
+             proof_ids,
+             evidence_uri,
+             redaction,
+             created_by,
+             created_at,
+             updated_at,
+             expires_at,
+             rollback_ref,
+             reviewer_note
+           FROM content_draft_operations
+           ORDER BY updated_at DESC
+           LIMIT 20`,
+        )
+        .all<ContentOperationRow>(),
+    ]);
+
+    return {
+      mode: "ready",
+      counts: [
+        { table_name: "content_records", rows: records },
+        { table_name: "content_draft_operations", rows: operations },
+        { table_name: "content_publish_events", rows: events },
+      ],
+      operations: (recent.results ?? []).map(contentOperationFromRow),
+    };
+  } catch (error) {
+    return {
+      mode: "read_failed",
+      counts: fallbackCounts,
+      operations: [],
+      error: error instanceof Error ? error.message : "unknown read failure",
+    };
+  }
+}
+
+function countRows(
+  db: ContentOperationD1Database,
+  table: ContentOperationTable["table"],
+): Promise<number> {
+  return db
+    .prepare(`SELECT COUNT(*) AS count FROM ${table}`)
+    .first<{ count: number }>()
+    .then((row) => Number(row?.count ?? 0));
+}
+
+function contentOperationFromRow(row: ContentOperationRow): ContentOperation {
+  return {
+    operation_id: row.operation_id,
+    kind: parseKind(row.kind),
+    surface: parseSurface(row.surface),
+    route: row.route,
+    source_ref: row.source_ref,
+    field_path: row.field_path,
+    current_value_ref: row.current_value_ref,
+    proposed_value: row.proposed_value,
+    status: parseStatus(row.status),
+    risk_level: parseRisk(row.risk_level),
+    authority_state: row.authority_state,
+    required_approval_ids: parseStringArray(row.required_approval_ids),
+    allowed_actions: parseStringArray(row.allowed_actions),
+    forbidden_actions: parseStringArray(row.forbidden_actions),
+    preview_targets: parseStringArray(row.preview_targets),
+    proof_ids: parseStringArray(row.proof_ids),
+    evidence_uri: row.evidence_uri ?? undefined,
+    redaction: row.redaction,
+    created_by: parseCreatedBy(row.created_by),
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+    expires_at: row.expires_at ?? undefined,
+    rollback_ref: row.rollback_ref,
+    reviewer_note: row.reviewer_note ?? undefined,
+  };
+}
+
+function parseStringArray(raw: string): string[] {
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((value): value is string => typeof value === "string");
+  } catch {
+    return [];
+  }
+}
+
+function parseKind(value: string): ContentOperationKind {
+  return value === "content_record" ||
+    value === "content_draft" ||
+    value === "content_publish"
+    ? value
+    : "content_draft";
+}
+
+function parseSurface(value: string): ContentOperationSurface {
+  return value === "public_site" || value === "newsletter" || value === "admin"
+    ? value
+    : "public_site";
+}
+
+function parseStatus(value: string): ContentOperationStatus {
+  return value === "draft" ||
+    value === "previewed" ||
+    value === "needs_ani" ||
+    value === "blocked" ||
+    value === "approved" ||
+    value === "publishing" ||
+    value === "published" ||
+    value === "verified" ||
+    value === "reverted"
+    ? value
+    : "draft";
+}
+
+function parseRisk(value: string): RiskLevel {
+  return value === "low" || value === "medium" || value === "high"
+    ? value
+    : "medium";
+}
+
+function parseCreatedBy(value: string): ContentOperation["created_by"] {
+  return value === "agent" || value === "ani" || value === "system"
+    ? value
+    : "agent";
+}
 
 export const contentOperationTemplates: ContentOperation[] = [
   {


### PR DESCRIPTION
## summary\n- move read-only D1 content operation counts and row parsing into packages/content\n- make /content/operations and /content/review use the same shared adapter\n- make /content/review prefer real D1 draft operation rows, with static previews only as fallback\n\n## verification\n- pnpm format:check\n- pnpm turbo typecheck --filter=@anipotts/content... --filter=@anipotts/admin...\n- pnpm turbo build --filter=@anipotts/content... --filter=@anipotts/admin...\n- pnpm test:deploy-targets\n- git diff --check\n- deploy target calculation: admin=true, all other targets=false\n\n## live impact\n- read-only admin UI change\n- no D1 writes\n- no migration\n- no public content change\n- no save/publish/send path