### PR TITLE
feat: guide admin passkey proof

### DIFF
--- a/apps/admin/src/pages/auth/passkey.astro
+++ b/apps/admin/src/pages/auth/passkey.astro
@@ -55,6 +55,17 @@ import AdminLayout from "../../layouts/AdminLayout.astro";
     proven.
   </p>
 
+  <section class="runbook-board" aria-labelledby="passkey-runbook-heading">
+    <div class="section-header">
+      <div>
+        <p>production sequence</p>
+        <h2 id="passkey-runbook-heading">Access removal runbook</h2>
+      </div>
+      <span id="passkey-runbook-summary">loading</span>
+    </div>
+    <ol id="passkey-runbook" class="runbook-list" aria-live="polite"></ol>
+  </section>
+
   <section class="proof-checklist" aria-labelledby="passkey-proof-heading">
     <div class="section-header">
       <div>
@@ -112,6 +123,12 @@ import AdminLayout from "../../layouts/AdminLayout.astro";
     next_safe_action: string;
   };
 
+  type PasskeyRunbookStep = {
+    label: string;
+    detail: string;
+    complete: boolean;
+  };
+
   const dbLabel = document.querySelector("#passkey-db");
   const originLabel = document.querySelector("#passkey-origin");
   const credentialsLabel = document.querySelector("#passkey-credentials");
@@ -120,6 +137,8 @@ import AdminLayout from "../../layouts/AdminLayout.astro";
   const sessionLabel = document.querySelector("#passkey-session");
   const nextLabel = document.querySelector("#passkey-next");
   const message = document.querySelector("#passkey-message");
+  const runbookSummary = document.querySelector("#passkey-runbook-summary");
+  const runbookList = document.querySelector("#passkey-runbook");
   const proofSummary = document.querySelector("#passkey-proof-summary");
   const proofList = document.querySelector("#passkey-proof-list");
   const registerButton =
@@ -175,6 +194,7 @@ import AdminLayout from "../../layouts/AdminLayout.astro";
     if (loginButton) loginButton.disabled = !status.available;
     if (logoutButton) logoutButton.disabled = !status.has_session;
     if (revokeButton) revokeButton.disabled = !status.has_session;
+    renderRunbook();
     renderProofList();
   }
 
@@ -285,6 +305,104 @@ import AdminLayout from "../../layouts/AdminLayout.astro";
         return row;
       }),
     );
+  }
+
+  function renderRunbook() {
+    if (!status || !runbookList) return;
+    const steps = buildRunbookSteps(status);
+    const firstOpenStep = steps.find((step) => !step.complete);
+    setText(
+      runbookSummary,
+      firstOpenStep ? `next: ${firstOpenStep.label}` : "ready to remove Access",
+    );
+    runbookList.replaceChildren(
+      ...steps.map((step, index) => {
+        const row = document.createElement("li");
+        row.className = `runbook-step ${step.complete ? "complete" : "open"}`;
+        row.innerHTML = `
+          <span class="step-index"></span>
+          <span>
+            <strong></strong>
+            <small></small>
+          </span>
+        `;
+        setText(row.querySelector(".step-index"), String(index + 1));
+        setText(row.querySelector("strong"), step.label);
+        setText(row.querySelector("small"), step.detail);
+        return row;
+      }),
+    );
+  }
+
+  function buildRunbookSteps(
+    currentStatus: PasskeyStatus,
+  ): PasskeyRunbookStep[] {
+    const events = currentStatus.audit_events;
+    const registered = events["passkey.credential.registered"] > 0;
+    const sessionCreated = events["passkey.session.created"] > 0;
+    const sessionRevoked = events["passkey.session.revoked"] > 0;
+    const credentialRevoked = events["passkey.credential.revoked"] > 0;
+    const denied = events["passkey.authentication.denied"] > 0;
+    const activeCredential = currentStatus.credential_count > 0;
+    const activeSession = currentStatus.has_session;
+
+    return [
+      {
+        label: "enter through Cloudflare Access",
+        detail: currentStatus.access_identity_present
+          ? `Access identity verified as ${currentStatus.access_identity_hint ?? "admin user"}.`
+          : "sign in through Access once so first registration is allowed.",
+        complete:
+          currentStatus.access_identity_present ||
+          activeCredential ||
+          activeSession,
+      },
+      {
+        label: "register platform passkey",
+        detail: activeCredential
+          ? "active credential exists in D1."
+          : "use register passkey and finish the biometric prompt.",
+        complete: activeCredential && registered,
+      },
+      {
+        label: "create app-native session",
+        detail: activeSession
+          ? "active session exists in D1."
+          : "use authenticate after registration.",
+        complete: activeSession && sessionCreated,
+      },
+      {
+        label: "prove persistence",
+        detail: activeSession
+          ? "reload a protected admin route and confirm it still renders."
+          : "authenticate first so protected routes can prove session reuse.",
+        complete: activeSession,
+      },
+      {
+        label: "prove logout and recovery",
+        detail:
+          sessionRevoked && activeSession
+            ? "logout proof exists and a replacement session is active."
+            : "logout once, then authenticate again before continuing.",
+        complete: sessionRevoked && activeSession,
+      },
+      {
+        label: "prove revoked credential denial",
+        detail:
+          credentialRevoked && denied && activeCredential && activeSession
+            ? "revoked credential denial exists and replacement access is live."
+            : "revoke current passkey, attempt authenticate, then register and authenticate a replacement.",
+        complete:
+          credentialRevoked && denied && activeCredential && activeSession,
+      },
+      {
+        label: "remove Cloudflare Access",
+        detail: currentStatus.ready_for_access_removal
+          ? "rerun proof, remove Access, then verify app-native blocking."
+          : currentStatus.next_safe_action,
+        complete: currentStatus.ready_for_access_removal,
+      },
+    ];
   }
 
   function setBusy(busy: boolean) {

--- a/apps/admin/src/styles/admin.css
+++ b/apps/admin/src/styles/admin.css
@@ -295,21 +295,31 @@ th {
   margin-top: 12px;
 }
 
+.runbook-board,
 .proof-checklist {
   margin-top: 24px;
   border: 1px solid var(--border);
   background: var(--panel);
 }
 
+.runbook-board .section-header,
 .proof-checklist .section-header {
   padding: 16px;
   border-bottom: 1px solid var(--border);
 }
 
+.runbook-list,
 .proof-list {
   display: grid;
 }
 
+.runbook-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.runbook-step,
 .proof-item {
   display: grid;
   grid-template-columns: 14px minmax(0, 1fr) auto;
@@ -320,18 +330,38 @@ th {
   border-bottom: 1px solid var(--border);
 }
 
+.runbook-step {
+  grid-template-columns: 34px minmax(0, 1fr);
+}
+
+.runbook-step:last-child,
 .proof-item:last-child {
   border-bottom: 0;
 }
 
+.runbook-step strong,
+.runbook-step small,
 .proof-item strong,
 .proof-item small {
   display: block;
 }
 
+.runbook-step small,
 .proof-item small {
   color: var(--muted);
   line-height: 1.45;
+}
+
+.step-index {
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  border: 1px solid var(--border);
+  background: var(--panel-strong);
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 800;
 }
 
 .proof-dot {
@@ -340,8 +370,10 @@ th {
   background: var(--risk);
 }
 
+.runbook-step.complete .step-index,
 .proof-item.complete .proof-dot {
   background: var(--accent);
+  color: #101010;
 }
 
 .proof-item code {

--- a/scripts/ci/admin-route-parity.test.mjs
+++ b/scripts/ci/admin-route-parity.test.mjs
@@ -72,6 +72,10 @@ const ROUTES = [
 ];
 
 const navSource = readFileSync("apps/admin/src/data/admin.ts", "utf8");
+const passkeySource = readFileSync(
+  "apps/admin/src/pages/auth/passkey.astro",
+  "utf8",
+);
 const deployWorkflow = readFileSync(".github/workflows/deploy.yml", "utf8");
 const smokeWorkflow = readFileSync(".github/workflows/smoke.yml", "utf8");
 const deploySmokeRoutes = extractShellForRoutes(deployWorkflow);
@@ -97,6 +101,18 @@ for (const route of ROUTES) {
       `${route.route} missing from smoke.yml admin route proof`,
     );
   }
+}
+
+for (const marker of [
+  "Access removal runbook",
+  "passkey-runbook",
+  "buildRunbookSteps",
+  "ready_for_access_removal",
+]) {
+  assert.ok(
+    passkeySource.includes(marker),
+    `/auth/passkey missing proof runbook marker ${marker}`,
+  );
 }
 
 function extractShellForRoutes(source) {


### PR DESCRIPTION
## summary
- add a live Access removal runbook to the Astro admin passkey page
- derive the operator sequence from the existing passkey status API
- guard the runbook markers in admin route parity tests

## verification
- pnpm exec prettier --check apps/admin/src/pages/auth/passkey.astro apps/admin/src/styles/admin.css scripts/ci/admin-route-parity.test.mjs
- git diff --check
- pnpm test:admin-routes
- pnpm test:deploy-targets
- pnpm test:security-review
- pnpm turbo typecheck --filter=@anipotts/admin...
- pnpm turbo build --filter=@anipotts/admin...
- local route probe: /auth/passkey contains runbook markers, /api/admin/passkey/status returns 200, protected local routes redirect to /auth/passkey

## deploy target
- admin=true only
- www/admin-solid/workers=false

## live impact
- none until merged and deployed