### PR TITLE
Read homepage from CMS boundary

### DIFF
--- a/apps/www/src/pages/index.astro
+++ b/apps/www/src/pages/index.astro
@@ -3,15 +3,14 @@ import Shell from "../layouts/Shell.astro";
 import ProjectCard from "../components/ProjectCard.astro";
 import WritingRow from "../components/WritingRow.astro";
 import NewsletterSubscribe from "../components/NewsletterSubscribe.astro";
-import InlineMention from "../components/InlineMention.astro";
 import HomepageRichSummary from "../components/HomepageRichSummary.astro";
 import { Icon } from "astro-icon/components";
-import { homeContent } from "../data/site";
 import { publishedWriting, visibleProjects } from "../lib/content";
 import { setDB } from "@anipotts/lib/db";
 import type { D1Database } from "@anipotts/lib/db";
 import {
   fetchPageContent,
+  homepageSummaryText,
   normalizeHomepageContent,
   normalizeNewsletterContent,
 } from "@anipotts/lib/cms";
@@ -23,53 +22,16 @@ const [homePage, newsletterPage] = await Promise.all([
   fetchPageContent("home"),
   fetchPageContent("newsletter"),
 ]);
-const rawHomeContent =
-  homePage?.content && typeof homePage.content === "object"
-    ? (homePage.content as {
-        sections?: {
-          intro?: {
-            heading?: unknown;
-            subheading?: unknown;
-            rich_summary?: unknown;
-          };
-        };
-      })
-    : null;
 const cmsHome = normalizeHomepageContent(homePage?.content);
 const newsletterCopy = normalizeNewsletterContent(newsletterPage?.content);
-const cmsIntroSource = rawHomeContent?.sections?.intro;
-const hasCmsHeading = hasText(cmsIntroSource?.heading);
-const hasCmsSubheading = hasText(cmsIntroSource?.subheading);
-const hasCmsRichSummary = hasNonEmptyArray(cmsIntroSource?.rich_summary);
 const intro = cmsHome.sections.intro;
 const work = cmsHome.sections.past_work;
 const writing = cmsHome.sections.latest_thoughts;
-const heading = hasCmsHeading ? intro.heading : homeContent.heading;
-const proofCards =
-  cmsHome.proof_cards.length > 0 ? cmsHome.proof_cards : homeContent.proof;
-const mentionMap =
-  Object.keys(cmsHome.mentions).length > 0
-    ? cmsHome.mentions
-    : homeContent.mentions;
-const homeMakingSlugs = [
-  "quantercise",
-  "quantercise-extension",
-  "saeshify",
-  "nyu-purity-test",
-] as const;
-const homeWritingSlugs = [
-  "saturdays-are-for-claude-code",
-  "i-built-a-monitor-for-my-claude-code-sessions",
-  "stop-ending-your-day-with-fix-the-bug",
-] as const;
-const selectedMakingSlugs =
-  work.project_slugs && work.project_slugs.length > 0
-    ? work.project_slugs
-    : [...homeMakingSlugs];
-const selectedWritingSlugs =
-  writing.writing_slugs && writing.writing_slugs.length > 0
-    ? writing.writing_slugs
-    : [...homeWritingSlugs];
+const heading = intro.heading;
+const proofCards = cmsHome.proof_cards;
+const mentionMap = cmsHome.mentions;
+const selectedMakingSlugs = work.project_slugs ?? [];
+const selectedWritingSlugs = writing.writing_slugs ?? [];
 const homeMakingOrder = new Map<string, number>(
   selectedMakingSlugs.map((slug, index) => [slug, index]),
 );
@@ -92,60 +54,23 @@ const writingEntries = (await publishedWriting())
   .slice(0, writing.limit ?? 3);
 const workLabel = work.label || "making";
 const workHref = work.view_all ?? work.links?.[0]?.href ?? "/making";
-const ycMention = mentionMap.yCombinatorF25;
-
-function hasText(value: unknown): value is string {
-  return typeof value === "string" && value.trim().length > 0;
-}
-
-function hasNonEmptyArray(value: unknown): value is unknown[] {
-  return Array.isArray(value) && value.length > 0;
-}
+const summaryText = homepageSummaryText(cmsHome);
 ---
 
-<Shell title="ani potts" description={homeContent.summary} path="/">
+<Shell title="ani potts" description={summaryText} path="/">
   <section data-rise>
     <h1 class="home-hero">
       {heading}<span class="spark">.</span>
     </h1>
     <p class="hero-summary hero-line">
       {
-        hasCmsRichSummary && intro.rich_summary ? (
+        intro.rich_summary && intro.rich_summary.length > 0 ? (
           <HomepageRichSummary
             sentences={intro.rich_summary}
             mentions={mentionMap}
           />
-        ) : hasCmsSubheading ? (
-          (intro.subheading ?? homeContent.summary)
         ) : (
-          <>
-            <span class="hero-sentence">
-              previously worked on real-time agent i/o at{" "}
-              <span class="mention-cluster">
-                <InlineMention {...mentionMap.structuredAi} />
-                <span class="brand-parens">
-                  <>
-                    <span>(</span>
-                    <InlineMention {...ycMention} />
-                    <span>)</span>
-                  </>
-                </span>
-              </span>{" "}
-              and{" "}
-              <span class="mention-cluster">
-                <InlineMention {...mentionMap.badHabit} suffix="," />
-                <span>an</span>
-                <InlineMention {...mentionMap.atlanticRecords} />
-                <span>venture.</span>
-              </span>
-            </span>
-            <span class="hero-break" aria-hidden="true" />
-            <span class="hero-sentence">
-              every now and then i post about what i'm doing with claude code
-              and codex, as featured on{" "}
-              <InlineMention {...mentionMap.businessInsider} suffix="." />
-            </span>
-          </>
+          summaryText
         )
       }
     </p>

--- a/packages/lib/src/cms/defaults.ts
+++ b/packages/lib/src/cms/defaults.ts
@@ -36,7 +36,7 @@ export const DEFAULT_HOMEPAGE_CONTENT: HomepageContent = {
       label: "index",
       heading: "hi, i'm ani",
       subheading:
-        "previously worked on real-time agent i/o at structured ai (YC F25) and our bad habit, an atlantic records venture. every now and then i post about what i'm doing with claude code and codex",
+        "previously worked on real-time agent i/o at structured ai (YC F25) and our bad habit, an atlantic records venture. every now and then i post about what i'm doing with claude code and codex.",
       rich_summary: [
         {
           segments: [

--- a/packages/lib/src/cms/homepage.ts
+++ b/packages/lib/src/cms/homepage.ts
@@ -54,9 +54,12 @@ function normalizeSection(
         : coerceString(source.subheading, fallback.subheading ?? "").trim();
   }
 
+  const hasSourceSubheading =
+    typeof source.subheading === "string" &&
+    source.subheading.trim().length > 0;
   if (
     Array.isArray(source.rich_summary) ||
-    fallback.rich_summary !== undefined
+    (fallback.rich_summary !== undefined && !hasSourceSubheading)
   ) {
     normalized.rich_summary = normalizeRichSummary(
       source.rich_summary,
@@ -489,6 +492,29 @@ function richSummaryTextLength(segments: HomepageRichSummarySegment[]): number {
   }, 0);
 }
 
+function richSummaryPlainText(
+  segments: HomepageRichSummarySegment[],
+  mentions: Record<string, HomepageMention>,
+): string {
+  return segments
+    .map((segment) => richSummarySegmentPlainText(segment, mentions))
+    .join("");
+}
+
+function richSummarySegmentPlainText(
+  segment: HomepageRichSummarySegment,
+  mentions: Record<string, HomepageMention>,
+): string {
+  if (segment.kind === "text") return segment.text;
+  if (segment.kind === "mention") {
+    return `${mentions[segment.key]?.label ?? segment.key}${segment.suffix ?? ""}`;
+  }
+  if (segment.kind === "parens") {
+    return ` (${richSummaryPlainText(segment.segments, mentions)})`;
+  }
+  return richSummaryPlainText(segment.segments, mentions);
+}
+
 function collectRichSummaryMentionKeys(
   sentences: HomepageRichSummarySentence[] | undefined,
 ): string[] {
@@ -706,6 +732,27 @@ export function normalizeHomepageContent(content: unknown): HomepageContent {
       DEFAULT_HOMEPAGE_CONTENT.mentions,
     ),
   };
+}
+
+export function homepageSummaryText(content: HomepageContent): string {
+  const intro = content.sections.intro;
+  const subheading = intro.subheading?.trim();
+  if (subheading) return subheading;
+
+  const richSummary = intro.rich_summary ?? [];
+  const plainText = richSummary
+    .map((sentence) =>
+      richSummaryPlainText(sentence.segments, content.mentions),
+    )
+    .join(" ")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  return (
+    plainText ||
+    DEFAULT_HOMEPAGE_CONTENT.sections.intro.subheading ||
+    DEFAULT_HOMEPAGE_CONTENT.sections.intro.heading
+  );
 }
 
 export async function fetchHomepageContent(): Promise<HomepageContent> {

--- a/packages/lib/src/cms/index.test.ts
+++ b/packages/lib/src/cms/index.test.ts
@@ -16,6 +16,7 @@ import {
   validateCmsWriting,
   validateHomepageContent,
   validateNewsletterContent,
+  homepageSummaryText,
 } from "./index";
 
 describe("homepage cms validation", () => {
@@ -349,6 +350,33 @@ describe("homepage cms validation", () => {
       ok: false,
       error: "About paragraph is too long",
     });
+  });
+
+  it("derives plain homepage summary text from rich summary mentions", () => {
+    const content = normalizeHomepageContent(DEFAULT_HOMEPAGE_CONTENT);
+
+    expect(homepageSummaryText(content)).toBe(
+      "previously worked on real-time agent i/o at structured ai (YC F25) and our bad habit, an atlantic records venture. every now and then i post about what i'm doing with claude code and codex.",
+    );
+  });
+
+  it("keeps D1 subheading-only intro copy plain", () => {
+    const content = normalizeHomepageContent({
+      ...DEFAULT_HOMEPAGE_CONTENT,
+      sections: {
+        ...DEFAULT_HOMEPAGE_CONTENT.sections,
+        intro: {
+          visible: true,
+          label: "index",
+          heading: "hi, i'm ani",
+          subheading: "plain d1 summary",
+        },
+      },
+    });
+
+    expect(content.sections.intro.rich_summary).toBeUndefined();
+    expect(homepageSummaryText(content)).toBe("plain d1 summary");
+    expect(validateHomepageContent(content)).toEqual({ ok: true });
   });
 });
 

--- a/packages/lib/src/cms/index.ts
+++ b/packages/lib/src/cms/index.ts
@@ -16,6 +16,7 @@ export {
 } from "./editor";
 export {
   fetchHomepageContent,
+  homepageSummaryText,
   normalizeHomepageContent,
   validateHomepageContent,
 } from "./homepage";


### PR DESCRIPTION
## summary
- remove page-local homepage fallback slugs, proof cards, mention maps, and hardcoded rich-summary markup from `apps/www/src/pages/index.astro`
- add `homepageSummaryText` to the shared cms package for seo/meta summary text
- preserve plain D1 subheading-only behavior when no rich summary is present

## deploy scope
`node scripts/ci/compute-deploy-targets.mjs` on the committed file list:

```text
www=true
admin=false
admin_solid=false
ingest=false
newsletter=false
state=false
weekly_email=false
```

## verification
- `pnpm --filter @anipotts/lib test -- --runInBand`
- `pnpm turbo typecheck --filter=@anipotts/www...`
- `pnpm turbo build --filter=@anipotts/www...`
- `pnpm exec prettier --check` on touched files
- `git diff --check HEAD~1 HEAD`

## notes
- no d1 migration
- no admin, auth, worker, dns, secret, write path, or external mutation
