### PR TITLE
Cover all protected admin parity routes in smoke

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -212,7 +212,7 @@ jobs:
       - name: Smoke admin unauthenticated block
         run: |
           set -euo pipefail
-          for path in /auth/passkey / /content /content/review /content/preview /content/operations /newsletter /newsletter/first-thing-agents-need-control-plane /needs-ani /proof /repos /fleet; do
+          for path in /auth/passkey / /content /content/review /content/preview /content/operations /newsletter /newsletter/first-thing-agents-need-control-plane /needs-ani /proof /repos /handoffs /fleet /mutations /ops/destructive; do
             ok=false
             for _ in $(seq 1 6); do
               code="$(curl -sS -o /dev/null -w '%{http_code}' "https://admin.anipotts.com${path}")"

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -43,7 +43,7 @@ jobs:
         if: inputs.target == 'admin'
         run: |
           set -euo pipefail
-          for path in /auth/passkey / /content /content/review /content/preview /content/operations /newsletter /newsletter/first-thing-agents-need-control-plane /needs-ani /proof /repos /fleet; do
+          for path in /auth/passkey / /content /content/review /content/preview /content/operations /newsletter /newsletter/first-thing-agents-need-control-plane /needs-ani /proof /repos /handoffs /fleet /mutations /ops/destructive; do
             code="$(curl -sS -o /dev/null -w '%{http_code}' "https://admin.anipotts.com${path}")"
             echo "https://admin.anipotts.com${path} -> ${code}"
             case "$path:$code" in


### PR DESCRIPTION
## summary

- add `/handoffs`, `/mutations`, and `/ops/destructive` to deploy admin smoke coverage
- add the same routes to the manual `smoke.yml` admin target
- align smoke proof with the platform route parity matrix while keeping this workflow-only

## deploy impact

- expected affected targets: none
- workflow-only change; deploy target computation returned all false
- no app code, worker code, DNS, auth, env, secret, D1 migration, write path, or outbound action

## verification

- `git diff --check`
- `pnpm format:check`
- `pnpm test:deploy-targets`
- `node scripts/ci/compute-deploy-targets.mjs /tmp/workflow-only-files.txt` returned all deploy targets false
- live `/handoffs`, `/mutations`, and `/ops/destructive` returned 302 behind Cloudflare Access