### PR TITLE
feat: seed homepage intro subheading in d1

### DIFF
--- a/docs/platform-architecture.md
+++ b/docs/platform-architecture.md
@@ -207,5 +207,8 @@ Rules:
 17. remove duplicate `homeContent` homepage fallback from `apps/www/src/data`;
     homepage fallback content now lives in `@anipotts/lib/cms`.
 18. stop auto-deploying `apps/admin-solid`; keep it manual-only for rollback.
-19. reduce deploy workflow inputs to retained production targets after rollback
+19. move homepage intro subheading into D1 `page_content`; seeded by
+    `drizzle/migrations/0019_seed_homepage_intro_subheading.sql` with source
+    fallback still retained.
+20. reduce deploy workflow inputs to retained production targets after rollback
     no longer needs `apps/admin-solid`.

--- a/drizzle/migrations/0019_seed_homepage_intro_subheading.sql
+++ b/drizzle/migrations/0019_seed_homepage_intro_subheading.sql
@@ -1,0 +1,42 @@
+-- 0019_seed_homepage_intro_subheading.sql
+-- Move the homepage intro subheading into the published D1 home row.
+--
+-- This keeps the source fallback in @anipotts/lib/cms and does not add save
+-- APIs, publish routes, deploy triggers, provider sync, sends, or write paths.
+--
+-- Rollback:
+--   UPDATE page_content
+--   SET
+--     content = json_remove(content, '$.sections.intro.subheading'),
+--     version = 6,
+--     updated_at = '2026-06-28T00:00:00Z'
+--   WHERE id = 'page-home-v1-2026-06-28'
+--     AND page_key = 'home';
+
+UPDATE page_content
+SET
+  content = json_set(
+    content,
+    '$.sections.intro.subheading',
+    'previously worked on real-time agent i/o at structured ai (YC F25) and our bad habit, an atlantic records venture. every now and then i post about what i''m doing with claude code and codex.'
+  ),
+  version = 7,
+  updated_at = '2026-06-29T00:00:00Z',
+  updated_by = 'codex',
+  version_history = json_insert(
+    CASE
+      WHEN json_valid(version_history) THEN version_history
+      ELSE '[]'
+    END,
+    '$[#]',
+    json_object(
+      'event',
+      'seeded',
+      'source',
+      'drizzle/migrations/0019_seed_homepage_intro_subheading.sql',
+      'summary',
+      'Moved homepage intro subheading into D1 page_content while preserving source fallback.'
+    )
+  )
+WHERE id = 'page-home-v1-2026-06-28'
+  AND page_key = 'home';

--- a/scripts/admin/content-proof.mjs
+++ b/scripts/admin/content-proof.mjs
@@ -145,9 +145,15 @@ const homeMentionCount = Number(
     (row) => String(row.page_key) === "home" && Number(row.published) === 1,
   )?.home_mention_count ?? 0,
 );
+const homeSubheadingType = String(
+  pageRows.find(
+    (row) => String(row.page_key) === "home" && Number(row.published) === 1,
+  )?.home_subheading_type ?? "missing",
+);
 
 const missingProof = [
   ...missingPageKeys.map((pageKey) => `published_page_content:${pageKey}`),
+  ...(homeSubheadingType === "text" ? [] : ["home_intro_subheading"]),
   ...(homeRichSummaryCount === 2 ? [] : ["home_rich_summary"]),
   ...(homeProofCardCount === 4 ? [] : ["home_proof_cards"]),
   ...(homeMakingSlugCount === 4 ? [] : ["home_making_slugs"]),


### PR DESCRIPTION
## summary
- add additive D1 migration 0019_seed_homepage_intro_subheading.sql
- move the homepage intro subheading into the published page_content home row while preserving source fallback
- tighten proof:admin-content so the D1 home row must include sections.intro.subheading
- update the platform cleanup sequence

## verification
- pnpm test:deploy-targets
- pnpm test:security-review
- pnpm test:workspace
- pnpm test:workflows
- pnpm exec prettier --check scripts/admin/content-proof.mjs docs/platform-architecture.md
- git diff --check
- node --check scripts/admin/content-proof.mjs
- sqlite3 temp migration smoke: subheading_type=text, version=7, history_count=1
- node scripts/ci/compute-deploy-targets.mjs /tmp/homepage-subheading-files.txt -> all deploy targets false
- node scripts/ci/security-review.mjs --required /tmp/homepage-subheading-files.txt -> security_review=true
- pnpm --silent proof:admin-content -> currently catches missing home_intro_subheading before migration apply

## deploy / migration
- expected app deploy targets: none
- after merge, apply reviewed D1 migration drizzle/migrations/0019_seed_homepage_intro_subheading.sql to anipotts-db, then rerun pnpm --silent proof:admin-content
- no save API, publish write, send path, provider sync, or route change