### PR TITLE
feat: refresh admin proof events

### DIFF
--- a/apps/admin/src/data/proof.ts
+++ b/apps/admin/src/data/proof.ts
@@ -41,7 +41,7 @@ const baseProofEntries: ProofEntry[] = [
       "https://github.com/anipotts/anipotts.com/actions/workflows/deploy.yml",
     redaction: "public_metadata",
     next_safe_action:
-      "Keep deploy proof attached to admin route-level changes until proof rows move into D1.",
+      "Keep scoped deploy and skipped-target proof current in admin_proof_events after each admin route-level change.",
   },
   {
     id: "proof.site.public-routes",
@@ -70,14 +70,14 @@ const baseProofEntries: ProofEntry[] = [
   {
     id: "proof.admin.write-paths",
     kind: "gate",
-    status: "pending",
+    status: "verified",
     title: "admin write paths remain inert",
     summary:
       "Content preview, review, operations, mutation, and destructive-operation routes expose no save, publish, send, or live-control endpoint.",
     evidence_uri: "apps/admin/src/pages",
     redaction: "metadata_only",
     next_safe_action:
-      "Before adding writes, require audited D1 operation records, rollback, and route proof.",
+      "Keep content save, publish, send, and live-control endpoints absent until a reviewed write path is approved.",
   },
 ];
 

--- a/docs/platform-architecture.md
+++ b/docs/platform-architecture.md
@@ -211,5 +211,7 @@ Rules:
 19. move homepage intro subheading into D1 `page_content`; seeded by
     `drizzle/migrations/0019_seed_homepage_intro_subheading.sql` with source
     fallback still retained.
-20. reduce deploy workflow inputs to retained production targets after rollback
+20. refresh D1 admin proof event metadata now that the proof log is durable;
+    updated by `drizzle/migrations/0020_refresh_admin_proof_events.sql`.
+21. reduce deploy workflow inputs to retained production targets after rollback
     no longer needs `apps/admin-solid`.

--- a/drizzle/migrations/0020_refresh_admin_proof_events.sql
+++ b/drizzle/migrations/0020_refresh_admin_proof_events.sql
@@ -1,0 +1,53 @@
+-- 0020_refresh_admin_proof_events.sql
+-- Refresh durable admin proof metadata now that the proof log is D1-backed.
+--
+-- This updates proof row status and next-action metadata only. It does not add
+-- write APIs, deploy triggers, auth changes, Cloudflare Access changes,
+-- content publishes, sends, or live-control paths.
+--
+-- Rollback:
+--   UPDATE admin_proof_events
+--   SET
+--     next_safe_action = 'Keep deploy proof attached to admin route-level changes until proof rows move into D1.',
+--     source_ref = 'apps/admin/src/data/proof.ts',
+--     updated_at = '2026-06-28T00:00:00Z'
+--   WHERE id = 'proof.admin.agent-deploy-scope';
+--
+--   UPDATE admin_proof_events
+--   SET
+--     status = 'pending',
+--     next_safe_action = 'Before adding writes, require audited D1 operation records, rollback, and route proof.',
+--     source_ref = 'apps/admin/src/data/proof.ts',
+--     updated_at = '2026-06-28T00:00:00Z'
+--   WHERE id = 'proof.admin.write-paths';
+
+UPDATE admin_proof_events
+SET
+  next_safe_action = 'Keep scoped deploy and skipped-target proof current in admin_proof_events after each admin route-level change.',
+  source_ref = 'drizzle/migrations/0012_admin_proof_events.sql',
+  updated_at = '2026-06-29T00:00:00Z',
+  metadata = json_set(
+    CASE
+      WHEN json_valid(metadata) THEN metadata
+      ELSE '{}'
+    END,
+    '$.refreshed_by',
+    'drizzle/migrations/0020_refresh_admin_proof_events.sql'
+  )
+WHERE id = 'proof.admin.agent-deploy-scope';
+
+UPDATE admin_proof_events
+SET
+  status = 'verified',
+  next_safe_action = 'Keep content save, publish, send, and live-control endpoints absent until a reviewed write path is approved.',
+  source_ref = 'apps/admin/src/pages/api and scripts/admin/content-proof.mjs',
+  updated_at = '2026-06-29T00:00:00Z',
+  metadata = json_set(
+    CASE
+      WHEN json_valid(metadata) THEN metadata
+      ELSE '{}'
+    END,
+    '$.refreshed_by',
+    'drizzle/migrations/0020_refresh_admin_proof_events.sql'
+  )
+WHERE id = 'proof.admin.write-paths';


### PR DESCRIPTION
## summary
- add D1 migration 0020_refresh_admin_proof_events.sql
- refresh stale D1-backed admin proof metadata after proof rows became durable
- mark admin write-path proof verified because the current admin API surface has no content save, publish, send, or live-control endpoint
- update matching Astro admin fallback proof text and platform cleanup map

## verification
- sqlite3 temp migration smoke: deploy proof and write-path rows refreshed
- pnpm exec prettier --check apps/admin/src/data/proof.ts docs/platform-architecture.md
- git diff --check
- pnpm test:deploy-targets
- pnpm test:security-review
- pnpm test:workspace
- pnpm test:workflows
- pnpm test:admin-routes
- pnpm turbo typecheck --filter=@anipotts/admin...
- pnpm turbo build --filter=@anipotts/admin...
- pnpm --silent proof:admin-content
- node scripts/ci/compute-deploy-targets.mjs /tmp/admin-proof-refresh-files.txt -> admin=true only
- node scripts/ci/security-review.mjs --required /tmp/admin-proof-refresh-files.txt -> security_review=true
- node scripts/ci/security-review.mjs /tmp/admin-proof-refresh-files.txt

## deploy / migration
- expected app deploy target: admin only
- after merge, apply reviewed D1 migration drizzle/migrations/0020_refresh_admin_proof_events.sql to anipotts-db
- no write APIs, auth changes, Cloudflare Access changes, publish paths, sends, or live controls
