### PR TITLE
Tighten admin passkey proof gate

### DIFF
--- a/apps/admin/src/data/proof.ts
+++ b/apps/admin/src/data/proof.ts
@@ -80,6 +80,13 @@ const baseProofEntries: ProofEntry[] = [
   },
 ];
 
+const requiredPasskeyAuditEvents = [
+  "passkey.credential.registered",
+  "passkey.session.created",
+  "passkey.session.revoked",
+  "passkey.authentication.denied",
+] as const;
+
 export async function readProofEntries(
   db: ProofD1Database | null | undefined,
 ): Promise<ProofEntry[]> {
@@ -173,7 +180,7 @@ async function readPasskeyProof(
 
   try {
     const now = new Date().toISOString();
-    const [credentials, sessions, auditEvents] = await Promise.all([
+    const [credentials, sessions, ...auditEventCounts] = await Promise.all([
       countRows(db, "admin_passkey_credentials", "WHERE revoked_at IS NULL"),
       countRows(
         db,
@@ -181,22 +188,33 @@ async function readPasskeyProof(
         "WHERE revoked_at IS NULL AND expires_at > ?",
         [now],
       ),
-      countRows(db, "admin_passkey_audit"),
+      ...requiredPasskeyAuditEvents.map((eventType) =>
+        countRows(db, "admin_passkey_audit", "WHERE event_type = ?", [
+          eventType,
+        ]),
+      ),
     ]);
-    const proven = credentials > 0 && sessions > 0 && auditEvents > 0;
+    const auditSummary = requiredPasskeyAuditEvents.map(
+      (eventType, index) => `${eventType}=${auditEventCounts[index] ?? 0}`,
+    );
+    const missingAuditEvents = requiredPasskeyAuditEvents.filter(
+      (_eventType, index) => (auditEventCounts[index] ?? 0) === 0,
+    );
+    const proven =
+      credentials > 0 && sessions > 0 && missingAuditEvents.length === 0;
     return {
       id: "proof.admin.passkey-enrollment",
       kind: "gate",
       status: proven ? "verified" : "blocked",
       title: proven
-        ? "passkey credential and session exist"
-        : "passkey enrollment proof missing",
-      summary: `active_credentials=${credentials}, active_sessions=${sessions}, audit_events=${auditEvents}. Cloudflare Access removal waits for full register, login, logout, persistence, and revoked-credential denial proof.`,
+        ? "passkey removal checklist is D1-backed"
+        : "passkey removal checklist is incomplete",
+      summary: `active_credentials=${credentials}, active_sessions=${sessions}, ${auditSummary.join(", ")}. Cloudflare Access removal waits for register, login, logout, persistence, and revoked-credential denial proof.`,
       evidence_uri: "D1 anipotts-db admin passkey tables",
       redaction: "metadata_only",
       next_safe_action: proven
-        ? "Run full route proof, logout proof, and revoked-credential denial before Access removal."
-        : "Register the first passkey behind Cloudflare Access, then record credential, session, and audit evidence.",
+        ? "Run route-boundary proof, then remove Cloudflare Access and prove app-native blocking."
+        : nextPasskeyProofAction(credentials, sessions, missingAuditEvents),
     };
   } catch (error) {
     return {
@@ -225,4 +243,24 @@ async function countRows(
     .bind(...binds)
     .first<{ count: number }>();
   return Number(row?.count ?? 0);
+}
+
+function nextPasskeyProofAction(
+  credentials: number,
+  sessions: number,
+  missingAuditEvents: readonly string[],
+): string {
+  if (credentials === 0) {
+    return "Register the first passkey behind Cloudflare Access.";
+  }
+  if (sessions === 0) {
+    return "Authenticate with the registered passkey and prove a durable session.";
+  }
+  if (missingAuditEvents.includes("passkey.session.revoked")) {
+    return "Logout once to record revocation, then authenticate again before Access removal.";
+  }
+  if (missingAuditEvents.includes("passkey.authentication.denied")) {
+    return "Record revoked-credential denial proof while Cloudflare Access remains active.";
+  }
+  return `Record missing audit proof: ${missingAuditEvents.join(", ")}.`;
 }

--- a/docs/platform-architecture.md
+++ b/docs/platform-architecture.md
@@ -93,12 +93,13 @@ Required proof before removing Access:
 
 Use `pnpm --silent proof:admin-passkey` before and after enrollment. It reads
 the remote `anipotts-db` passkey tables and probes protected admin routes
-without printing Cloudflare Access tokens. The proof is not complete until it
-shows at least one active credential, an app-native session, logout proof in
-audit rows, and app-native route blocking after Access removal. The route probe
-set must include content inventory, review, preview, operations, newsletter
-queue, newsletter detail preview, needs-ani, proof, repos, handoffs, fleet,
-mutations, and destructive-ops routes.
+without printing Cloudflare Access tokens. Before Access removal, the script
+must show one active credential, one active session, and audit rows for
+registration, session creation, session revocation, and revoked-credential
+denial. After Access removal, the same script must show app-native route
+blocking. The route probe set must include content inventory, review, preview,
+operations, newsletter queue, newsletter detail preview, needs-ani, proof,
+repos, handoffs, fleet, mutations, and destructive-ops routes.
 
 ## ci/cd target
 

--- a/scripts/admin/passkey-proof.mjs
+++ b/scripts/admin/passkey-proof.mjs
@@ -23,6 +23,14 @@ const ROUTES = [
   "/ops/destructive",
 ];
 
+const checkedAt = new Date().toISOString();
+const REQUIRED_AUDIT_EVENTS = [
+  "passkey.credential.registered",
+  "passkey.session.created",
+  "passkey.session.revoked",
+  "passkey.authentication.denied",
+];
+
 const tableSql = `
 SELECT name
 FROM sqlite_master
@@ -37,7 +45,7 @@ WHERE revoked_at IS NULL
 UNION ALL
 SELECT 'sessions', COUNT(*)
 FROM admin_passkey_sessions
-WHERE revoked_at IS NULL AND expires_at > datetime('now')
+WHERE revoked_at IS NULL AND expires_at > '${checkedAt}'
 UNION ALL
 SELECT 'audit', COUNT(*)
 FROM admin_passkey_audit;
@@ -71,9 +79,19 @@ const credentialCount = counts.credentials ?? 0;
 const sessionCount = counts.sessions ?? 0;
 const auditCount = counts.audit ?? 0;
 const routeBoundary = summarizeBoundary(routes);
+const missingAuditEvents = REQUIRED_AUDIT_EVENTS.filter(
+  (eventType) => !auditEvents[eventType],
+);
+const missingProof = missingProofItems({
+  schemaReady,
+  credentialCount,
+  sessionCount,
+  missingAuditEvents,
+  routeBoundary,
+});
 
 const proof = {
-  checked_at: new Date().toISOString(),
+  checked_at: checkedAt,
   admin_origin: ADMIN_ORIGIN,
   d1_database: D1_DATABASE,
   schema_ready: schemaReady,
@@ -84,12 +102,24 @@ const proof = {
     audit_events: auditCount,
   },
   audit_events: auditEvents,
+  required_audit_events: Object.fromEntries(
+    REQUIRED_AUDIT_EVENTS.map((eventType) => [
+      eventType,
+      Number(auditEvents[eventType] ?? 0),
+    ]),
+  ),
+  missing_proof: missingProof,
+  ready_for_access_removal:
+    missingProof.length === 1 &&
+    missingProof[0] === "cloudflare_access_still_active",
+  post_access_removal_verified: missingProof.length === 0,
   routes,
   route_boundary: routeBoundary,
   next_safe_action: nextSafeAction({
     schemaReady,
     credentialCount,
     sessionCount,
+    missingAuditEvents,
     routeBoundary,
   }),
 };
@@ -177,6 +207,7 @@ function nextSafeAction({
   schemaReady,
   credentialCount,
   sessionCount,
+  missingAuditEvents,
   routeBoundary,
 }) {
   if (!schemaReady) {
@@ -188,11 +219,40 @@ function nextSafeAction({
   if (sessionCount === 0) {
     return "authenticate with the registered passkey and prove a durable app-native session";
   }
+  if (missingAuditEvents.includes("passkey.session.revoked")) {
+    return "logout once to record session revocation, then authenticate again before Access removal";
+  }
+  if (missingAuditEvents.includes("passkey.authentication.denied")) {
+    return "record revoked-credential denial proof while Cloudflare Access remains active";
+  }
+  if (missingAuditEvents.length > 0) {
+    return `record missing passkey audit proof: ${missingAuditEvents.join(", ")}`;
+  }
   if (routeBoundary === "cloudflare_access") {
-    return "prove logout and failure paths, then remove Cloudflare Access and rerun this proof";
+    return "passkey proof is staged; remove Cloudflare Access and rerun this proof";
   }
   if (routeBoundary === "app_native_passkey") {
     return "record app-native unauthenticated block and authenticated route render proof";
   }
   return "inspect route boundary before changing Access";
+}
+
+function missingProofItems({
+  schemaReady,
+  credentialCount,
+  sessionCount,
+  missingAuditEvents,
+  routeBoundary,
+}) {
+  const missing = [];
+  if (!schemaReady) missing.push("schema_ready");
+  if (credentialCount === 0) missing.push("active_credential");
+  if (sessionCount === 0) missing.push("active_session");
+  missing.push(...missingAuditEvents);
+  if (routeBoundary === "cloudflare_access") {
+    missing.push("cloudflare_access_still_active");
+  } else if (routeBoundary !== "app_native_passkey") {
+    missing.push("app_native_route_boundary");
+  }
+  return missing;
 }


### PR DESCRIPTION
## summary
- make passkey proof require explicit audit events before Access removal
- expose missing proof items and ready/post-removal booleans in the proof script
- show the same stricter passkey proof checklist on the Astro admin proof page
- document the exact pre-removal and post-removal proof criteria

## verification
- git diff --check
- pnpm format:check
- pnpm turbo typecheck --filter=@anipotts/admin...
- pnpm turbo build --filter=@anipotts/admin...
- pnpm --silent proof:admin-passkey
- pnpm test:deploy-targets

## live impact
- admin route metadata only
- no Cloudflare Access change
- no credential/session mutation
- no env/secret change
- expected deploy target: admin only