### PR TITLE
test: prove newsletter content fields

### DIFF
--- a/docs/platform-architecture.md
+++ b/docs/platform-architecture.md
@@ -119,8 +119,9 @@ identity headers.
 
 Use `pnpm --silent proof:admin-content` after content migrations. It reads only
 remote D1 metadata and route status, then proves published `home` and
-`newsletter` page content, the four inert draft operations, empty content write
-tables, public route health, and protected admin route boundaries.
+`newsletter` page content, the newsletter subscribe copy fields, the four inert
+draft operations, empty content write tables, public route health, and protected
+admin route boundaries.
 
 The admin proof log reads durable rows from D1 table `admin_proof_events` when
 available, then appends live D1 metadata for content operations and passkey

--- a/scripts/admin/content-proof.mjs
+++ b/scripts/admin/content-proof.mjs
@@ -63,7 +63,13 @@ SELECT
     THEN json_extract(content, '$.mentions.structuredAi.logoSrc')
     ELSE NULL
   END AS home_structured_ai_logo,
-  json_extract(content, '$.headline') AS newsletter_headline
+  json_extract(content, '$.headline') AS newsletter_headline,
+  coalesce(json_type(content, '$.deck'), 'missing') AS newsletter_deck_type,
+  coalesce(json_type(content, '$.cta_label'), 'missing') AS newsletter_cta_label_type,
+  coalesce(json_type(content, '$.success_message'), 'missing') AS newsletter_success_message_type,
+  coalesce(json_type(content, '$.error_message'), 'missing') AS newsletter_error_message_type,
+  coalesce(json_type(content, '$.footer_text'), 'missing') AS newsletter_footer_text_type,
+  json_extract(content, '$.buttondown_url') AS newsletter_buttondown_url
 FROM page_content
 ORDER BY page_key ASC, version DESC;
 `);
@@ -150,6 +156,13 @@ const homeSubheadingType = String(
     (row) => String(row.page_key) === "home" && Number(row.published) === 1,
   )?.home_subheading_type ?? "missing",
 );
+const newsletterRow = pageRows.find(
+  (row) => String(row.page_key) === "newsletter" && Number(row.published) === 1,
+);
+const newsletterFieldTypes = newsletterProofFieldTypes(newsletterRow);
+const missingNewsletterFields = Object.entries(newsletterFieldTypes)
+  .filter(([, type]) => type !== "text")
+  .map(([field]) => `newsletter_${field}`);
 
 const missingProof = [
   ...missingPageKeys.map((pageKey) => `published_page_content:${pageKey}`),
@@ -159,6 +172,7 @@ const missingProof = [
   ...(homeMakingSlugCount === 4 ? [] : ["home_making_slugs"]),
   ...(homeWritingSlugCount === 3 ? [] : ["home_writing_slugs"]),
   ...(homeMentionCount === 5 ? [] : ["home_mentions"]),
+  ...missingNewsletterFields,
   ...missingOperations.map((operationId) => `content_operation:${operationId}`),
   ...staleOperationSources.map(
     (operationId) => `stale_content_operation_source:${operationId}`,
@@ -210,6 +224,10 @@ const proof = {
         : Number(row.home_mention_count),
     home_structured_ai_logo: row.home_structured_ai_logo ?? null,
     newsletter_headline: row.newsletter_headline ?? null,
+    newsletter_field_types:
+      String(row.page_key) === "newsletter"
+        ? newsletterProofFieldTypes(row)
+        : null,
   })),
   content_draft_operations: operationRows.map((row) => ({
     operation_id: String(row.operation_id),
@@ -310,4 +328,24 @@ function summarizeBoundary(routes) {
   if (boundaries.has("cloudflare_access")) return "cloudflare_access";
   if (boundaries.has("app_native_passkey")) return "app_native_passkey";
   return "unknown";
+}
+
+function newsletterProofFieldTypes(row) {
+  return {
+    headline:
+      typeof row?.newsletter_headline === "string" &&
+      row.newsletter_headline.trim().length > 0
+        ? "text"
+        : "missing",
+    deck: String(row?.newsletter_deck_type ?? "missing"),
+    cta_label: String(row?.newsletter_cta_label_type ?? "missing"),
+    success_message: String(row?.newsletter_success_message_type ?? "missing"),
+    error_message: String(row?.newsletter_error_message_type ?? "missing"),
+    footer_text: String(row?.newsletter_footer_text_type ?? "missing"),
+    buttondown_url:
+      typeof row?.newsletter_buttondown_url === "string" &&
+      row.newsletter_buttondown_url.startsWith("https://")
+        ? "text"
+        : "missing",
+  };
 }


### PR DESCRIPTION
## summary
- tighten proof:admin-content for the published newsletter D1 row
- verify headline, deck, cta_label, success_message, error_message, footer_text, and buttondown_url as present public subscribe-copy fields
- document the stronger proof contract in docs/platform-architecture.md

## verification
- node --check scripts/admin/content-proof.mjs
- pnpm test:deploy-targets
- pnpm test:security-review
- pnpm test:workspace
- pnpm test:workflows
- pnpm exec prettier --check scripts/admin/content-proof.mjs docs/platform-architecture.md
- git diff --check
- node scripts/ci/compute-deploy-targets.mjs /tmp/newsletter-proof-files.txt -> all deploy targets false
- node scripts/ci/security-review.mjs --required /tmp/newsletter-proof-files.txt -> security_review=true
- pnpm --silent proof:admin-content -> newsletter_field_types all text, writes_inert true, missing_proof empty

## deploy
- expected app deploy targets: none
- no migration, save API, publish write, provider sync, send path, or route change
