### PR TITLE
Show page content field breakdown in admin

### DIFF
--- a/apps/admin/src/pages/content/index.astro
+++ b/apps/admin/src/pages/content/index.astro
@@ -75,6 +75,10 @@ const pageContentState = await readPageContentInventoryStore(
                   <dd>{row.field_count}</dd>
                 </div>
                 <div>
+                  <dt>source-backed</dt>
+                  <dd>{row.source_backed_fields.length}</dd>
+                </div>
+                <div>
                   <dt>updated</dt>
                   <dd>{row.updated_at || "unknown"}</dd>
                 </div>
@@ -83,6 +87,28 @@ const pageContentState = await readPageContentInventoryStore(
                   <dd>no admin save or publish endpoint</dd>
                 </div>
               </dl>
+              <div class="field-grid" aria-label={`${row.page_key} d1 fields`}>
+                {row.fields.slice(0, 16).map((field) => (
+                  <div class="field-chip">
+                    <span>{field.path}</span>
+                    <strong>{field.value}</strong>
+                    <small>{field.kind}</small>
+                  </div>
+                ))}
+                {row.fields.length > 16 && (
+                  <div class="field-chip muted-chip">
+                    <span>more</span>
+                    <strong>{row.fields.length - 16} fields hidden</strong>
+                    <small>truncated</small>
+                  </div>
+                )}
+              </div>
+              {row.source_backed_fields.length > 0 && (
+                <div class="field-gap">
+                  <span>source-backed until schema exists</span>
+                  <p>{row.source_backed_fields.join(", ")}</p>
+                </div>
+              )}
             </article>
           ))
         )

--- a/apps/admin/src/styles/admin.css
+++ b/apps/admin/src/styles/admin.css
@@ -387,6 +387,58 @@ dd {
   font-size: 13px;
 }
 
+.field-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+  gap: 8px;
+  margin-top: 14px;
+}
+
+.field-chip {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+  border: 1px solid var(--border);
+  background: #141414;
+  padding: 10px;
+}
+
+.field-chip span,
+.field-gap span {
+  color: var(--muted);
+  font-size: 11px;
+  text-transform: uppercase;
+}
+
+.field-chip strong,
+.field-gap p {
+  min-width: 0;
+  margin: 0;
+  overflow-wrap: anywhere;
+  color: var(--text);
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.field-chip small {
+  color: var(--accent);
+  font-size: 11px;
+}
+
+.muted-chip strong,
+.muted-chip small {
+  color: var(--muted);
+}
+
+.field-gap {
+  display: grid;
+  gap: 6px;
+  margin-top: 10px;
+  border: 1px solid #4a3b28;
+  background: #181510;
+  padding: 10px;
+}
+
 .lane-grid {
   display: grid;
   grid-template-columns: minmax(260px, 0.9fr) minmax(0, 1.4fr);

--- a/packages/content/src/admin/content.ts
+++ b/packages/content/src/admin/content.ts
@@ -60,10 +60,18 @@ export type PageContentInventoryRow = {
   version: number;
   published: boolean;
   field_count: number;
+  fields: PageContentInventoryField[];
+  source_backed_fields: string[];
   summary: string;
   source_ref: string;
   updated_at: string;
   updated_by: string | null;
+};
+
+export type PageContentInventoryField = {
+  path: string;
+  value: string;
+  kind: string;
 };
 
 export type PageContentInventoryReadState =
@@ -347,12 +355,15 @@ function pageContentInventoryFromRow(
   row: PageContentD1Row,
 ): PageContentInventoryRow {
   const content = parseJsonObject(row.content);
+  const fields = listLeafFields(content);
   return {
     id: row.id,
     page_key: row.page_key,
     version: Number(row.version ?? 1),
     published: row.published === true || row.published === 1,
-    field_count: countLeafFields(content),
+    field_count: fields.length,
+    fields,
+    source_backed_fields: sourceBackedFields(row.page_key, content),
     summary: summarizePageContent(row.page_key, content),
     source_ref: `D1 page_content:${row.page_key}`,
     updated_at: row.updated_at ?? "",
@@ -371,17 +382,86 @@ function parseJsonObject(raw: string): Record<string, unknown> {
   }
 }
 
-function countLeafFields(value: unknown): number {
+function listLeafFields(
+  value: unknown,
+  path = "",
+): PageContentInventoryField[] {
   if (Array.isArray(value)) {
-    return value.reduce((sum, item) => sum + countLeafFields(item), 0);
-  }
-  if (value && typeof value === "object") {
-    return Object.values(value).reduce(
-      (sum, item) => sum + countLeafFields(item),
-      0,
+    return value.flatMap((item, index) =>
+      listLeafFields(item, `${path}[${index}]`),
     );
   }
-  return value === undefined || value === null ? 0 : 1;
+
+  if (value && typeof value === "object") {
+    return Object.entries(value as Record<string, unknown>).flatMap(
+      ([key, item]) => listLeafFields(item, path ? `${path}.${key}` : key),
+    );
+  }
+
+  if (value === undefined || value === null) {
+    return [];
+  }
+
+  return [
+    {
+      path: path || "value",
+      value: formatFieldValue(value),
+      kind: Array.isArray(value) ? "array" : typeof value,
+    },
+  ];
+}
+
+function formatFieldValue(value: unknown): string {
+  if (typeof value === "string") {
+    return value.length > 96 ? `${value.slice(0, 93)}...` : value;
+  }
+  if (typeof value === "boolean") {
+    return value ? "true" : "false";
+  }
+  if (typeof value === "number") {
+    return String(value);
+  }
+  return JSON.stringify(value) ?? String(value);
+}
+
+function sourceBackedFields(
+  pageKey: string,
+  content: Record<string, unknown>,
+): string[] {
+  if (pageKey !== "home") {
+    return [];
+  }
+
+  const gaps = [
+    "sections.past_work.project_slugs",
+    "sections.latest_thoughts.entries",
+  ];
+
+  if (!hasNestedField(content, ["sections", "intro", "subheading"])) {
+    gaps.unshift("sections.intro.subheading");
+  }
+
+  return gaps;
+}
+
+function hasNestedField(
+  value: Record<string, unknown>,
+  path: string[],
+): boolean {
+  let current: unknown = value;
+
+  for (const key of path) {
+    if (!current || typeof current !== "object" || Array.isArray(current)) {
+      return false;
+    }
+    const record = current as Record<string, unknown>;
+    if (!(key in record)) {
+      return false;
+    }
+    current = record[key];
+  }
+
+  return current !== undefined && current !== null;
 }
 
 function summarizePageContent(


### PR DESCRIPTION
## summary

- flatten live D1 `page_content` rows into path/value/kind fields for admin `/content`
- show source-backed homepage gaps that remain intentionally outside D1 until schema exists
- add compact field chips with contained wrapping for the read-only admin inventory

## deploy impact

- expected affected target: `admin`
- no www, workers, admin-solid, dns, auth, env, secret, d1 migration, save api, publish path, or outbound action

## verification

- `git diff --check`
- `pnpm format:check`
- `pnpm turbo typecheck --filter=@anipotts/admin...`
- `pnpm turbo build --filter=@anipotts/admin...`
- `pnpm test:deploy-targets`
- local adapter smoke for D1 field paths and source-backed homepage gaps
- local `/content` unauthenticated redirect to `/auth/passkey?next=%2Fcontent`