### PR TITLE
feat(admin): read proof baseline from D1

### DIFF
--- a/apps/admin/src/data/proof.ts
+++ b/apps/admin/src/data/proof.ts
@@ -15,6 +15,7 @@ export type ProofEntry = {
 type D1PreparedStatement = {
   bind(...values: unknown[]): D1PreparedStatement;
   first<T = unknown>(): Promise<T | null>;
+  all<T = unknown>(): Promise<{ results?: T[] }>;
 };
 
 export type ProofD1Database = {
@@ -22,9 +23,9 @@ export type ProofD1Database = {
 };
 
 export const proofSource = {
-  mode: "read_only_static_plus_d1_metadata",
+  mode: "read_only_d1_plus_runtime_metadata",
   generated_from:
-    "GitHub runs, route probes, PR state, and read-only D1 metadata",
+    "admin_proof_events, route probes, PR state, and read-only D1 metadata",
   live_writes: "disabled",
 };
 
@@ -88,11 +89,25 @@ const requiredPasskeyAuditEvents = [
   "passkey.authentication.denied",
 ] as const;
 
+type ProofEventRow = {
+  id: string;
+  kind: string;
+  status: string;
+  title: string;
+  summary: string;
+  evidence_uri: string;
+  redaction: string;
+  next_safe_action: string;
+};
+
 export async function readProofEntries(
   db: ProofD1Database | null | undefined,
 ): Promise<ProofEntry[]> {
+  const durableProofEntries = await readDurableProofEntries(db);
   return [
-    ...baseProofEntries,
+    ...(durableProofEntries.length > 0
+      ? durableProofEntries
+      : baseProofEntries),
     await readContentOperationProof(db),
     await readPasskeyProof(db),
   ];
@@ -161,6 +176,34 @@ async function readContentOperationProof(
       next_safe_action:
         "Fix D1 schema or binding before relying on content operation proof.",
     };
+  }
+}
+
+async function readDurableProofEntries(
+  db: ProofD1Database | null | undefined,
+): Promise<ProofEntry[]> {
+  if (!db) return [];
+
+  try {
+    const result = await db
+      .prepare(
+        `SELECT
+           id,
+           kind,
+           status,
+           title,
+           summary,
+           evidence_uri,
+           redaction,
+           next_safe_action
+         FROM admin_proof_events
+         ORDER BY updated_at DESC, id ASC
+         LIMIT 50`,
+      )
+      .all<ProofEventRow>();
+    return (result.results ?? []).map(proofEntryFromRow);
+  } catch {
+    return [];
   }
 }
 
@@ -249,6 +292,19 @@ async function countRows(
   return Number(row?.count ?? 0);
 }
 
+function proofEntryFromRow(row: ProofEventRow): ProofEntry {
+  return {
+    id: row.id,
+    kind: parseProofKind(row.kind),
+    status: parseProofStatus(row.status),
+    title: row.title,
+    summary: row.summary,
+    evidence_uri: row.evidence_uri,
+    redaction: parseRedaction(row.redaction),
+    next_safe_action: row.next_safe_action,
+  };
+}
+
 function nextPasskeyProofAction(
   credentials: number,
   sessions: number,
@@ -270,4 +326,35 @@ function nextPasskeyProofAction(
     return "Record revoked-credential denial proof while Cloudflare Access remains active.";
   }
   return `Record missing audit proof: ${missingAuditEvents.join(", ")}.`;
+}
+
+function parseProofKind(kind: string): ProofKind {
+  if (
+    kind === "deploy" ||
+    kind === "route" ||
+    kind === "auth" ||
+    kind === "repo" ||
+    kind === "gate"
+  ) {
+    return kind;
+  }
+  return "gate";
+}
+
+function parseProofStatus(status: string): ProofStatus {
+  if (status === "verified" || status === "blocked" || status === "pending") {
+    return status;
+  }
+  return "pending";
+}
+
+function parseRedaction(value: string): ProofEntry["redaction"] {
+  if (
+    value === "public_metadata" ||
+    value === "metadata_only" ||
+    value === "protected_route"
+  ) {
+    return value;
+  }
+  return "metadata_only";
 }

--- a/docs/platform-architecture.md
+++ b/docs/platform-architecture.md
@@ -114,6 +114,12 @@ remote D1 metadata and route status, then proves published `home` and
 `newsletter` page content, the four inert draft operations, empty content write
 tables, public route health, and protected admin route boundaries.
 
+The admin proof log reads durable rows from D1 table `admin_proof_events` when
+available, then appends live D1 metadata for content operations and passkey
+proof. The table is seeded by
+`drizzle/migrations/0012_admin_proof_events.sql`. There is still no admin proof
+write API.
+
 ## ci/cd target
 
 Primary workflows:
@@ -162,4 +168,6 @@ Rules:
    `drizzle/migrations/0010_seed_home_page_content.sql`. Source-backed project
    and writing review operations live in
    `drizzle/migrations/0011_seed_source_content_review_operations.sql`.
-10. reduce deploy workflow inputs to retained production targets.
+10. move admin proof baseline rows into D1 `admin_proof_events`; seeded by
+    `drizzle/migrations/0012_admin_proof_events.sql`.
+11. reduce deploy workflow inputs to retained production targets.

--- a/drizzle/migrations/0012_admin_proof_events.sql
+++ b/drizzle/migrations/0012_admin_proof_events.sql
@@ -1,0 +1,149 @@
+-- 0012_admin_proof_events.sql
+-- Add durable read-only admin proof rows.
+--
+-- This moves the static proof log baseline into D1 so admin proof can become
+-- part of the structured admin state model. It does not add write APIs,
+-- deploy triggers, auth changes, Cloudflare Access changes, or publish paths.
+--
+-- Rollback:
+--   DELETE FROM admin_proof_events
+--   WHERE id IN (
+--     'proof.admin.agent-deploy-scope',
+--     'proof.site.public-routes',
+--     'proof.admin.unauth-block',
+--     'proof.admin.write-paths'
+--   );
+--   DROP TABLE IF EXISTS admin_proof_events;
+
+CREATE TABLE IF NOT EXISTS admin_proof_events (
+  id TEXT PRIMARY KEY,
+  kind TEXT NOT NULL,
+  status TEXT NOT NULL,
+  title TEXT NOT NULL,
+  summary TEXT NOT NULL,
+  evidence_uri TEXT NOT NULL,
+  redaction TEXT NOT NULL,
+  next_safe_action TEXT NOT NULL,
+  source_ref TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  metadata TEXT NOT NULL DEFAULT '{}'
+);
+
+CREATE INDEX IF NOT EXISTS idx_admin_proof_events_status
+  ON admin_proof_events (status, updated_at);
+
+CREATE INDEX IF NOT EXISTS idx_admin_proof_events_kind
+  ON admin_proof_events (kind, updated_at);
+
+INSERT OR IGNORE INTO admin_proof_events (
+  id,
+  kind,
+  status,
+  title,
+  summary,
+  evidence_uri,
+  redaction,
+  next_safe_action,
+  source_ref,
+  created_at,
+  updated_at,
+  metadata
+) VALUES (
+  'proof.admin.agent-deploy-scope',
+  'deploy',
+  'verified',
+  'agent admin deploys stay scoped',
+  'Recent admin content platform PRs deployed the Astro admin target only. Www, admin-solid, ingest, newsletter, weekly-email, and state workers were skipped.',
+  'https://github.com/anipotts/anipotts.com/actions/workflows/deploy.yml',
+  'public_metadata',
+  'Keep deploy proof attached to admin route-level changes until proof rows move into D1.',
+  'apps/admin/src/data/proof.ts',
+  '2026-06-28T00:00:00Z',
+  '2026-06-28T00:00:00Z',
+  '{"seed":"drizzle/migrations/0012_admin_proof_events.sql","write_path":"inactive"}'
+);
+
+INSERT OR IGNORE INTO admin_proof_events (
+  id,
+  kind,
+  status,
+  title,
+  summary,
+  evidence_uri,
+  redaction,
+  next_safe_action,
+  source_ref,
+  created_at,
+  updated_at,
+  metadata
+) VALUES (
+  'proof.site.public-routes',
+  'route',
+  'verified',
+  'public content routes answer',
+  'Live public route probes have returned 200 for the current Astro site routes, while admin remains separately protected.',
+  'https://anipotts.com',
+  'public_metadata',
+  'Keep public smoke coverage on the stable route set before expanding content from D1.',
+  'apps/admin/src/data/proof.ts',
+  '2026-06-28T00:00:00Z',
+  '2026-06-28T00:00:00Z',
+  '{"seed":"drizzle/migrations/0012_admin_proof_events.sql","write_path":"inactive"}'
+);
+
+INSERT OR IGNORE INTO admin_proof_events (
+  id,
+  kind,
+  status,
+  title,
+  summary,
+  evidence_uri,
+  redaction,
+  next_safe_action,
+  source_ref,
+  created_at,
+  updated_at,
+  metadata
+) VALUES (
+  'proof.admin.unauth-block',
+  'auth',
+  'verified',
+  'admin unauthenticated block holds',
+  'Unauthenticated admin probes return 302 to Cloudflare Access while app-native passkey proof is incomplete.',
+  'https://admin.anipotts.com/auth/passkey',
+  'protected_route',
+  'After passkey enrollment, prove app-native login and then remove Cloudflare Access.',
+  'apps/admin/src/data/proof.ts',
+  '2026-06-28T00:00:00Z',
+  '2026-06-28T00:00:00Z',
+  '{"seed":"drizzle/migrations/0012_admin_proof_events.sql","write_path":"inactive"}'
+);
+
+INSERT OR IGNORE INTO admin_proof_events (
+  id,
+  kind,
+  status,
+  title,
+  summary,
+  evidence_uri,
+  redaction,
+  next_safe_action,
+  source_ref,
+  created_at,
+  updated_at,
+  metadata
+) VALUES (
+  'proof.admin.write-paths',
+  'gate',
+  'pending',
+  'admin write paths remain inert',
+  'Content preview, review, operations, mutation, and destructive-operation routes expose no save, publish, send, or live-control endpoint.',
+  'apps/admin/src/pages',
+  'metadata_only',
+  'Before adding writes, require audited D1 operation records, rollback, and route proof.',
+  'apps/admin/src/data/proof.ts',
+  '2026-06-28T00:00:00Z',
+  '2026-06-28T00:00:00Z',
+  '{"seed":"drizzle/migrations/0012_admin_proof_events.sql","write_path":"inactive"}'
+);


### PR DESCRIPTION
## summary
- add additive `admin_proof_events` D1 table and seed the current proof baseline
- update the Astro admin proof reader to prefer D1 proof rows
- keep safe fallback to static proof rows until the migration is applied

## verification
- `sqlite3` applied `drizzle/migrations/0012_admin_proof_events.sql` and returned 4 rows
- `pnpm turbo typecheck --filter=@anipotts/admin...`
- `pnpm turbo build --filter=@anipotts/admin...`
- `git diff --check`
- `pnpm format:check`
- `pnpm test:deploy-targets`
- deploy target computation returned `admin=true` only

## migration
After merge, apply reviewed migration:

```bash
pnpm exec wrangler d1 execute anipotts-db --remote --file=drizzle/migrations/0012_admin_proof_events.sql --yes
```

## live impact
Admin target only. No write API, no publish path, no auth or Cloudflare Access change.