### PR TITLE
fix(admin): verify Access JWT for passkey bootstrap

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -16,7 +16,8 @@
     "@astrojs/cloudflare": "^12.6.0",
     "@simplewebauthn/browser": "13.3.0",
     "@simplewebauthn/server": "13.3.2",
-    "astro": "^5.16.0"
+    "astro": "^5.16.0",
+    "jose": "^6.1.3"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.4",

--- a/apps/admin/src/env.d.ts
+++ b/apps/admin/src/env.d.ts
@@ -14,6 +14,8 @@ type D1Database = {
 type Runtime = import("@astrojs/cloudflare").Runtime<{
   DB: D1Database;
   PUBLIC_STATE_API: string;
+  ACCESS_TEAM_DOMAIN: string;
+  ACCESS_POLICY_AUD: string;
 }>;
 
 declare namespace App {

--- a/apps/admin/src/lib/passkey-auth.ts
+++ b/apps/admin/src/lib/passkey-auth.ts
@@ -4,6 +4,7 @@ import {
   verifyAuthenticationResponse,
   verifyRegistrationResponse,
 } from "@simplewebauthn/server";
+import { createRemoteJWKSet, jwtVerify } from "jose";
 import type {
   AuthenticationResponseJSON,
   AuthenticatorTransportFuture,
@@ -23,6 +24,7 @@ const LOCAL_ORIGIN = "http://localhost:3001";
 const USER_ID = "ani";
 const USER_NAME = "ani@admin.anipotts.com";
 const USER_DISPLAY_NAME = "Ani";
+const ACCESS_JWT_HEADER = "cf-access-jwt-assertion";
 
 type D1Result<T = unknown> = {
   results?: T[];
@@ -76,6 +78,11 @@ type SessionRow = {
   revoked_at: string | null;
 };
 
+type AccessIdentity = {
+  verified: boolean;
+  hint: string | null;
+};
+
 export type PasskeyContext = {
   request: Request;
   url: URL;
@@ -125,7 +132,7 @@ export async function getPasskeyStatus(
   context: PasskeyContext,
 ): Promise<PasskeyStatus> {
   const db = dbFromContext(context);
-  const accessIdentity = accessIdentityHint(context);
+  const accessIdentity = await resolveAccessIdentity(context);
   if (!db) {
     return {
       available: false,
@@ -134,8 +141,8 @@ export async function getPasskeyStatus(
       audit_count: 0,
       has_session: false,
       can_register: false,
-      access_identity_present: Boolean(accessIdentity),
-      access_identity_hint: accessIdentity,
+      access_identity_present: accessIdentity.verified,
+      access_identity_hint: accessIdentity.hint,
       expected_origin: EXPECTED_ORIGIN,
       expected_rp_id: expectedRpId(context),
       current_origin: context.url.origin,
@@ -160,8 +167,8 @@ export async function getPasskeyStatus(
       audit_count: 0,
       has_session: false,
       can_register: false,
-      access_identity_present: Boolean(accessIdentity),
-      access_identity_hint: accessIdentity,
+      access_identity_present: accessIdentity.verified,
+      access_identity_hint: accessIdentity.hint,
       expected_origin: EXPECTED_ORIGIN,
       expected_rp_id: expectedRpId(context),
       current_origin: context.url.origin,
@@ -170,7 +177,7 @@ export async function getPasskeyStatus(
     };
   }
   const canRegister =
-    Boolean(session) || (credentialCount === 0 && Boolean(accessIdentity));
+    Boolean(session) || (credentialCount === 0 && accessIdentity.verified);
 
   return {
     available: true,
@@ -179,14 +186,16 @@ export async function getPasskeyStatus(
     audit_count: auditCount,
     has_session: Boolean(session),
     can_register: canRegister,
-    access_identity_present: Boolean(accessIdentity),
-    access_identity_hint: accessIdentity,
+    access_identity_present: accessIdentity.verified,
+    access_identity_hint: accessIdentity.hint,
     expected_origin: EXPECTED_ORIGIN,
     expected_rp_id: expectedRpId(context),
     current_origin: context.url.origin,
-    next_safe_action: session
-      ? "passkey session active"
-      : "register the first passkey while Cloudflare Access identity is present",
+    next_safe_action: passkeyStatusNextAction(
+      Boolean(session),
+      credentialCount,
+      accessIdentity,
+    ),
   };
 }
 
@@ -687,11 +696,57 @@ function expectedRpId(context: PasskeyContext): string {
   return PRODUCTION_RP_ID;
 }
 
-function accessIdentityHint(context: PasskeyContext): string | null {
-  const email = context.request.headers.get(
-    "cf-access-authenticated-user-email",
-  );
-  if (!email) return import.meta.env.DEV ? "local-dev" : null;
+async function resolveAccessIdentity(
+  context: PasskeyContext,
+): Promise<AccessIdentity> {
+  if (context.url.origin === LOCAL_ORIGIN && import.meta.env.DEV) {
+    return { verified: true, hint: "local-dev" };
+  }
+
+  const teamDomain = context.locals.runtime?.env.ACCESS_TEAM_DOMAIN;
+  const audience = context.locals.runtime?.env.ACCESS_POLICY_AUD;
+  if (!teamDomain || !audience) {
+    return { verified: false, hint: null };
+  }
+
+  const token = context.request.headers.get(ACCESS_JWT_HEADER);
+  if (!token) {
+    return { verified: false, hint: null };
+  }
+
+  try {
+    const issuer = teamDomain.replace(/\/$/, "");
+    const jwks = createRemoteJWKSet(new URL(`${issuer}/cdn-cgi/access/certs`));
+    const { payload } = await jwtVerify(token, jwks, {
+      issuer,
+      audience,
+    });
+    const email = typeof payload.email === "string" ? payload.email : null;
+    if (!email) {
+      return { verified: false, hint: null };
+    }
+    return { verified: true, hint: maskEmail(email) };
+  } catch {
+    return { verified: false, hint: null };
+  }
+}
+
+function passkeyStatusNextAction(
+  hasSession: boolean,
+  credentialCount: number,
+  accessIdentity: AccessIdentity,
+): string {
+  if (hasSession) return "passkey session active";
+  if (credentialCount === 0 && accessIdentity.verified) {
+    return "register the first passkey with verified Cloudflare Access identity";
+  }
+  if (credentialCount === 0) {
+    return "authenticate through Cloudflare Access before first passkey registration";
+  }
+  return "authenticate with the registered passkey";
+}
+
+function maskEmail(email: string): string {
   const [name, domain] = email.split("@");
   if (!name || !domain) return "access-user";
   return `${name.slice(0, 2)}***@${domain}`;

--- a/apps/admin/wrangler.toml
+++ b/apps/admin/wrangler.toml
@@ -20,6 +20,8 @@ run_worker_first = true
 # Non-secret env vars available at runtime
 [vars]
 PUBLIC_STATE_API = "https://api.anipotts.com"
+ACCESS_TEAM_DOMAIN = "https://anipotts.cloudflareaccess.com"
+ACCESS_POLICY_AUD = "ca3ea64cba714dee7d50eae63f62b18d6c2aeeecc0fc16ec0335ed0aa863a49f"
 
 # D1 database binding
 [[d1_databases]]

--- a/docs/platform-architecture.md
+++ b/docs/platform-architecture.md
@@ -101,6 +101,14 @@ app-native route blocking. The route probe set must include content inventory,
 review, preview, operations, newsletter queue, newsletter detail preview,
 needs-ani, proof, repos, handoffs, fleet, mutations, and destructive-ops routes.
 
+First-passkey bootstrap in production requires a verified Cloudflare Access
+application JWT from `Cf-Access-Jwt-Assertion`. The admin Worker validates it
+against `ACCESS_TEAM_DOMAIN` and `ACCESS_POLICY_AUD`, both non-secret
+configuration values in `apps/admin/wrangler.toml`, before allowing the first
+credential registration. After an active passkey session exists, additional
+credential operations use the app-native passkey session rather than Access
+identity headers.
+
 Use `pnpm --silent proof:admin-content` after content migrations. It reads only
 remote D1 metadata and route status, then proves published `home` and
 `newsletter` page content, the four inert draft operations, empty content write

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       astro:
         specifier: ^5.16.0
         version: 5.18.2(@types/node@22.19.19)(aws4fetch@1.0.20)(db0@0.3.4(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260518.1)(@opentelemetry/api@1.9.0)))(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.59.0)(terser@5.47.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0)
+      jose:
+        specifier: ^6.1.3
+        version: 6.2.3
     devDependencies:
       '@astrojs/check':
         specifier: ^0.9.4
@@ -4136,6 +4139,9 @@ packages:
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
+
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
@@ -9766,6 +9772,8 @@ snapshots:
   jiti@1.21.7: {}
 
   jiti@2.7.0: {}
+
+  jose@6.2.3: {}
 
   joycon@3.1.1: {}
 


### PR DESCRIPTION
## summary
- require a verified Cloudflare Access application JWT before first-passkey registration in production
- add non-secret Access team/audience config to the admin Worker
- document the bootstrap hardening in the platform architecture

## verification
- `pnpm turbo typecheck --filter=@anipotts/admin...`
- `pnpm turbo build --filter=@anipotts/admin...`
- `git diff --check`
- `pnpm format:check`
- `pnpm test:deploy-targets`
- deploy target computation returned `admin=true` only
- `pnpm --silent proof:admin-passkey` still reports Access active and no enrolled credential, expected before biometric registration

## live impact
admin target only after merge/deploy. no D1 migration and no Access removal.