### PR TITLE
ci: guard workflow inventory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Validate admin route parity
         run: pnpm test:admin-routes
 
+      - name: Validate workflow inventory
+        run: pnpm test:workflows
+
       - name: Validate security review rules
         run: pnpm test:security-review
 

--- a/docs/platform-architecture.md
+++ b/docs/platform-architecture.md
@@ -137,6 +137,9 @@ Primary workflows:
 | `deploy.yml`          | deploy explicit targets only                             |
 | `smoke.yml`           | manual route proof for public and admin targets          |
 
+`pnpm test:workflows` enforces this exact workflow inventory and rejects
+disabled external Claude or Anthropic review hooks.
+
 Rules:
 
 - docs-only changes deploy nothing.

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "update-claude-stats": "node scripts/claude/generate-claude-stats.mjs",
     "test:deploy-targets": "node scripts/ci/compute-deploy-targets.test.mjs",
     "test:admin-routes": "node scripts/ci/admin-route-parity.test.mjs",
+    "test:workflows": "node scripts/ci/workflow-inventory.test.mjs",
     "test:security-review": "node scripts/ci/security-review.test.mjs",
     "test:unit": "turbo test",
     "test": "pnpm test:unit",

--- a/scripts/ci/workflow-inventory.test.mjs
+++ b/scripts/ci/workflow-inventory.test.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const WORKFLOW_DIR = ".github/workflows";
+const ALLOWED_WORKFLOWS = [
+  "agent-automerge.yml",
+  "ci.yml",
+  "deploy.yml",
+  "security-review.yml",
+  "smoke.yml",
+];
+
+const BANNED_PATTERNS = [
+  /ANTHROPIC_API_KEY/i,
+  /CLAUDE_API_KEY/i,
+  /anthropic-ai\/claude/i,
+  /claude-code-action/i,
+  /api\.anthropic\.com/i,
+];
+
+const workflowFiles = readdirSync(WORKFLOW_DIR)
+  .filter((file) => file.endsWith(".yml") || file.endsWith(".yaml"))
+  .sort();
+
+assert.deepEqual(
+  workflowFiles,
+  ALLOWED_WORKFLOWS,
+  "workflow inventory drifted from the approved CI/CD set",
+);
+
+for (const file of workflowFiles) {
+  const body = readFileSync(join(WORKFLOW_DIR, file), "utf8");
+  for (const pattern of BANNED_PATTERNS) {
+    assert.equal(
+      pattern.test(body),
+      false,
+      `${file} includes disabled external LLM review hook ${pattern}`,
+    );
+  }
+}


### PR DESCRIPTION
## summary
- add a local workflow inventory guard for the approved five-workflow CI/CD set
- reject disabled Claude/Anthropic external review hooks in workflow files
- run the guard in CI before affected package checks

## verification
- pnpm test:workflows
- pnpm test:deploy-targets
- pnpm test:admin-routes
- pnpm test:security-review
- pnpm format:check
- git diff --check
- ruby -ryaml -e 'ARGV.each { |f| YAML.load_file(f); puts f }' .github/workflows/*.yml
- pnpm turbo build --affected --output-logs=errors-only
- pnpm turbo lint --affected --output-logs=errors-only
- pnpm turbo typecheck --affected --output-logs=errors-only
- pnpm turbo test --affected --output-logs=errors-only
- committed file deploy target proof: all deploy targets false
- committed file security review: required and passed for 3 sensitive files

## live impact
- none expected; deploy targets compute to false
