### PR TITLE
test(ci): cover admin worker config deploy target

### DIFF
--- a/scripts/ci/compute-deploy-targets.test.mjs
+++ b/scripts/ci/compute-deploy-targets.test.mjs
@@ -51,6 +51,12 @@ expectTargets(
 );
 
 expectTargets(
+  "admin worker config deploys admin",
+  ["apps/admin/wrangler.toml"],
+  { admin: true },
+);
+
+expectTargets(
   "admin-solid source deploys only admin-solid",
   ["apps/admin-solid/src/routes/index.tsx"],
   {


### PR DESCRIPTION
## summary
- add deploy-target regression coverage for `apps/admin/wrangler.toml`
- prove future admin Worker config changes map to `admin=true`

## verification
- `pnpm test:deploy-targets`
- `git diff --check`
- `pnpm format:check`
- deploy target computation for this test-only diff returned all false

## live impact
none expected. CI test-only change; no deploy target.