### PR TITLE
Show source content inventory in admin

### DIFF
--- a/apps/admin/src/data/source-content.ts
+++ b/apps/admin/src/data/source-content.ts
@@ -1,0 +1,221 @@
+type SourceSurface = "projects" | "writing";
+
+export type SourceContentField = {
+  path: string;
+  value: string;
+  kind: string;
+};
+
+export type SourceContentRecord = {
+  id: string;
+  surface: SourceSurface;
+  slug: string;
+  title: string;
+  route: string;
+  status: string;
+  source_ref: string;
+  summary: string;
+  body_words: number;
+  fields: SourceContentField[];
+  next_safe_action: string;
+};
+
+const projectModules = import.meta.glob<string>(
+  "../../../www/src/content/projects/*.md",
+  {
+    eager: true,
+    import: "default",
+    query: "?raw",
+  },
+);
+
+const writingModules = import.meta.glob<string>(
+  "../../../www/src/content/writing/*.md",
+  {
+    eager: true,
+    import: "default",
+    query: "?raw",
+  },
+);
+
+export const sourceContentRecords: SourceContentRecord[] = [
+  ...recordsFromModules("projects", projectModules),
+  ...recordsFromModules("writing", writingModules),
+];
+
+export const sourceContentSummary = {
+  projects: sourceContentRecords.filter(
+    (record) => record.surface === "projects",
+  ).length,
+  writing: sourceContentRecords.filter((record) => record.surface === "writing")
+    .length,
+  published_writing: sourceContentRecords.filter(
+    (record) => record.surface === "writing" && record.status === "published",
+  ).length,
+  visible_projects: sourceContentRecords.filter(
+    (record) => record.surface === "projects" && record.status !== "hidden",
+  ).length,
+};
+
+function recordsFromModules(
+  surface: SourceSurface,
+  modules: Record<string, string>,
+): SourceContentRecord[] {
+  return Object.entries(modules)
+    .map(([path, raw]) => recordFromRaw(surface, path, raw))
+    .sort(compareSourceRecords);
+}
+
+function recordFromRaw(
+  surface: SourceSurface,
+  path: string,
+  raw: string,
+): SourceContentRecord {
+  const file = fileSlug(path);
+  const source = splitMarkdown(raw);
+  const frontmatter = parseFrontmatter(source.frontmatter);
+  const slug = asString(frontmatter.slug) || file;
+  const title = asString(frontmatter.title) || slug;
+  const status = sourceStatus(surface, frontmatter);
+  const route =
+    surface === "projects" ? `/projects/${slug}` : `/writing/${slug}`;
+  const fields = Object.entries(frontmatter).map(([key, value]) => ({
+    path: key,
+    value: formatFieldValue(value),
+    kind: fieldKind(value),
+  }));
+
+  return {
+    id: `${surface}.${slug}`,
+    surface,
+    slug,
+    title,
+    route,
+    status,
+    source_ref: `apps/www/src/content/${surface}/${file}.md`,
+    summary:
+      asString(frontmatter.summary) ||
+      asString(frontmatter.subtitle) ||
+      asString(frontmatter.description) ||
+      "no summary field",
+    body_words: countWords(source.body),
+    fields,
+    next_safe_action:
+      surface === "projects"
+        ? "review project frontmatter and body before modeling a draft operation"
+        : "review title, summary, tags, and body before newsletter backfill",
+  };
+}
+
+function splitMarkdown(raw: string): { frontmatter: string; body: string } {
+  if (!raw.startsWith("---\n")) {
+    return { frontmatter: "", body: raw };
+  }
+
+  const end = raw.indexOf("\n---", 4);
+  if (end === -1) {
+    return { frontmatter: "", body: raw };
+  }
+
+  return {
+    frontmatter: raw.slice(4, end),
+    body: raw.slice(end + 4).trim(),
+  };
+}
+
+function parseFrontmatter(raw: string): Record<string, unknown> {
+  const fields: Record<string, unknown> = {};
+  const lines = raw.split("\n");
+  for (const line of lines) {
+    if (!line.trim() || line.startsWith(" ") || line.startsWith("-")) {
+      continue;
+    }
+
+    const match = line.match(/^([A-Za-z0-9_-]+):(?:\s*(.*))?$/);
+    if (!match) continue;
+
+    const [, key, rawValue = ""] = match;
+    fields[key] = parseScalar(rawValue);
+  }
+  return fields;
+}
+
+function parseScalar(raw: string): unknown {
+  const value = raw.trim();
+  if (!value) return "[structured list]";
+  if (value === "true") return true;
+  if (value === "false") return false;
+  if (/^-?\d+(?:\.\d+)?$/.test(value)) return Number(value);
+  if (value.startsWith("[") && value.endsWith("]")) {
+    return value
+      .slice(1, -1)
+      .split(",")
+      .map((part) => stripQuotes(part.trim()))
+      .filter(Boolean);
+  }
+  return stripQuotes(value);
+}
+
+function stripQuotes(value: string): string {
+  if (
+    (value.startsWith('"') && value.endsWith('"')) ||
+    (value.startsWith("'") && value.endsWith("'"))
+  ) {
+    return value.slice(1, -1);
+  }
+  return value;
+}
+
+function fileSlug(path: string): string {
+  return path.split("/").pop()?.replace(/\.md$/, "") ?? path;
+}
+
+function sourceStatus(
+  surface: SourceSurface,
+  frontmatter: Record<string, unknown>,
+): string {
+  if (surface === "writing") return asString(frontmatter.status) || "draft";
+  if (frontmatter.visible === false) return "hidden";
+  return asString(frontmatter.status) || "unknown";
+}
+
+function asString(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function countWords(body: string): number {
+  return body.trim().split(/\s+/).filter(Boolean).length;
+}
+
+function formatFieldValue(value: unknown): string {
+  if (Array.isArray(value)) return value.join(", ");
+  if (typeof value === "boolean") return value ? "true" : "false";
+  if (typeof value === "number") return String(value);
+  if (typeof value === "string") {
+    return value.length > 96 ? `${value.slice(0, 93)}...` : value;
+  }
+  return JSON.stringify(value) ?? String(value);
+}
+
+function fieldKind(value: unknown): string {
+  if (Array.isArray(value)) return "array";
+  return typeof value;
+}
+
+function compareSourceRecords(
+  a: SourceContentRecord,
+  b: SourceContentRecord,
+): number {
+  if (a.surface !== b.surface) return a.surface.localeCompare(b.surface);
+  if (a.surface === "projects") {
+    const aOrder = numericField(a, "sort_order");
+    const bOrder = numericField(b, "sort_order");
+    return bOrder - aOrder || a.title.localeCompare(b.title);
+  }
+  return b.source_ref.localeCompare(a.source_ref);
+}
+
+function numericField(record: SourceContentRecord, path: string): number {
+  const field = record.fields.find((item) => item.path === path);
+  return Number(field?.value ?? 0);
+}

--- a/apps/admin/src/pages/content/index.astro
+++ b/apps/admin/src/pages/content/index.astro
@@ -5,6 +5,10 @@ import {
   contentInventorySource,
   readPageContentInventoryStore,
 } from "../../data/content";
+import {
+  sourceContentRecords,
+  sourceContentSummary,
+} from "../../data/source-content";
 
 const surfaces = ["homepage", "projects", "writing", "newsletter"] as const;
 const pageContentState = await readPageContentInventoryStore(
@@ -23,6 +27,8 @@ const pageContentState = await readPageContentInventoryStore(
     <span>{pageContentState.mode}</span>
     <span>{contentInventorySource.mode}</span>
     <span>{contentInventorySource.source_doc}</span>
+    <span>{sourceContentSummary.visible_projects} visible projects</span>
+    <span>{sourceContentSummary.published_writing} published writing</span>
   </section>
 
   <section class="table-card">
@@ -112,6 +118,69 @@ const pageContentState = await readPageContentInventoryStore(
             </article>
           ))
         )
+      }
+    </div>
+  </section>
+
+  <section class="table-card operation-card">
+    <div class="section-head">
+      <div>
+        <p>source content collections</p>
+        <h2>
+          {sourceContentSummary.projects} projects / {
+            sourceContentSummary.writing
+          }
+          writing
+        </h2>
+      </div>
+      <span>bundled read only</span>
+    </div>
+    <div class="record-list">
+      {
+        sourceContentRecords.map((record) => (
+          <article class="record-row">
+            <div>
+              <p>
+                {record.surface} / {record.status} / {record.body_words} words
+              </p>
+              <h3>{record.title}</h3>
+            </div>
+            <dl>
+              <div>
+                <dt>route</dt>
+                <dd>{record.route}</dd>
+              </div>
+              <div>
+                <dt>source</dt>
+                <dd>{record.source_ref}</dd>
+              </div>
+              <div>
+                <dt>summary</dt>
+                <dd>{record.summary}</dd>
+              </div>
+              <div>
+                <dt>next</dt>
+                <dd>{record.next_safe_action}</dd>
+              </div>
+            </dl>
+            <div class="field-grid" aria-label={`${record.slug} source fields`}>
+              {record.fields.slice(0, 14).map((field) => (
+                <div class="field-chip">
+                  <span>{field.path}</span>
+                  <strong>{field.value}</strong>
+                  <small>{field.kind}</small>
+                </div>
+              ))}
+              {record.fields.length > 14 && (
+                <div class="field-chip muted-chip">
+                  <span>more</span>
+                  <strong>{record.fields.length - 14} fields hidden</strong>
+                  <small>truncated</small>
+                </div>
+              )}
+            </div>
+          </article>
+        ))
       }
     </div>
   </section>

--- a/docs/content-admin-editor-brief.md
+++ b/docs/content-admin-editor-brief.md
@@ -20,6 +20,10 @@ or any live write path.
 | newsletter block      | D1 `page_content:newsletter`, seeded by `drizzle/migrations/0009_seed_newsletter_page_content.sql`, fallback `@anipotts/lib/cms` defaults and `NewsletterSubscribe` props  | headline, deck, CTA label, success text, error text, footer, email form                                          | reader path exists; D1 seed matches current source defaults                                                               |
 | archived making notes | `docs/archive/labs/content/**`                                                                                                                                             | old weekly digests and experiments                                                                               | reference only, not an active public-site content source                                                                  |
 
+Admin `/content` now renders the D1 `page_content` rows and bundled read-only
+metadata from the project and writing markdown collections. It still does not
+add a save endpoint, publish endpoint, provider sync, or source file mutation.
+
 ## highest-leverage cleanup batch
 
 | priority | cleanup                                                 | why it matters                                                                           | owner fit                     |


### PR DESCRIPTION
## summary

- add a build-time read-only adapter for public project and writing markdown metadata
- render those source-backed records on admin `/content` beside D1 `page_content`
- update the content editor brief to document that `/content` now shows D1 rows plus bundled markdown collection metadata

## deploy impact

- expected affected target: `admin`
- no www, workers, admin-solid, dns, auth, env, secret, D1 migration, save api, publish path, source mutation, provider sync, or outbound action

## verification

- `git diff --check`
- `pnpm format:check`
- `pnpm turbo typecheck --filter=@anipotts/admin...`
- `pnpm turbo build --filter=@anipotts/admin...`
- `pnpm test:deploy-targets`
- build output contains the bundled source content rows
- local `/content` unauthenticated redirect to `/auth/passkey?next=%2Fcontent`