### PR TITLE
ci: add static security review workflow

### DIFF
--- a/.github/workflows/agent-automerge.yml
+++ b/.github/workflows/agent-automerge.yml
@@ -62,6 +62,40 @@ jobs:
 
           node scripts/ci/compute-deploy-targets.mjs "$files" | tee "$targets"
           cat "$targets" >> "$GITHUB_OUTPUT"
+          node scripts/ci/security-review.mjs --required "$files" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for security review
+        if: steps.targets.outputs.security_review == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          for _ in $(seq 1 40); do
+            bucket="$(
+              gh pr checks "$PR_URL" \
+                --json name,bucket \
+                --jq '.[] | select(.name == "Security Review") | .bucket' \
+                2>/dev/null | head -n 1
+            )"
+            case "$bucket" in
+              pass)
+                exit 0
+                ;;
+              fail|cancel)
+                echo "Security Review did not pass"
+                exit 1
+                ;;
+              "")
+                echo "waiting for Security Review to register"
+                ;;
+              *)
+                echo "Security Review is ${bucket}"
+                ;;
+            esac
+            sleep 15
+          done
+          echo "Security Review did not finish in time"
+          exit 1
 
       - name: Merge PR
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Validate deploy target rules
         run: pnpm test:deploy-targets
 
+      - name: Validate security review rules
+        run: pnpm test:security-review
+
       - name: Validate formatting
         run: pnpm format:check
 

--- a/.github/workflows/security-review.yml
+++ b/.github/workflows/security-review.yml
@@ -1,0 +1,47 @@
+name: Security Review
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+      - "apps/admin/src/middleware.ts"
+      - "apps/admin/src/lib/passkey-auth.ts"
+      - "apps/admin/src/pages/api/**"
+      - "apps/admin/src/pages/auth/**"
+      - "apps/admin-solid/src/lib/**"
+      - "apps/admin-solid/src/routes/api/**"
+      - "drizzle/migrations/**"
+      - "packages/lib/**"
+      - "scripts/**"
+      - "workers/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - "turbo.json"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: security-review-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  security-review:
+    name: Security Review
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Compute changed files
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --prune origin "${{ github.base_ref }}"
+          git diff --name-only "origin/${{ github.base_ref }}"...HEAD > "$RUNNER_TEMP/security-files.txt"
+          cat "$RUNNER_TEMP/security-files.txt"
+
+      - name: Run static security review
+        run: node scripts/ci/security-review.mjs "$RUNNER_TEMP/security-files.txt"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,14 +22,17 @@ approved target.
 
 Do not add or restore GitHub workflows that call Anthropic, Claude Code, or
 other external LLM review APIs for this repo. Ani disabled those on 2026-06-27
-to avoid unnecessary Claude API spend. There is no Claude security-review
-workflow and no required Claude API check. Real safety comes from small scoped
-diffs, local checks, CodeRabbit/GitHub signals, focused human review when
-needed, and deploy proof.
+to avoid unnecessary Claude API spend. `security-review.yml` is local static
+checking only: sensitive path detection, literal-secret scans, banned external
+LLM review hooks, and destructive migration guards. It must not call Claude,
+Anthropic, or any paid model API. Real safety comes from small scoped diffs,
+local checks, CodeRabbit/GitHub signals, focused human review when needed, and
+deploy proof.
 
 Primary workflows are intentionally limited to:
 
 - `ci.yml`
+- `security-review.yml`
 - `agent-automerge.yml`
 - `deploy.yml`
 - `smoke.yml`

--- a/docs/platform-architecture.md
+++ b/docs/platform-architecture.md
@@ -130,6 +130,7 @@ Primary workflows:
 | Workflow              | Role                                                     |
 | --------------------- | -------------------------------------------------------- |
 | `ci.yml`              | build, lint, typecheck, and test affected packages on PR |
+| `security-review.yml` | local static checks for sensitive path changes on PR     |
 | `agent-automerge.yml` | merge green agent PRs and dispatch exact deploy targets  |
 | `deploy.yml`          | deploy explicit targets only                             |
 | `smoke.yml`           | manual route proof for public and admin targets          |
@@ -145,8 +146,9 @@ Rules:
   `apps/admin` does not depend on them.
 - `deploy.yml` records route proof inside the `www` and `admin` deploy jobs.
 - D1 migrations run as reviewed migration steps before app deploy.
-- Anthropic and Claude Code API-backed GitHub workflows are disabled for this
-  repo.
+- `security-review.yml` does not call Anthropic, Claude Code, or any external
+  model API. It scans sensitive diffs for literal secrets, disabled LLM review
+  hooks, and destructive migration patterns.
 - `/api/admin/runtime-feed` is disabled in production and reads only the local
   Infra runtime metadata file during development.
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "proof:admin-content": "node scripts/admin/content-proof.mjs",
     "update-claude-stats": "node scripts/claude/generate-claude-stats.mjs",
     "test:deploy-targets": "node scripts/ci/compute-deploy-targets.test.mjs",
+    "test:security-review": "node scripts/ci/security-review.test.mjs",
     "test:unit": "turbo test",
     "test": "pnpm test:unit",
     "validate": "turbo build && turbo lint && turbo typecheck && turbo test",

--- a/scripts/ci/security-review.mjs
+++ b/scripts/ci/security-review.mjs
@@ -1,0 +1,225 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+
+const DEPENDENCY_ROOTS = new Set([
+  "package.json",
+  "pnpm-lock.yaml",
+  "pnpm-workspace.yaml",
+  "turbo.json",
+]);
+
+const SENSITIVE_PREFIXES = [
+  ".github/workflows/",
+  "apps/admin/src/pages/api/",
+  "apps/admin/src/pages/auth/",
+  "apps/admin-solid/src/lib/",
+  "apps/admin-solid/src/routes/api/",
+  "drizzle/migrations/",
+  "packages/lib/",
+  "scripts/",
+  "workers/",
+];
+
+const SENSITIVE_EXACT_FILES = new Set([
+  "apps/admin/src/middleware.ts",
+  "apps/admin/src/lib/passkey-auth.ts",
+]);
+
+const SECRET_PATTERNS = [
+  {
+    id: "private-key",
+    pattern: /-----BEGIN [A-Z ]*PRIVATE KEY-----/,
+  },
+  {
+    id: "openai-or-similar-key",
+    pattern: /\bsk-[A-Za-z0-9_-]{20,}\b/,
+  },
+  {
+    id: "github-token",
+    pattern: /\b(?:ghp|gho|ghu|ghs|ghr|github_pat)_[A-Za-z0-9_]{20,}\b/,
+  },
+  {
+    id: "slack-token",
+    pattern: /\bxox[aboprs]-[A-Za-z0-9-]{20,}\b/,
+  },
+  {
+    id: "aws-access-key",
+    pattern: /\bAKIA[0-9A-Z]{16}\b/,
+  },
+  {
+    id: "inline-secret-assignment",
+    pattern:
+      /\b(?:api|auth|access|secret|token|key|password)[A-Z0-9_ -]*[=:]\s*["']?[A-Za-z0-9_./+=-]{24,}/i,
+  },
+];
+
+const BANNED_LLM_REVIEW_PATTERNS = [
+  {
+    id: "anthropic-api-key",
+    pattern: /\bANTHROPIC_API_KEY\b/,
+  },
+  {
+    id: "claude-api-key",
+    pattern: /\bCLAUDE_API_KEY\b/,
+  },
+  {
+    id: "claude-code-action",
+    pattern: /claude-code-action|anthropic-ai\/claude/i,
+  },
+  {
+    id: "anthropic-api-host",
+    pattern: /api\.anthropic\.com/i,
+  },
+];
+
+const DESTRUCTIVE_SQL_PATTERNS = [
+  {
+    id: "drop-table",
+    pattern: /\bDROP\s+TABLE\b/i,
+  },
+  {
+    id: "drop-column",
+    pattern: /\bDROP\s+COLUMN\b/i,
+  },
+  {
+    id: "delete-from",
+    pattern: /\bDELETE\s+FROM\b/i,
+  },
+  {
+    id: "truncate",
+    pattern: /\bTRUNCATE\b/i,
+  },
+];
+
+export function requiresSecurityReview(files) {
+  return files.some(isSensitivePath);
+}
+
+export function reviewFiles(files, readFile = readFileSync) {
+  const findings = [];
+
+  for (const file of files.filter(isSensitivePath)) {
+    let content = "";
+    try {
+      content = readFile(file, "utf8");
+    } catch {
+      continue;
+    }
+
+    findings.push(...scanForSecrets(file, content));
+    findings.push(...scanForBannedLlmReview(file, content));
+    if (file.startsWith("drizzle/migrations/")) {
+      findings.push(...scanForDestructiveSql(file, content));
+    }
+  }
+
+  return findings;
+}
+
+export function isSensitivePath(file) {
+  if (!file || file.endsWith(".md")) return false;
+  if (DEPENDENCY_ROOTS.has(file)) return true;
+  if (SENSITIVE_EXACT_FILES.has(file)) return true;
+  return SENSITIVE_PREFIXES.some((prefix) => file.startsWith(prefix));
+}
+
+function scanForSecrets(file, content) {
+  const findings = [];
+  for (const [lineIndex, line] of content.split(/\r?\n/).entries()) {
+    if (line.includes("${{ secrets.")) continue;
+    for (const { id, pattern } of SECRET_PATTERNS) {
+      if (pattern.test(line)) {
+        findings.push({
+          file,
+          line: lineIndex + 1,
+          rule: id,
+          summary: "possible literal secret in sensitive file",
+        });
+      }
+    }
+  }
+  return findings;
+}
+
+function scanForBannedLlmReview(file, content) {
+  if (!file.startsWith(".github/workflows/")) return [];
+
+  return BANNED_LLM_REVIEW_PATTERNS.flatMap(({ id, pattern }) =>
+    pattern.test(content)
+      ? [
+          {
+            file,
+            line: 1,
+            rule: id,
+            summary: "external Claude or Anthropic review API is disabled",
+          },
+        ]
+      : [],
+  );
+}
+
+function scanForDestructiveSql(file, content) {
+  const stripped = content
+    .split(/\r?\n/)
+    .filter((line) => !line.trimStart().startsWith("--"))
+    .join("\n");
+
+  return DESTRUCTIVE_SQL_PATTERNS.flatMap(({ id, pattern }) =>
+    pattern.test(stripped)
+      ? [
+          {
+            file,
+            line: 1,
+            rule: id,
+            summary: "destructive migration needs separate human review",
+          },
+        ]
+      : [],
+  );
+}
+
+function readFiles(path) {
+  return readFileSync(path, "utf8")
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function printFindings(findings) {
+  for (const finding of findings) {
+    console.error(
+      `${finding.file}:${finding.line} ${finding.rule}: ${finding.summary}`,
+    );
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const requiredOnly = process.argv.includes("--required");
+  const fileListPath = process.argv
+    .slice(2)
+    .find((arg) => !arg.startsWith("--"));
+
+  if (!fileListPath) {
+    console.error("usage: security-review.mjs [--required] <file-list>");
+    process.exit(2);
+  }
+
+  const files = readFiles(fileListPath);
+
+  if (requiredOnly) {
+    console.log(
+      `security_review=${requiresSecurityReview(files) ? "true" : "false"}`,
+    );
+    process.exit(0);
+  }
+
+  const findings = reviewFiles(files);
+  if (findings.length > 0) {
+    printFindings(findings);
+    process.exit(1);
+  }
+
+  const sensitiveCount = files.filter(isSensitivePath).length;
+  console.log(`security review passed for ${sensitiveCount} sensitive files`);
+}

--- a/scripts/ci/security-review.test.mjs
+++ b/scripts/ci/security-review.test.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import {
+  isSensitivePath,
+  requiresSecurityReview,
+  reviewFiles,
+} from "./security-review.mjs";
+
+function expectSensitive(file, expected) {
+  assert.equal(isSensitivePath(file), expected, file);
+}
+
+expectSensitive(".github/workflows/deploy.yml", true);
+expectSensitive("apps/admin/src/middleware.ts", true);
+expectSensitive("apps/admin/src/pages/api/admin/passkey/status.ts", true);
+expectSensitive("apps/admin/src/pages/auth/passkey.astro", true);
+expectSensitive("workers/state/src/index.ts", true);
+expectSensitive("packages/lib/src/cms/homepage.ts", true);
+expectSensitive("drizzle/migrations/0016_seed_homepage_rich_summary.sql", true);
+expectSensitive("scripts/ci/security-review.mjs", true);
+expectSensitive("package.json", true);
+expectSensitive("docs/platform-architecture.md", false);
+expectSensitive("apps/www/src/pages/index.astro", false);
+expectSensitive("apps/admin/README.md", false);
+
+assert.equal(
+  requiresSecurityReview([
+    "docs/platform-architecture.md",
+    "apps/admin/src/middleware.ts",
+  ]),
+  true,
+);
+
+assert.equal(
+  requiresSecurityReview(["docs/platform-architecture.md"]),
+  false,
+);
+
+const fakeFiles = new Map([
+  [
+    ".github/workflows/review.yml",
+    "env:\n  ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}\n",
+  ],
+  [
+    "scripts/example.ts",
+    `const token = "${"sk-proj-" + "abcdefghijklmnopqrstuvwxyz"}";\n`,
+  ],
+  [
+    "drizzle/migrations/0099_drop.sql",
+    "-- rollback comment can say DELETE FROM safely\nDROP TABLE sessions;\n",
+  ],
+  [
+    ".github/workflows/deploy.yml",
+    "env:\n  CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}\n",
+  ],
+]);
+
+function readFake(file) {
+  return fakeFiles.get(file) ?? "";
+}
+
+const findings = reviewFiles(
+  [
+    ".github/workflows/review.yml",
+    "scripts/example.ts",
+    "drizzle/migrations/0099_drop.sql",
+    ".github/workflows/deploy.yml",
+    "docs/archive/old.md",
+  ],
+  readFake,
+);
+
+assert.deepEqual(
+  findings.map((finding) => finding.rule).sort(),
+  [
+    "anthropic-api-key",
+    "drop-table",
+    "inline-secret-assignment",
+    "openai-or-similar-key",
+  ],
+);
+
+assert.deepEqual(
+  reviewFiles([".github/workflows/deploy.yml"], readFake),
+  [],
+);


### PR DESCRIPTION
## summary\n- add a path-scoped, local-only security-review workflow for sensitive PR changes\n- add static checks for literal secrets, banned Claude/Anthropic review hooks, and destructive migration patterns\n- make agent automerge wait for Security Review when a PR touches sensitive paths\n- document that this does not call Claude, Anthropic, or any paid model API\n\n## verification\n- pnpm test:security-review\n- pnpm test:deploy-targets\n- node scripts/ci/security-review.mjs --required /tmp/security-review-commit-files.txt\n- node scripts/ci/security-review.mjs /tmp/security-review-commit-files.txt\n- node scripts/ci/compute-deploy-targets.mjs /tmp/security-review-commit-files.txt\n- pnpm format:check\n- git diff --check\n- node --check scripts/ci/security-review.mjs\n- node --check scripts/ci/security-review.test.mjs\n- ruby -ryaml -e 'ARGV.each { |f| YAML.load_file(f); puts f }' .github/workflows/*.yml\n\n## deploy\n- computed deploy targets: all false\n- no app, worker, D1, auth, DNS, env, secret, or route mutation\n