### PR TITLE
ci: guard workspace inventory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Validate workspace inventory
+        run: pnpm test:workspace
+
       - name: Validate deploy target rules
         run: pnpm test:deploy-targets
 

--- a/docs/platform-architecture.md
+++ b/docs/platform-architecture.md
@@ -5,6 +5,9 @@ Last updated: 2026-06-27
 This repo is being reduced to one public Astro app, one admin Astro app, one
 structured content/state model, and one predictable CI/CD path.
 
+`pnpm test:workspace` enforces the active app, package, and worker inventory so
+archived surfaces do not re-enter the workspace quietly.
+
 ## target state
 
 | Surface        | Target                              | Status              | Next action                                           |

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "update-claude-stats": "node scripts/claude/generate-claude-stats.mjs",
     "test:deploy-targets": "node scripts/ci/compute-deploy-targets.test.mjs",
     "test:admin-routes": "node scripts/ci/admin-route-parity.test.mjs",
+    "test:workspace": "node scripts/ci/workspace-inventory.test.mjs",
     "test:workflows": "node scripts/ci/workflow-inventory.test.mjs",
     "test:security-review": "node scripts/ci/security-review.test.mjs",
     "test:unit": "turbo test",

--- a/scripts/ci/workspace-inventory.test.mjs
+++ b/scripts/ci/workspace-inventory.test.mjs
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const EXPECTED_APPS = ["admin", "admin-solid", "www"];
+const EXPECTED_PACKAGES = ["config", "content", "lib", "styles", "types"];
+const EXPECTED_WORKERS = ["ingest", "newsletter", "state", "weekly-email"];
+const EXPECTED_WORKSPACE_GLOBS = ['"apps/*"', '"packages/*"', '"workers/*"'];
+
+assert.deepEqual(
+  packageDirs("apps"),
+  EXPECTED_APPS,
+  "apps inventory drifted from the target platform",
+);
+assert.deepEqual(
+  packageDirs("packages"),
+  EXPECTED_PACKAGES,
+  "packages inventory drifted from the target platform",
+);
+assert.deepEqual(
+  packageDirs("workers"),
+  EXPECTED_WORKERS,
+  "workers inventory drifted from retained production workers",
+);
+assert.equal(existsSync("apps/labs"), false, "apps/labs must stay archived");
+assert.equal(existsSync("services"), false, "services workspace must stay removed");
+
+const workspace = readFileSync("pnpm-workspace.yaml", "utf8");
+for (const glob of EXPECTED_WORKSPACE_GLOBS) {
+  assert.ok(workspace.includes(glob), `missing workspace glob ${glob}`);
+}
+assert.equal(
+  workspace.includes('"services"'),
+  false,
+  "services workspace glob must stay removed",
+);
+
+function packageDirs(root) {
+  return readdirSync(root, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .filter((name) => existsSync(join(root, name, "package.json")))
+    .sort();
+}


### PR DESCRIPTION
## summary
- add a local workspace inventory guard for active apps, packages, and retained workers
- fail CI if archived surfaces like apps/labs or services re-enter the workspace
- run the guard in CI before deploy-target and affected-package checks

## verification
- pnpm test:workspace
- pnpm test:workflows
- pnpm test:deploy-targets
- pnpm test:admin-routes
- pnpm test:security-review
- pnpm format:check
- git diff --check
- ruby -ryaml -e 'ARGV.each { |f| YAML.load_file(f); puts f }' .github/workflows/*.yml
- pnpm turbo build --affected --output-logs=errors-only
- pnpm turbo lint --affected --output-logs=errors-only
- pnpm turbo typecheck --affected --output-logs=errors-only
- pnpm turbo test --affected --output-logs=errors-only
- committed file deploy target proof: all deploy targets false
- committed file security review: required and passed for 3 sensitive files

## live impact
- none expected; deploy targets compute to false
