### PR TITLE
Add admin passkey revocation proof path

### DIFF
--- a/apps/admin/src/data/proof.ts
+++ b/apps/admin/src/data/proof.ts
@@ -84,6 +84,7 @@ const requiredPasskeyAuditEvents = [
   "passkey.credential.registered",
   "passkey.session.created",
   "passkey.session.revoked",
+  "passkey.credential.revoked",
   "passkey.authentication.denied",
 ] as const;
 
@@ -258,6 +259,9 @@ function nextPasskeyProofAction(
   }
   if (missingAuditEvents.includes("passkey.session.revoked")) {
     return "Logout once to record revocation, then authenticate again before Access removal.";
+  }
+  if (missingAuditEvents.includes("passkey.credential.revoked")) {
+    return "Revoke the current passkey while Cloudflare Access remains active, then register a replacement.";
   }
   if (missingAuditEvents.includes("passkey.authentication.denied")) {
     return "Record revoked-credential denial proof while Cloudflare Access remains active.";

--- a/apps/admin/src/lib/passkey-auth.ts
+++ b/apps/admin/src/lib/passkey-auth.ts
@@ -303,6 +303,15 @@ export async function authenticationOptions(
   const db = requiredDb(context);
   const credentials = await listActiveCredentials(db);
   if (credentials.length === 0) {
+    const revokedCredentials = await countRevokedCredentials(db);
+    if (revokedCredentials > 0) {
+      await recordAudit(
+        db,
+        "passkey.authentication.denied",
+        null,
+        "denied authentication because all registered passkeys are revoked",
+      );
+    }
     return json(
       {
         error: "no_credentials",
@@ -442,6 +451,63 @@ export async function logout(context: PasskeyContext): Promise<Response> {
   );
 }
 
+export async function revokeCurrentCredential(
+  context: PasskeyContext,
+): Promise<Response> {
+  const db = requiredDb(context);
+  const session = await getSession(context, db);
+  if (!session) {
+    return json(
+      {
+        error: "session_required",
+        next_safe_action:
+          "authenticate with a passkey before revoking the current credential",
+      },
+      { status: 403 },
+    );
+  }
+
+  await db
+    .prepare(
+      `UPDATE admin_passkey_credentials
+       SET revoked_at = ?, updated_at = ?
+       WHERE credential_id = ? AND revoked_at IS NULL`,
+    )
+    .bind(nowIso(), nowIso(), session.credential_id)
+    .run();
+
+  await db
+    .prepare(
+      `UPDATE admin_passkey_sessions
+       SET revoked_at = ?, updated_at = ?
+       WHERE credential_id = ? AND revoked_at IS NULL`,
+    )
+    .bind(nowIso(), nowIso(), session.credential_id)
+    .run();
+
+  await recordAudit(
+    db,
+    "passkey.credential.revoked",
+    session.credential_id,
+    "revoked current admin passkey for denial proof",
+  );
+  await recordAudit(
+    db,
+    "passkey.session.revoked",
+    session.credential_id,
+    "revoked app-native admin session during credential revocation",
+  );
+
+  return json(
+    {
+      ok: true,
+      next_safe_action:
+        "attempt authenticate to record denial, then register a replacement passkey while Cloudflare Access remains active",
+    },
+    { headers: { "set-cookie": expiredSessionCookie(context) } },
+  );
+}
+
 export function dbFromContext(context: PasskeyContext): D1Database | null {
   return context.locals.runtime?.env.DB ?? null;
 }
@@ -478,6 +544,17 @@ async function countActiveCredentials(db: D1Database): Promise<number> {
     .prepare(
       `SELECT COUNT(*) AS count FROM admin_passkey_credentials
        WHERE user_id = ? AND revoked_at IS NULL`,
+    )
+    .bind(USER_ID)
+    .first<{ count: number }>();
+  return Number(row?.count ?? 0);
+}
+
+async function countRevokedCredentials(db: D1Database): Promise<number> {
+  const row = await db
+    .prepare(
+      `SELECT COUNT(*) AS count FROM admin_passkey_credentials
+       WHERE user_id = ? AND revoked_at IS NOT NULL`,
     )
     .bind(USER_ID)
     .first<{ count: number }>();

--- a/apps/admin/src/middleware.ts
+++ b/apps/admin/src/middleware.ts
@@ -15,6 +15,7 @@ const PUBLIC_PASSKEY_API_PATHS = new Set([
   "/api/admin/passkey/logout",
   "/api/admin/passkey/register-options",
   "/api/admin/passkey/register-verify",
+  "/api/admin/passkey/revoke-current",
   "/api/admin/passkey/status",
 ]);
 

--- a/apps/admin/src/pages/api/admin/passkey/revoke-current.ts
+++ b/apps/admin/src/pages/api/admin/passkey/revoke-current.ts
@@ -1,0 +1,13 @@
+import type { APIRoute } from "astro";
+import {
+  handlePasskeyError,
+  revokeCurrentCredential,
+} from "../../../../lib/passkey-auth";
+
+export const POST: APIRoute = async (context) => {
+  try {
+    return await revokeCurrentCredential(context);
+  } catch (error) {
+    return handlePasskeyError(error);
+  }
+};

--- a/apps/admin/src/pages/auth/passkey.astro
+++ b/apps/admin/src/pages/auth/passkey.astro
@@ -44,6 +44,9 @@ import AdminLayout from "../../layouts/AdminLayout.astro";
     <button class="button secondary" id="logout-passkey" type="button">
       logout
     </button>
+    <button class="button secondary danger" id="revoke-passkey" type="button">
+      revoke current passkey
+    </button>
   </div>
 
   <p class="notice" id="passkey-message">
@@ -100,12 +103,15 @@ import AdminLayout from "../../layouts/AdminLayout.astro";
     document.querySelector<HTMLButtonElement>("#login-passkey");
   const logoutButton =
     document.querySelector<HTMLButtonElement>("#logout-passkey");
+  const revokeButton =
+    document.querySelector<HTMLButtonElement>("#revoke-passkey");
 
   let status: PasskeyStatus | null = null;
 
   registerButton?.addEventListener("click", () => void register());
   loginButton?.addEventListener("click", () => void authenticate());
   logoutButton?.addEventListener("click", () => void logout());
+  revokeButton?.addEventListener("click", () => void revokeCurrent());
 
   await refreshStatus();
 
@@ -137,6 +143,7 @@ import AdminLayout from "../../layouts/AdminLayout.astro";
     if (registerButton) registerButton.disabled = !status.can_register;
     if (loginButton) loginButton.disabled = !status.available;
     if (logoutButton) logoutButton.disabled = !status.has_session;
+    if (revokeButton) revokeButton.disabled = !status.has_session;
   }
 
   async function register() {
@@ -177,6 +184,19 @@ import AdminLayout from "../../layouts/AdminLayout.astro";
     });
   }
 
+  async function revokeCurrent() {
+    const confirmed = window.confirm(
+      "Revoke the current passkey for denial proof? Cloudflare Access must remain active so a replacement passkey can be registered.",
+    );
+    if (!confirmed) return;
+
+    await withBusy("revoking current passkey", async () => {
+      const result = await postJson("/api/admin/passkey/revoke-current");
+      setText(message, result.next_safe_action ?? "current passkey revoked");
+      await refreshStatus();
+    });
+  }
+
   async function withBusy(label: string, action: () => Promise<void>) {
     setBusy(true);
     setText(message, label);
@@ -213,6 +233,7 @@ import AdminLayout from "../../layouts/AdminLayout.astro";
     if (registerButton) registerButton.disabled = busy || !status?.can_register;
     if (loginButton) loginButton.disabled = busy || !status?.available;
     if (logoutButton) logoutButton.disabled = busy || !status?.has_session;
+    if (revokeButton) revokeButton.disabled = busy || !status?.has_session;
   }
 
   function setText(node: Element | null, value: string) {

--- a/apps/admin/src/styles/admin.css
+++ b/apps/admin/src/styles/admin.css
@@ -225,6 +225,11 @@ th {
   color: var(--text);
 }
 
+.button.danger {
+  border-color: #8f4b3f;
+  color: #f2b8ad;
+}
+
 .inert-button {
   color: var(--muted);
 }

--- a/docs/platform-architecture.md
+++ b/docs/platform-architecture.md
@@ -95,11 +95,11 @@ Use `pnpm --silent proof:admin-passkey` before and after enrollment. It reads
 the remote `anipotts-db` passkey tables and probes protected admin routes
 without printing Cloudflare Access tokens. Before Access removal, the script
 must show one active credential, one active session, and audit rows for
-registration, session creation, session revocation, and revoked-credential
-denial. After Access removal, the same script must show app-native route
-blocking. The route probe set must include content inventory, review, preview,
-operations, newsletter queue, newsletter detail preview, needs-ani, proof,
-repos, handoffs, fleet, mutations, and destructive-ops routes.
+registration, session creation, session revocation, credential revocation, and
+revoked-credential denial. After Access removal, the same script must show
+app-native route blocking. The route probe set must include content inventory,
+review, preview, operations, newsletter queue, newsletter detail preview,
+needs-ani, proof, repos, handoffs, fleet, mutations, and destructive-ops routes.
 
 ## ci/cd target
 

--- a/scripts/admin/passkey-proof.mjs
+++ b/scripts/admin/passkey-proof.mjs
@@ -28,6 +28,7 @@ const REQUIRED_AUDIT_EVENTS = [
   "passkey.credential.registered",
   "passkey.session.created",
   "passkey.session.revoked",
+  "passkey.credential.revoked",
   "passkey.authentication.denied",
 ];
 
@@ -221,6 +222,9 @@ function nextSafeAction({
   }
   if (missingAuditEvents.includes("passkey.session.revoked")) {
     return "logout once to record session revocation, then authenticate again before Access removal";
+  }
+  if (missingAuditEvents.includes("passkey.credential.revoked")) {
+    return "revoke the current passkey while Cloudflare Access remains active, then register a replacement";
   }
   if (missingAuditEvents.includes("passkey.authentication.denied")) {
     return "record revoked-credential denial proof while Cloudflare Access remains active";


### PR DESCRIPTION
## summary
- add session-required passkey revoke-current API route
- add a passkey page control for revoking the current credential while Access is still active
- record credential revocation and session revocation audit rows
- record authentication denied when only revoked credentials remain
- make proof gates require credential revocation plus revoked-denial audit evidence

## verification
- git diff --check
- pnpm format:check
- pnpm turbo typecheck --filter=@anipotts/admin...
- pnpm turbo build --filter=@anipotts/admin...
- pnpm --silent proof:admin-passkey
- pnpm test:deploy-targets

## live impact
- admin auth proof flow only
- no Cloudflare Access removal
- no DNS/env/secret changes
- no credential is created or revoked by this PR itself
- expected deploy target: admin only