### PR TITLE
chore(admin): clarify passkey proof gate

### DIFF
--- a/docs/admin-v2-architecture.md
+++ b/docs/admin-v2-architecture.md
@@ -197,6 +197,9 @@ Auth boundary note:
 - The current unblocker is first passkey enrollment, then proof for register,
   login, logout, session persistence, revoked credential denial, and
   unauthenticated app-native blocking after Access removal.
+- `pnpm --silent proof:admin-passkey` reports pre-removal blockers in
+  `access_removal_blockers`; `cloudflare_access_still_active: true` is expected
+  until the final Access removal step.
 - Historical auth and Access planning packets live under `docs/archive/`.
 - See `docs/admin-content-draft-operations.md` for the inert content draft
   operation schema that should precede any save or publish path.

--- a/docs/platform-architecture.md
+++ b/docs/platform-architecture.md
@@ -96,10 +96,13 @@ the remote `anipotts-db` passkey tables and probes protected admin routes
 without printing Cloudflare Access tokens. Before Access removal, the script
 must show one active credential, one active session, and audit rows for
 registration, session creation, session revocation, credential revocation, and
-revoked-credential denial. After Access removal, the same script must show
-app-native route blocking. The route probe set must include content inventory,
-review, preview, operations, newsletter queue, newsletter detail preview,
-needs-ani, proof, repos, handoffs, fleet, mutations, and destructive-ops routes.
+revoked-credential denial. It reports missing pre-removal evidence in
+`access_removal_blockers`; `cloudflare_access_still_active: true` is expected
+until the edge gate is removed, not a blocker by itself. After Access removal,
+the same script must show app-native route blocking. The route probe set must
+include content inventory, review, preview, operations, newsletter queue,
+newsletter detail preview, needs-ani, proof, repos, handoffs, fleet, mutations,
+and destructive-ops routes.
 
 First-passkey bootstrap in production requires a verified Cloudflare Access
 application JWT from `Cf-Access-Jwt-Assertion`. The admin Worker validates it

--- a/scripts/admin/passkey-proof.mjs
+++ b/scripts/admin/passkey-proof.mjs
@@ -83,11 +83,16 @@ const routeBoundary = summarizeBoundary(routes);
 const missingAuditEvents = REQUIRED_AUDIT_EVENTS.filter(
   (eventType) => !auditEvents[eventType],
 );
-const missingProof = missingProofItems({
+const accessRemovalBlockers = accessRemovalBlockerItems({
   schemaReady,
   credentialCount,
   sessionCount,
   missingAuditEvents,
+});
+const cloudflareAccessStillActive = routeBoundary === "cloudflare_access";
+const appNativeRouteBoundaryReady = routeBoundary === "app_native_passkey";
+const missingProof = missingProofItems({
+  accessRemovalBlockers,
   routeBoundary,
 });
 
@@ -109,11 +114,13 @@ const proof = {
       Number(auditEvents[eventType] ?? 0),
     ]),
   ),
+  access_removal_blockers: accessRemovalBlockers,
+  cloudflare_access_still_active: cloudflareAccessStillActive,
   missing_proof: missingProof,
   ready_for_access_removal:
-    missingProof.length === 1 &&
-    missingProof[0] === "cloudflare_access_still_active",
-  post_access_removal_verified: missingProof.length === 0,
+    accessRemovalBlockers.length === 0 && cloudflareAccessStillActive,
+  post_access_removal_verified:
+    accessRemovalBlockers.length === 0 && appNativeRouteBoundaryReady,
   routes,
   route_boundary: routeBoundary,
   next_safe_action: nextSafeAction({
@@ -242,21 +249,27 @@ function nextSafeAction({
 }
 
 function missingProofItems({
+  accessRemovalBlockers,
+  routeBoundary,
+}) {
+  const missing = [...accessRemovalBlockers];
+  if (routeBoundary === "cloudflare_access") return missing;
+  if (routeBoundary !== "app_native_passkey") {
+    missing.push("app_native_route_boundary");
+  }
+  return missing;
+}
+
+function accessRemovalBlockerItems({
   schemaReady,
   credentialCount,
   sessionCount,
   missingAuditEvents,
-  routeBoundary,
 }) {
   const missing = [];
   if (!schemaReady) missing.push("schema_ready");
   if (credentialCount === 0) missing.push("active_credential");
   if (sessionCount === 0) missing.push("active_session");
   missing.push(...missingAuditEvents);
-  if (routeBoundary === "cloudflare_access") {
-    missing.push("cloudflare_access_still_active");
-  } else if (routeBoundary !== "app_native_passkey") {
-    missing.push("app_native_route_boundary");
-  }
   return missing;
 }


### PR DESCRIPTION
## summary\n- separate pre-removal passkey blockers from the expected Cloudflare Access boundary\n- keep Access active as a boolean proof field instead of treating it like missing evidence\n- update the current admin architecture docs with the clarified proof semantics\n\n## verification\n- pnpm --silent proof:admin-passkey\n- node --check scripts/admin/passkey-proof.mjs\n- pnpm format:check\n- pnpm test:deploy-targets\n- git diff --check\n\n## deploy\n- computed deploy targets: all false\n- no live auth, DNS, env, secret, D1, worker, or route mutation\n