### PR TITLE
Show admin passkey proof checklist

### DIFF
--- a/apps/admin/src/lib/passkey-auth.ts
+++ b/apps/admin/src/lib/passkey-auth.ts
@@ -25,6 +25,13 @@ const USER_ID = "ani";
 const USER_NAME = "ani@admin.anipotts.com";
 const USER_DISPLAY_NAME = "Ani";
 const ACCESS_JWT_HEADER = "cf-access-jwt-assertion";
+const REQUIRED_PASSKEY_AUDIT_EVENTS = [
+  "passkey.credential.registered",
+  "passkey.session.created",
+  "passkey.session.revoked",
+  "passkey.credential.revoked",
+  "passkey.authentication.denied",
+] as const;
 
 type D1Result<T = unknown> = {
   results?: T[];
@@ -83,6 +90,21 @@ type AccessIdentity = {
   hint: string | null;
 };
 
+type RequiredPasskeyAuditEvent = (typeof REQUIRED_PASSKEY_AUDIT_EVENTS)[number];
+
+type PasskeyAuditEventRow = {
+  event_type: string;
+  count: number;
+};
+
+export type PasskeyProofItem = {
+  id: string;
+  label: string;
+  count: number;
+  complete: boolean;
+  next_safe_action: string;
+};
+
 export type PasskeyContext = {
   request: Request;
   url: URL;
@@ -104,6 +126,10 @@ export type PasskeyStatus = {
   expected_origin: string;
   expected_rp_id: string;
   current_origin: string;
+  audit_events: Record<RequiredPasskeyAuditEvent, number>;
+  proof_items: PasskeyProofItem[];
+  access_removal_blockers: string[];
+  ready_for_access_removal: boolean;
   next_safe_action: string;
 };
 
@@ -134,6 +160,8 @@ export async function getPasskeyStatus(
   const db = dbFromContext(context);
   const accessIdentity = await resolveAccessIdentity(context);
   if (!db) {
+    const auditEvents = emptyAuditEvents();
+    const blockers = accessRemovalBlockerItems(0, false, auditEvents);
     return {
       available: false,
       mode: "missing_db",
@@ -146,6 +174,10 @@ export async function getPasskeyStatus(
       expected_origin: EXPECTED_ORIGIN,
       expected_rp_id: expectedRpId(context),
       current_origin: context.url.origin,
+      audit_events: auditEvents,
+      proof_items: buildPasskeyProofItems(0, false, auditEvents),
+      access_removal_blockers: blockers,
+      ready_for_access_removal: false,
       next_safe_action:
         "deploy with DB binding and apply migration before enrollment",
     };
@@ -153,13 +185,17 @@ export async function getPasskeyStatus(
 
   let credentialCount = 0;
   let auditCount = 0;
+  let auditEvents = emptyAuditEvents();
   let session: SessionRow | null = null;
   try {
     credentialCount = await countActiveCredentials(db);
     auditCount = await countAuditEvents(db);
+    auditEvents = await readRequiredAuditEvents(db);
     session = await getSession(context, db);
   } catch (error) {
     if (!isMissingPasskeyTable(error)) throw error;
+    const missingAuditEvents = emptyAuditEvents();
+    const blockers = accessRemovalBlockerItems(0, false, missingAuditEvents);
     return {
       available: false,
       mode: "missing_db",
@@ -172,12 +208,21 @@ export async function getPasskeyStatus(
       expected_origin: EXPECTED_ORIGIN,
       expected_rp_id: expectedRpId(context),
       current_origin: context.url.origin,
+      audit_events: missingAuditEvents,
+      proof_items: buildPasskeyProofItems(0, false, missingAuditEvents),
+      access_removal_blockers: blockers,
+      ready_for_access_removal: false,
       next_safe_action:
         "apply drizzle/migrations/0006_admin_passkeys.sql before enrollment",
     };
   }
   const canRegister =
     Boolean(session) || (credentialCount === 0 && accessIdentity.verified);
+  const blockers = accessRemovalBlockerItems(
+    credentialCount,
+    Boolean(session),
+    auditEvents,
+  );
 
   return {
     available: true,
@@ -191,6 +236,14 @@ export async function getPasskeyStatus(
     expected_origin: EXPECTED_ORIGIN,
     expected_rp_id: expectedRpId(context),
     current_origin: context.url.origin,
+    audit_events: auditEvents,
+    proof_items: buildPasskeyProofItems(
+      credentialCount,
+      Boolean(session),
+      auditEvents,
+    ),
+    access_removal_blockers: blockers,
+    ready_for_access_removal: blockers.length === 0,
     next_safe_action: passkeyStatusNextAction(
       Boolean(session),
       credentialCount,
@@ -577,6 +630,30 @@ async function countAuditEvents(db: D1Database): Promise<number> {
   return Number(row?.count ?? 0);
 }
 
+async function readRequiredAuditEvents(
+  db: D1Database,
+): Promise<Record<RequiredPasskeyAuditEvent, number>> {
+  const eventCounts = emptyAuditEvents();
+  const placeholders = REQUIRED_PASSKEY_AUDIT_EVENTS.map(() => "?").join(", ");
+  const result = await db
+    .prepare(
+      `SELECT event_type, COUNT(*) AS count
+       FROM admin_passkey_audit
+       WHERE event_type IN (${placeholders})
+       GROUP BY event_type`,
+    )
+    .bind(...REQUIRED_PASSKEY_AUDIT_EVENTS)
+    .all<PasskeyAuditEventRow>();
+
+  for (const row of result.results ?? []) {
+    if (isRequiredAuditEvent(row.event_type)) {
+      eventCounts[row.event_type] = Number(row.count ?? 0);
+    }
+  }
+
+  return eventCounts;
+}
+
 async function findCredential(
   db: D1Database,
   credentialId: string,
@@ -709,15 +786,15 @@ async function resolveAccessIdentity(
     return { verified: false, hint: null };
   }
 
-  const token = context.request.headers.get(ACCESS_JWT_HEADER);
-  if (!token) {
+  const cfJwt = context.request.headers.get(ACCESS_JWT_HEADER);
+  if (!cfJwt) {
     return { verified: false, hint: null };
   }
 
   try {
     const issuer = teamDomain.replace(/\/$/, "");
     const jwks = createRemoteJWKSet(new URL(`${issuer}/cdn-cgi/access/certs`));
-    const { payload } = await jwtVerify(token, jwks, {
+    const { payload } = await jwtVerify(cfJwt, jwks, {
       issuer,
       audience,
     });
@@ -744,6 +821,94 @@ function passkeyStatusNextAction(
     return "authenticate through Cloudflare Access before first passkey registration";
   }
   return "authenticate with the registered passkey";
+}
+
+function emptyAuditEvents(): Record<RequiredPasskeyAuditEvent, number> {
+  return Object.fromEntries(
+    REQUIRED_PASSKEY_AUDIT_EVENTS.map((eventType) => [eventType, 0]),
+  ) as Record<RequiredPasskeyAuditEvent, number>;
+}
+
+function buildPasskeyProofItems(
+  credentialCount: number,
+  hasSession: boolean,
+  auditEvents: Record<RequiredPasskeyAuditEvent, number>,
+): PasskeyProofItem[] {
+  return [
+    {
+      id: "active_credential",
+      label: "active credential",
+      count: credentialCount,
+      complete: credentialCount > 0,
+      next_safe_action: "register the first platform passkey",
+    },
+    {
+      id: "active_session",
+      label: "active session",
+      count: hasSession ? 1 : 0,
+      complete: hasSession,
+      next_safe_action: "authenticate with the registered passkey",
+    },
+    {
+      id: "passkey.credential.registered",
+      label: "registration audit",
+      count: auditEvents["passkey.credential.registered"],
+      complete: auditEvents["passkey.credential.registered"] > 0,
+      next_safe_action: "register the first platform passkey",
+    },
+    {
+      id: "passkey.session.created",
+      label: "login audit",
+      count: auditEvents["passkey.session.created"],
+      complete: auditEvents["passkey.session.created"] > 0,
+      next_safe_action: "authenticate with the registered passkey",
+    },
+    {
+      id: "passkey.session.revoked",
+      label: "logout audit",
+      count: auditEvents["passkey.session.revoked"],
+      complete: auditEvents["passkey.session.revoked"] > 0,
+      next_safe_action: "logout once, then authenticate again",
+    },
+    {
+      id: "passkey.credential.revoked",
+      label: "credential revoke audit",
+      count: auditEvents["passkey.credential.revoked"],
+      complete: auditEvents["passkey.credential.revoked"] > 0,
+      next_safe_action:
+        "revoke the current passkey while Cloudflare Access remains active",
+    },
+    {
+      id: "passkey.authentication.denied",
+      label: "revoked credential denial audit",
+      count: auditEvents["passkey.authentication.denied"],
+      complete: auditEvents["passkey.authentication.denied"] > 0,
+      next_safe_action:
+        "attempt authenticate after revocation, then register a replacement",
+    },
+  ];
+}
+
+function accessRemovalBlockerItems(
+  credentialCount: number,
+  hasSession: boolean,
+  auditEvents: Record<RequiredPasskeyAuditEvent, number>,
+): string[] {
+  const blockers: string[] = [];
+  if (credentialCount === 0) blockers.push("active_credential");
+  if (!hasSession) blockers.push("active_session");
+  for (const eventType of REQUIRED_PASSKEY_AUDIT_EVENTS) {
+    if (auditEvents[eventType] === 0) blockers.push(eventType);
+  }
+  return blockers;
+}
+
+function isRequiredAuditEvent(
+  eventType: string,
+): eventType is RequiredPasskeyAuditEvent {
+  return REQUIRED_PASSKEY_AUDIT_EVENTS.includes(
+    eventType as RequiredPasskeyAuditEvent,
+  );
 }
 
 function maskEmail(email: string): string {

--- a/apps/admin/src/pages/auth/passkey.astro
+++ b/apps/admin/src/pages/auth/passkey.astro
@@ -54,6 +54,17 @@ import AdminLayout from "../../layouts/AdminLayout.astro";
     persistence, revoked credential denial, and unauthenticated blocking are
     proven.
   </p>
+
+  <section class="proof-checklist" aria-labelledby="passkey-proof-heading">
+    <div class="section-header">
+      <div>
+        <p>access removal proof</p>
+        <h2 id="passkey-proof-heading">passkey checklist</h2>
+      </div>
+      <span id="passkey-proof-summary">loading</span>
+    </div>
+    <div id="passkey-proof-list" class="proof-list" aria-live="polite"></div>
+  </section>
 </AdminLayout>
 
 <script>
@@ -86,6 +97,18 @@ import AdminLayout from "../../layouts/AdminLayout.astro";
     expected_origin: string;
     expected_rp_id: string;
     current_origin: string;
+    audit_events: Record<string, number>;
+    proof_items: PasskeyProofItem[];
+    access_removal_blockers: string[];
+    ready_for_access_removal: boolean;
+    next_safe_action: string;
+  };
+
+  type PasskeyProofItem = {
+    id: string;
+    label: string;
+    count: number;
+    complete: boolean;
     next_safe_action: string;
   };
 
@@ -97,6 +120,8 @@ import AdminLayout from "../../layouts/AdminLayout.astro";
   const sessionLabel = document.querySelector("#passkey-session");
   const nextLabel = document.querySelector("#passkey-next");
   const message = document.querySelector("#passkey-message");
+  const proofSummary = document.querySelector("#passkey-proof-summary");
+  const proofList = document.querySelector("#passkey-proof-list");
   const registerButton =
     document.querySelector<HTMLButtonElement>("#register-passkey");
   const loginButton =
@@ -133,6 +158,12 @@ import AdminLayout from "../../layouts/AdminLayout.astro";
     setText(credentialsLabel, String(status.credential_count));
     setText(auditLabel, String(status.audit_count));
     setText(
+      proofSummary,
+      status.ready_for_access_removal
+        ? "ready for Access removal"
+        : `${status.access_removal_blockers.length} blockers`,
+    );
+    setText(
       registerState,
       status.can_register
         ? "registration allowed"
@@ -144,6 +175,7 @@ import AdminLayout from "../../layouts/AdminLayout.astro";
     if (loginButton) loginButton.disabled = !status.available;
     if (logoutButton) logoutButton.disabled = !status.has_session;
     if (revokeButton) revokeButton.disabled = !status.has_session;
+    renderProofList();
   }
 
   async function register() {
@@ -222,11 +254,37 @@ import AdminLayout from "../../layouts/AdminLayout.astro";
     const data = (await response.json()) as TResponse;
     const apiData = data as ApiResult;
     if (!response.ok) {
-      throw new Error(
+      throw new ApiError(
         apiData.detail ?? apiData.error ?? `request failed: ${response.status}`,
+        apiData.next_safe_action,
       );
     }
     return data;
+  }
+
+  function renderProofList() {
+    if (!status || !proofList) return;
+    proofList.replaceChildren(
+      ...status.proof_items.map((item) => {
+        const row = document.createElement("article");
+        row.className = `proof-item ${item.complete ? "complete" : "blocked"}`;
+        row.innerHTML = `
+          <span class="proof-dot" aria-hidden="true"></span>
+          <span>
+            <strong></strong>
+            <small></small>
+          </span>
+          <code></code>
+        `;
+        const title = row.querySelector("strong");
+        const detail = row.querySelector("small");
+        const count = row.querySelector("code");
+        setText(title, item.label);
+        setText(detail, item.complete ? "recorded" : item.next_safe_action);
+        setText(count, String(item.count));
+        return row;
+      }),
+    );
   }
 
   function setBusy(busy: boolean) {
@@ -241,6 +299,19 @@ import AdminLayout from "../../layouts/AdminLayout.astro";
   }
 
   function errorMessage(error: unknown): string {
+    if (error instanceof ApiError && error.nextSafeAction) {
+      return error.nextSafeAction;
+    }
     return error instanceof Error ? error.message : "passkey request failed";
+  }
+
+  class ApiError extends Error {
+    nextSafeAction: string | undefined;
+
+    constructor(message: string, nextSafeAction: string | undefined) {
+      super(message);
+      this.name = "ApiError";
+      this.nextSafeAction = nextSafeAction;
+    }
   }
 </script>

--- a/apps/admin/src/styles/admin.css
+++ b/apps/admin/src/styles/admin.css
@@ -295,6 +295,64 @@ th {
   margin-top: 12px;
 }
 
+.proof-checklist {
+  margin-top: 24px;
+  border: 1px solid var(--border);
+  background: var(--panel);
+}
+
+.proof-checklist .section-header {
+  padding: 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.proof-list {
+  display: grid;
+}
+
+.proof-item {
+  display: grid;
+  grid-template-columns: 14px minmax(0, 1fr) auto;
+  gap: 12px;
+  align-items: center;
+  min-height: 58px;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.proof-item:last-child {
+  border-bottom: 0;
+}
+
+.proof-item strong,
+.proof-item small {
+  display: block;
+}
+
+.proof-item small {
+  color: var(--muted);
+  line-height: 1.45;
+}
+
+.proof-dot {
+  width: 10px;
+  height: 10px;
+  background: var(--risk);
+}
+
+.proof-item.complete .proof-dot {
+  background: var(--accent);
+}
+
+.proof-item code {
+  border: 1px solid var(--border);
+  background: var(--panel-strong);
+  color: var(--muted);
+  min-width: 34px;
+  padding: 6px 8px;
+  text-align: center;
+}
+
 .preview-grid {
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }


### PR DESCRIPTION
## summary
- add d1-backed passkey proof items to the admin passkey status API
- render the access-removal checklist on /auth/passkey
- preserve next_safe_action text when a blocked passkey proof API call still records useful proof

## verification
- pnpm turbo typecheck --filter=@anipotts/admin...
- pnpm turbo build --filter=@anipotts/admin...
- pnpm test:security-review
- pnpm exec prettier --check apps/admin/src/lib/passkey-auth.ts apps/admin/src/pages/auth/passkey.astro apps/admin/src/styles/admin.css && git diff --check
- local /api/admin/passkey/status reports seven access-removal blockers after local D1 passkey migration
- local /api/admin/passkey/register-options returns localhost WebAuthn platform-passkey options
- pnpm --silent proof:admin-passkey still reports production Cloudflare Access active with no credential/session yet

## live impact
- admin-only after merge/deploy
- no Cloudflare Access removal
- no secret/env/dns/write-path mutation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an access-removal readiness section to the passkey admin page with a proof checklist, per-item completion/blocking indicators, and an overall readiness summary.
  * Extended passkey status output to include audit coverage, proof items, blocker details, and “ready for access removal” state.
* **Bug Fixes**
  * Improved admin request error handling to surface the most relevant next action when an operation fails.
  * Kept passkey status summary data available even when required backend audit information is missing.
* **Style**
  * Added dedicated “proof checklist” styling for the new UI section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->