### PR TITLE
ci: guard admin route parity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Validate deploy target rules
         run: pnpm test:deploy-targets
 
+      - name: Validate admin route parity
+        run: pnpm test:admin-routes
+
       - name: Validate security review rules
         run: pnpm test:security-review
 

--- a/docs/platform-architecture.md
+++ b/docs/platform-architecture.md
@@ -55,6 +55,9 @@ The Astro admin replacement covers these live admin-solid routes. Keep them
 covered while passkey proof and Access removal are completed, then remove
 `apps/admin-solid`:
 
+`pnpm test:admin-routes` enforces the route files, admin navigation, deploy
+smoke list, and manual smoke list for this parity set.
+
 | Route                                               | Purpose                              |
 | --------------------------------------------------- | ------------------------------------ |
 | `/`                                                 | operator overview                    |

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "proof:admin-content": "node scripts/admin/content-proof.mjs",
     "update-claude-stats": "node scripts/claude/generate-claude-stats.mjs",
     "test:deploy-targets": "node scripts/ci/compute-deploy-targets.test.mjs",
+    "test:admin-routes": "node scripts/ci/admin-route-parity.test.mjs",
     "test:security-review": "node scripts/ci/security-review.test.mjs",
     "test:unit": "turbo test",
     "test": "pnpm test:unit",

--- a/scripts/ci/admin-route-parity.test.mjs
+++ b/scripts/ci/admin-route-parity.test.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+
+const ROUTES = [
+  { route: "/", file: "apps/admin/src/pages/index.astro", nav: true },
+  {
+    route: "/auth/passkey",
+    file: "apps/admin/src/pages/auth/passkey.astro",
+    nav: false,
+  },
+  {
+    route: "/content",
+    file: "apps/admin/src/pages/content/index.astro",
+    nav: true,
+  },
+  {
+    route: "/content/review",
+    file: "apps/admin/src/pages/content/review.astro",
+    nav: true,
+  },
+  {
+    route: "/content/preview",
+    file: "apps/admin/src/pages/content/preview.astro",
+    nav: true,
+  },
+  {
+    route: "/content/operations",
+    file: "apps/admin/src/pages/content/operations.astro",
+    nav: true,
+  },
+  {
+    route: "/newsletter",
+    file: "apps/admin/src/pages/newsletter.astro",
+    nav: true,
+  },
+  {
+    route: "/newsletter/first-thing-agents-need-control-plane",
+    file: "apps/admin/src/pages/newsletter/[slug].astro",
+    nav: false,
+  },
+  {
+    route: "/needs-ani",
+    file: "apps/admin/src/pages/needs-ani.astro",
+    nav: true,
+  },
+  { route: "/proof", file: "apps/admin/src/pages/proof.astro", nav: true },
+  { route: "/repos", file: "apps/admin/src/pages/repos.astro", nav: true },
+  {
+    route: "/handoffs",
+    file: "apps/admin/src/pages/handoffs.astro",
+    nav: true,
+  },
+  { route: "/fleet", file: "apps/admin/src/pages/fleet.astro", nav: true },
+  {
+    route: "/mutations",
+    file: "apps/admin/src/pages/mutations.astro",
+    nav: true,
+  },
+  {
+    route: "/ops/destructive",
+    file: "apps/admin/src/pages/ops/destructive.astro",
+    nav: true,
+  },
+  {
+    route: "/api/admin/runtime-feed",
+    file: "apps/admin/src/pages/api/admin/runtime-feed.ts",
+    nav: false,
+    smoke: false,
+  },
+];
+
+const navSource = readFileSync("apps/admin/src/data/admin.ts", "utf8");
+const deployWorkflow = readFileSync(".github/workflows/deploy.yml", "utf8");
+const smokeWorkflow = readFileSync(".github/workflows/smoke.yml", "utf8");
+const deploySmokeRoutes = extractShellForRoutes(deployWorkflow);
+const manualSmokeRoutes = extractShellForRoutes(smokeWorkflow);
+
+for (const route of ROUTES) {
+  assert.ok(existsSync(route.file), `${route.route} missing ${route.file}`);
+
+  if (route.nav) {
+    assert.ok(
+      navSource.includes(`href: "${route.route}"`),
+      `${route.route} missing from admin nav`,
+    );
+  }
+
+  if (route.smoke !== false) {
+    assert.ok(
+      deploySmokeRoutes.has(route.route),
+      `${route.route} missing from deploy admin smoke`,
+    );
+    assert.ok(
+      manualSmokeRoutes.has(route.route),
+      `${route.route} missing from smoke.yml admin route proof`,
+    );
+  }
+}
+
+function extractShellForRoutes(source) {
+  return new Set(
+    [...source.matchAll(/for path in ([^;]+); do/g)]
+      .flatMap((match) => match[1].trim().split(/\s+/))
+      .filter((route) => route.startsWith("/")),
+  );
+}


### PR DESCRIPTION
## summary
- add a Node-only CI guard for canonical Astro admin route parity
- verify route files, sidebar navigation, deploy smoke routes, and manual smoke routes
- document the guard in the platform architecture map

## verification
- pnpm test:admin-routes
- pnpm test:deploy-targets
- pnpm test:security-review
- ruby -ryaml -e 'ARGV.each { |f| YAML.load_file(f); puts f }' .github/workflows/*.yml
- pnpm format:check
- git diff --check
- committed file deploy target proof: all deploy targets false
- committed file security review: required and passed for 3 sensitive files

## live impact
- none expected; deploy targets compute to false


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added an automated parity check to catch missing or inconsistent admin routes before release.
  * Improved validation so admin navigation and smoke-test coverage stay aligned with the deployed routes.

* **Documentation**
  * Updated architecture docs to describe the admin route parity checks and what they verify.

* **Tests**
  * Added a new CI test step to run the admin route parity validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->