### PR TITLE
ci: stop admin-solid autodeploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,11 +7,12 @@
 #   TYPEFULLY_API_KEY       - Typefully API key
 #   TYPEFULLY_SOCIAL_SET_ID - Typefully social set ID
 #
-# Path-filtered deploys: each deploy-X job only runs when files relevant to
-# that target actually changed. Root dependency changes do not fan out to every
-# target; use workflow_dispatch for an explicit deploy when a root-only change
-# needs promotion. Docs-only commits skip the workflow entirely via
-# paths-ignore. Workflow-only changes run detection but deploy nothing. No
+# Path-filtered deploys: each retained production job only runs when files
+# relevant to that target actually changed. `apps/admin-solid` is a legacy
+# rollback surface and is workflow_dispatch-only. Root dependency changes do not
+# fan out to every target; use workflow_dispatch for an explicit deploy when a
+# root-only change needs promotion. Docs-only commits skip the workflow entirely
+# via paths-ignore. Workflow-only changes run detection but deploy nothing. No
 # untrusted input is interpolated into run: blocks anywhere here.
 
 name: Deploy
@@ -80,7 +81,6 @@ jobs:
     outputs:
       www: ${{ steps.filter.outputs.www }}
       admin: ${{ steps.filter.outputs.admin }}
-      admin-solid: ${{ steps.filter.outputs.admin-solid }}
       ingest: ${{ steps.filter.outputs.ingest }}
       newsletter: ${{ steps.filter.outputs.newsletter }}
       state: ${{ steps.filter.outputs.state }}
@@ -100,8 +100,6 @@ jobs:
             admin:
               - "apps/admin/**"
               - "packages/content/**"
-            admin-solid:
-              - "apps/admin-solid/**"
             ingest:
               - "workers/ingest/**"
             newsletter:
@@ -236,8 +234,7 @@ jobs:
     name: Deploy admin-solid
     needs: [changes]
     if: >
-      (github.event_name == 'workflow_dispatch' && inputs.admin_solid == 'true') ||
-      (github.event_name == 'push' && needs.changes.outputs['admin-solid'] == 'true')
+      github.event_name == 'workflow_dispatch' && inputs.admin_solid == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,9 @@ For admin UI, feed, content review, auth staging, and operator-dashboard work:
 - record deploy run, skipped targets, and route proof
 
 `apps/admin-solid` is legacy rollback. Keep it only until the Astro admin
-cutover and passkey proof are complete, then archive or remove it.
+cutover and passkey proof are complete, then archive or remove it. It is not a
+normal auto-deploy target; use the explicit manual `admin_solid=true` deploy
+input only for rollback.
 
 Approved includes reviewed D1 migrations needed by the green PR, passkey auth
 rollout, and Cloudflare Access removal after passkey proof.

--- a/docs/platform-architecture.md
+++ b/docs/platform-architecture.md
@@ -7,27 +7,27 @@ structured content/state model, and one predictable CI/CD path.
 
 ## target state
 
-| Surface        | Target                              | Status              | Next action                                              |
-| -------------- | ----------------------------------- | ------------------- | -------------------------------------------------------- |
-| public site    | `apps/www`                          | keep                | keep as Astro public app for `anipotts.com`              |
-| admin site     | `apps/admin`                        | canonical cutover   | prove passkey registration and then remove Access        |
-| current admin  | `apps/admin-solid`                  | legacy rollback     | keep briefly, then archive or delete after passkey proof |
-| legacy admin   | `docs/archive/admin-next-legacy.md` | archived            | no Next admin app remains                                |
-| labs           | `docs/archive/labs`                 | archived            | no app or deploy target remains                          |
-| workers        | `workers/*`                         | review individually | keep only production-required workers                    |
-| shared content | `packages/content`, `packages/lib`  | in progress         | use package contracts plus D1 operation tables           |
-| database       | `drizzle`, D1 `anipotts-db`         | keep                | seed inert content operations, then prove admin reads    |
+| Surface        | Target                              | Status              | Next action                                           |
+| -------------- | ----------------------------------- | ------------------- | ----------------------------------------------------- |
+| public site    | `apps/www`                          | keep                | keep as Astro public app for `anipotts.com`           |
+| admin site     | `apps/admin`                        | canonical cutover   | prove passkey registration and then remove Access     |
+| current admin  | `apps/admin-solid`                  | manual rollback     | no auto-deploy; archive or delete after passkey proof |
+| legacy admin   | `docs/archive/admin-next-legacy.md` | archived            | no Next admin app remains                             |
+| labs           | `docs/archive/labs`                 | archived            | no app or deploy target remains                       |
+| workers        | `workers/*`                         | review individually | keep only production-required workers                 |
+| shared content | `packages/content`, `packages/lib`  | in progress         | use package contracts plus D1 operation tables        |
+| database       | `drizzle`, D1 `anipotts-db`         | keep                | seed inert content operations, then prove admin reads |
 
 ## current inventory
 
 ### apps
 
-| Path                | Role today                                 | Classification      |
-| ------------------- | ------------------------------------------ | ------------------- |
-| `apps/www`          | public Astro site and newsletter endpoints | keep                |
-| `apps/admin`        | Astro admin app for `admin.anipotts.com`   | keep                |
-| `apps/admin-solid`  | legacy Solid admin rollback surface        | archive/remove next |
-| `docs/archive/labs` | archived labs reference material           | keep as archive     |
+| Path                | Role today                                 | Classification  |
+| ------------------- | ------------------------------------------ | --------------- |
+| `apps/www`          | public Astro site and newsletter endpoints | keep            |
+| `apps/admin`        | Astro admin app for `admin.anipotts.com`   | keep            |
+| `apps/admin-solid`  | legacy Solid admin rollback surface        | manual rollback |
+| `docs/archive/labs` | archived labs reference material           | keep as archive |
 
 ### workers
 
@@ -142,6 +142,8 @@ Rules:
 - public site changes deploy `www` only.
 - admin changes and `packages/content` changes deploy only the Astro admin
   target.
+- `apps/admin-solid` changes do not auto-deploy. Its deploy job remains
+  workflow-dispatch only for rollback while passkey proof is incomplete.
 - `packages/lib` and `packages/styles` changes deploy `www` only because
   `apps/admin` does not depend on them.
 - `deploy.yml` records route proof inside the `www` and `admin` deploy jobs.
@@ -187,4 +189,6 @@ Rules:
 14. move homepage rich summary text and mention keys into D1 `page_content`;
     seeded by `drizzle/migrations/0016_seed_homepage_rich_summary.sql` with
     Astro brand visual metadata still retained.
-15. reduce deploy workflow inputs to retained production targets.
+15. stop auto-deploying `apps/admin-solid`; keep it manual-only for rollback.
+16. reduce deploy workflow inputs to retained production targets after rollback
+    no longer needs `apps/admin-solid`.

--- a/scripts/ci/compute-deploy-targets.mjs
+++ b/scripts/ci/compute-deploy-targets.mjs
@@ -43,9 +43,9 @@ export function computeDeployTargets(files) {
       targets.admin = true;
     }
 
-    if (file.startsWith("apps/admin-solid/")) {
-      targets.admin_solid = true;
-    }
+    // apps/admin-solid is retained as a temporary rollback surface only.
+    // It should not auto-deploy from agent PRs or path-filtered main pushes.
+    // Use the explicit deploy workflow input if rollback deployment is needed.
 
     if (file.startsWith("workers/ingest/")) {
       targets.ingest = true;

--- a/scripts/ci/compute-deploy-targets.test.mjs
+++ b/scripts/ci/compute-deploy-targets.test.mjs
@@ -57,11 +57,9 @@ expectTargets(
 );
 
 expectTargets(
-  "admin-solid source deploys only admin-solid",
+  "admin-solid source does not auto-deploy rollback worker",
   ["apps/admin-solid/src/routes/index.tsx"],
-  {
-    admin_solid: true,
-  },
+  {},
 );
 
 expectTargets(


### PR DESCRIPTION
## summary
- keep apps/admin-solid as a manual rollback deploy only
- remove admin-solid from push path filters and agent deploy target calculation
- document that apps/admin is canonical and admin-solid is not a normal auto-deploy target

## verification
- pnpm test:deploy-targets
- pnpm test:security-review
- ruby -ryaml -e 'ARGV.each { |f| YAML.load_file(f); puts f }' .github/workflows/*.yml
- pnpm format:check
- git diff --check
- committed file deploy target proof: all deploy targets false
- committed file security review: required and passed for 3 sensitive files

## live impact
- none expected; deploy targets compute to false
