### PR TITLE
Seed source content review operations

### DIFF
--- a/docs/content-admin-editor-brief.md
+++ b/docs/content-admin-editor-brief.md
@@ -23,6 +23,9 @@ or any live write path.
 Admin `/content` now renders the D1 `page_content` rows and bundled read-only
 metadata from the project and writing markdown collections. It still does not
 add a save endpoint, publish endpoint, provider sync, or source file mutation.
+The D1 review queue includes inert homepage, newsletter, project, and writing
+operations seeded by `drizzle/migrations/0008_seed_content_draft_operations.sql`
+and `drizzle/migrations/0011_seed_source_content_review_operations.sql`.
 
 ## highest-leverage cleanup batch
 

--- a/docs/platform-architecture.md
+++ b/docs/platform-architecture.md
@@ -146,5 +146,7 @@ Rules:
    newsletter page-content seed lives in
    `drizzle/migrations/0009_seed_newsletter_page_content.sql`, and safe
    homepage heading/section metadata seed lives in
-   `drizzle/migrations/0010_seed_home_page_content.sql`.
+   `drizzle/migrations/0010_seed_home_page_content.sql`. Source-backed project
+   and writing review operations live in
+   `drizzle/migrations/0011_seed_source_content_review_operations.sql`.
 10. reduce deploy workflow inputs to retained production targets.

--- a/drizzle/migrations/0011_seed_source_content_review_operations.sql
+++ b/drizzle/migrations/0011_seed_source_content_review_operations.sql
@@ -1,0 +1,121 @@
+-- 0011_seed_source_content_review_operations.sql
+-- Seed inert admin review operations for source-backed project and writing content.
+--
+-- These rows make the project and writing lanes visible in the D1-backed
+-- content review queue. They do not insert published content records, edit
+-- markdown, add save APIs, publish, send, deploy, or mutate external services.
+--
+-- Rollback:
+--   DELETE FROM content_draft_operations
+--   WHERE operation_id IN (
+--     'content-draft-project-card-fields-2026-06-28',
+--     'content-draft-writing-newsletter-backfill-2026-06-28'
+--   );
+
+INSERT OR IGNORE INTO content_draft_operations (
+  operation_id,
+  kind,
+  surface,
+  route,
+  source_ref,
+  field_path,
+  current_value_ref,
+  proposed_value,
+  status,
+  risk_level,
+  authority_state,
+  required_approval_ids,
+  allowed_actions,
+  forbidden_actions,
+  preview_targets,
+  proof_ids,
+  evidence_uri,
+  redaction,
+  created_by,
+  created_at,
+  updated_at,
+  expires_at,
+  rollback_ref,
+  reviewer_note,
+  metadata
+) VALUES (
+  'content-draft-project-card-fields-2026-06-28',
+  'content_draft',
+  'public_site',
+  '/making',
+  'apps/www/src/content/projects/*.md frontmatter',
+  'projects.card_fields',
+  'source_markdown_frontmatter',
+  'Expose project title, subtitle, description, year, category, role, status, links, tags, technical notes, and roadmap in admin before modeling any write route.',
+  'previewed',
+  'low',
+  'source_inventory_preview_only',
+  '[]',
+  '["render_preview","request_review"]',
+  '["save","publish","deploy","rewrite_markdown","sync_external"]',
+  '["/content","/content/review","/content/preview","/making"]',
+  '["content.projects.frontmatter.schema","admin.content.source-inventory"]',
+  'repo://apps/www/src/content/projects',
+  'public_copy_only',
+  'agent',
+  '2026-06-28T00:00:00Z',
+  '2026-06-28T00:00:00Z',
+  '2026-07-28T00:00:00Z',
+  'source_markdown_frontmatter',
+  'Seeded as an inert review operation. No source files or public routes are changed.',
+  '{"source":"drizzle/migrations/0011_seed_source_content_review_operations.sql","write_path":"inactive"}'
+);
+
+INSERT OR IGNORE INTO content_draft_operations (
+  operation_id,
+  kind,
+  surface,
+  route,
+  source_ref,
+  field_path,
+  current_value_ref,
+  proposed_value,
+  status,
+  risk_level,
+  authority_state,
+  required_approval_ids,
+  allowed_actions,
+  forbidden_actions,
+  preview_targets,
+  proof_ids,
+  evidence_uri,
+  redaction,
+  created_by,
+  created_at,
+  updated_at,
+  expires_at,
+  rollback_ref,
+  reviewer_note,
+  metadata
+) VALUES (
+  'content-draft-writing-newsletter-backfill-2026-06-28',
+  'content_draft',
+  'newsletter',
+  '/writing',
+  'apps/www/src/content/writing/*.md frontmatter and body',
+  'writing.newsletter_backfill',
+  'source_markdown_collection',
+  'Review published writing titles, summaries, tags, dates, and body length as newsletter backfill candidates without sending or scheduling an issue.',
+  'previewed',
+  'medium',
+  'backfill_review_only_no_send',
+  '[]',
+  '["render_preview","request_review"]',
+  '["save","publish","send","schedule","sync_provider"]',
+  '["/content","/content/review","/content/preview","/writing","/newsletter"]',
+  '["content.writing.frontmatter.schema","content.newsletter.backfill.plan","admin.content.source-inventory"]',
+  'repo://apps/www/src/content/writing',
+  'public_copy_only',
+  'agent',
+  '2026-06-28T00:00:00Z',
+  '2026-06-28T00:00:00Z',
+  '2026-07-28T00:00:00Z',
+  'source_markdown_collection',
+  'Seeded as an inert review operation. No newsletter provider action, send, schedule, or source mutation is created.',
+  '{"source":"drizzle/migrations/0011_seed_source_content_review_operations.sql","write_path":"inactive"}'
+);


### PR DESCRIPTION
## summary

- add inert D1 draft operations for project card fields and writing newsletter backfill
- document that the D1 content review queue covers homepage, newsletter, project, and writing lanes
- keep the migration read-only from the app perspective: no content records, publish events, save APIs, source edits, sends, provider sync, or deploy triggers

## deploy impact

- expected affected targets: none
- migration/docs only; deploy target computation returned all false
- after merge, apply reviewed migration `drizzle/migrations/0011_seed_source_content_review_operations.sql` to `anipotts-db`

## rollback

```sql
DELETE FROM content_draft_operations
WHERE operation_id IN (
  'content-draft-project-card-fields-2026-06-28',
  'content-draft-writing-newsletter-backfill-2026-06-28'
);
```

## verification

- `git diff --check`
- `pnpm format:check`
- `pnpm test:deploy-targets`
- sqlite migration smoke returned the two expected operations
- deploy target computation for migration/docs returned all false