### PR TITLE
feat: add inert admin content draft editor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,7 @@ For `admin.anipotts.com`, use this order:
 4. prove passkey register, login, logout, session persistence, and blocked
    failure paths
 5. prove `/auth/passkey`, `/`, `/content`, `/content/review`,
-   `/content/preview`, `/content/operations`, `/newsletter`,
+   `/content/drafts`, `/content/preview`, `/content/operations`, `/newsletter`,
    `/newsletter/first-thing-agents-need-control-plane`, `/needs-ani`, and
    `/proof`
 6. remove Cloudflare Access only after proof passes

--- a/apps/admin/src/data/admin.ts
+++ b/apps/admin/src/data/admin.ts
@@ -22,6 +22,7 @@ export const navItems: NavItem[] = [
   { href: "/", label: "overview", status: "migrating" },
   { href: "/content", label: "content", status: "live-source" },
   { href: "/content/review", label: "review", status: "live-source" },
+  { href: "/content/drafts", label: "drafts", status: "live-source" },
   { href: "/content/preview", label: "preview", status: "live-source" },
   { href: "/content/operations", label: "operations", status: "live-source" },
   { href: "/newsletter", label: "newsletter", status: "live-source" },
@@ -49,9 +50,9 @@ export const overviewCards: DashboardCard[] = [
   },
   {
     title: "content platform",
-    status: "read-only inventory",
+    status: "inert draft editor",
     risk: "medium",
-    next: "move editable fields into D1-backed draft records",
+    next: "prove draft review shape before enabling audited save routes",
   },
   {
     title: "proof log",

--- a/apps/admin/src/pages/content/drafts.astro
+++ b/apps/admin/src/pages/content/drafts.astro
@@ -1,0 +1,201 @@
+---
+import AdminLayout from "../../layouts/AdminLayout.astro";
+import {
+  contentOperationTemplates,
+  readContentOperationStore,
+  readPageContentInventoryStore,
+} from "../../data/content";
+
+const operationState = await readContentOperationStore(
+  Astro.locals.runtime?.env.DB,
+);
+const pageContentState = await readPageContentInventoryStore(
+  Astro.locals.runtime?.env.DB,
+);
+const operations =
+  operationState.operations.length > 0
+    ? operationState.operations
+    : contentOperationTemplates;
+const writableRows = operationState.counts.filter(
+  (row) =>
+    row.table_name === "content_records" ||
+    row.table_name === "content_publish_events",
+);
+const writeRowsEmpty = writableRows.every((row) => row.rows === 0);
+---
+
+<AdminLayout
+  title="content drafts"
+  deck="Field-level draft editor shape. Inputs are inert until save and publish paths are audited."
+>
+  <section class="meta-strip" aria-label="content draft editor state">
+    <span>{operations.length} draft operations</span>
+    <span>{pageContentState.published_count} published page rows</span>
+    <span>{operationState.mode}</span>
+    <span>{writeRowsEmpty ? "writes empty" : "writes present"}</span>
+    <span>controls disabled</span>
+  </section>
+
+  <section class="table-card operation-card">
+    <div class="section-head">
+      <div>
+        <p>editor gate</p>
+        <h2>{writeRowsEmpty ? "safe preview shape" : "review write rows"}</h2>
+      </div>
+      <span>no save route</span>
+    </div>
+    <div class="record-list">
+      <article class="record-row">
+        <div>
+          <p>write state</p>
+          <h3>
+            {
+              writeRowsEmpty
+                ? "content_records and content_publish_events are empty"
+                : "write tables contain rows and need review"
+            }
+          </h3>
+        </div>
+        <dl>
+          {
+            operationState.counts.map((row) => (
+              <div>
+                <dt>{row.table_name}</dt>
+                <dd>{row.rows} rows</dd>
+              </div>
+            ))
+          }
+        </dl>
+      </article>
+    </div>
+  </section>
+
+  <div class="draft-editor-grid">
+    {
+      operations.map((operation) => (
+        <article class="draft-editor-card">
+          <div class="section-head">
+            <div>
+              <p>
+                {operation.surface} / {operation.status}
+              </p>
+              <h2>{operation.field_path}</h2>
+            </div>
+            <span>{operation.risk_level}</span>
+          </div>
+          <form class="draft-form" aria-label={`${operation.field_path} draft`}>
+            <label>
+              <span>operation</span>
+              <input value={operation.operation_id} disabled />
+            </label>
+            <label>
+              <span>route</span>
+              <input value={operation.route} disabled />
+            </label>
+            <label class="wide-field">
+              <span>source</span>
+              <textarea rows="2" disabled>
+                {operation.source_ref}
+              </textarea>
+            </label>
+            <label class="wide-field">
+              <span>current</span>
+              <textarea rows="3" disabled>
+                {operation.current_value_ref}
+              </textarea>
+            </label>
+            <label class="wide-field">
+              <span>draft preview</span>
+              <textarea rows="5" disabled>
+                {operation.proposed_value}
+              </textarea>
+            </label>
+            <div class="draft-control-row">
+              <button class="button secondary" type="button" disabled>
+                save draft
+              </button>
+              <button class="button secondary" type="button" disabled>
+                request review
+              </button>
+              <button class="button secondary danger" type="button" disabled>
+                publish
+              </button>
+            </div>
+          </form>
+          <dl class="draft-proof-grid">
+            <div>
+              <dt>authority</dt>
+              <dd>{operation.authority_state}</dd>
+            </div>
+            <div>
+              <dt>allowed</dt>
+              <dd>{operation.allowed_actions.join(", ")}</dd>
+            </div>
+            <div>
+              <dt>blocked</dt>
+              <dd>{operation.forbidden_actions.join(", ")}</dd>
+            </div>
+            <div>
+              <dt>proof</dt>
+              <dd>{operation.proof_ids.join(", ")}</dd>
+            </div>
+            <div>
+              <dt>rollback</dt>
+              <dd>{operation.rollback_ref}</dd>
+            </div>
+          </dl>
+        </article>
+      ))
+    }
+  </div>
+
+  <section class="table-card operation-card">
+    <div class="section-head">
+      <div>
+        <p>page_content fields</p>
+        <h2>{pageContentState.row_count} records</h2>
+      </div>
+      <span>{pageContentState.mode}</span>
+    </div>
+    <div class="record-list">
+      {
+        pageContentState.rows.map((row) => (
+          <article class="record-row">
+            <div>
+              <p>
+                {row.page_key} / v{row.version}
+              </p>
+              <h3>{row.summary}</h3>
+            </div>
+            <div class="field-grid">
+              {row.fields.slice(0, 12).map((field) => (
+                <label class="field-chip field-input-chip">
+                  <span>{field.path}</span>
+                  <input value={field.value} disabled />
+                  <small>{field.kind}</small>
+                </label>
+              ))}
+              {row.fields.length > 12 && (
+                <div class="field-chip muted-chip">
+                  <span>more</span>
+                  <strong>{row.fields.length - 12} fields hidden</strong>
+                  <small>truncated</small>
+                </div>
+              )}
+            </div>
+          </article>
+        ))
+      }
+    </div>
+  </section>
+
+  {
+    (operationState.mode === "read_failed" ||
+      pageContentState.mode === "read_failed") && (
+      <section class="notice">
+        D1 read failed. Static draft controls remained disabled and no write was
+        attempted.
+      </section>
+    )
+  }
+</AdminLayout>

--- a/apps/admin/src/styles/admin.css
+++ b/apps/admin/src/styles/admin.css
@@ -389,8 +389,16 @@ th {
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
+.draft-editor-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+  margin-top: 24px;
+}
+
 .table-card,
-.proposal-row {
+.proposal-row,
+.draft-editor-card {
   border: 1px solid var(--border);
   background: var(--panel);
 }
@@ -590,6 +598,76 @@ dd {
   padding: 16px;
 }
 
+.draft-form {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  padding: 16px;
+}
+
+.draft-form label {
+  display: grid;
+  gap: 6px;
+  min-width: 0;
+}
+
+.draft-form label span {
+  color: var(--muted);
+  font-size: 11px;
+  text-transform: uppercase;
+}
+
+.draft-form input,
+.draft-form textarea,
+.field-input-chip input {
+  width: 100%;
+  min-width: 0;
+  border: 1px solid var(--border);
+  background: #111;
+  color: var(--text);
+  font: inherit;
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.draft-form input,
+.field-input-chip input {
+  min-height: 38px;
+  padding: 8px 10px;
+}
+
+.draft-form textarea {
+  resize: vertical;
+  padding: 10px;
+}
+
+.draft-form input:disabled,
+.draft-form textarea:disabled,
+.field-input-chip input:disabled,
+.draft-control-row .button:disabled {
+  cursor: not-allowed;
+  opacity: 0.72;
+}
+
+.wide-field,
+.draft-control-row {
+  grid-column: 1 / -1;
+}
+
+.draft-control-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.draft-proof-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  margin: 0;
+  padding: 0 16px 16px;
+}
+
 .diff-pair {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -787,12 +865,15 @@ dd {
   }
 
   .preview-grid,
+  .draft-editor-grid,
   .lane-grid,
   .newsletter-detail,
   .newsletter-preview-layout,
   .record-row dl,
   .need-row dl,
   .proposal-row dl,
+  .draft-form,
+  .draft-proof-grid,
   .diff-pair {
     grid-template-columns: 1fr;
   }

--- a/docs/content-admin-editor-brief.md
+++ b/docs/content-admin-editor-brief.md
@@ -28,6 +28,9 @@ or any live write path.
 Admin `/content` now renders the D1 `page_content` rows and bundled read-only
 metadata from the project and writing markdown collections. It still does not
 add a save endpoint, publish endpoint, provider sync, or source file mutation.
+Admin `/content/drafts` renders the first inert draft-editor shape with disabled
+controls backed by `page_content` and `content_draft_operations`. It is an
+editor surface model only, not a write path.
 The D1 review queue includes inert homepage, newsletter, project, and writing
 operations seeded by `drizzle/migrations/0008_seed_content_draft_operations.sql`
 and `drizzle/migrations/0011_seed_source_content_review_operations.sql`.

--- a/docs/platform-architecture.md
+++ b/docs/platform-architecture.md
@@ -66,6 +66,7 @@ smoke list, and manual smoke list for this parity set.
 | `/auth/passkey`                                     | app-native passkey auth              |
 | `/content`                                          | content inventory                    |
 | `/content/review`                                   | content proposal queue               |
+| `/content/drafts`                                   | inert draft editor surface           |
 | `/content/preview`                                  | draft preview                        |
 | `/content/operations`                               | read-only D1 content operation state |
 | `/newsletter`                                       | newsletter issue queue               |
@@ -105,9 +106,9 @@ revoked-credential denial. It reports missing pre-removal evidence in
 `access_removal_blockers`; `cloudflare_access_still_active: true` is expected
 until the edge gate is removed, not a blocker by itself. After Access removal,
 the same script must show app-native route blocking. The route probe set must
-include content inventory, review, preview, operations, newsletter queue,
-newsletter detail preview, needs-ani, proof, repos, handoffs, fleet, mutations,
-and destructive-ops routes.
+include content inventory, review, drafts, preview, operations, newsletter
+queue, newsletter detail preview, needs-ani, proof, repos, handoffs, fleet,
+mutations, and destructive-ops routes.
 
 First-passkey bootstrap in production requires a verified Cloudflare Access
 application JWT from `Cf-Access-Jwt-Assertion`. The admin Worker validates it
@@ -240,5 +241,7 @@ Rules:
     `/making`, `/projects`, `/writing`, `/newsletter/archive`, and
     `/orchestrating`; seeded by
     `drizzle/migrations/0028_seed_listing_content_review_operations.sql`.
-29. reduce deploy workflow inputs to retained production targets after rollback
+29. add a first-class inert `/content/drafts` admin route with disabled editor
+    controls backed by page_content and content_draft_operations.
+30. reduce deploy workflow inputs to retained production targets after rollback
     no longer needs `apps/admin-solid`.

--- a/scripts/admin/content-proof.mjs
+++ b/scripts/admin/content-proof.mjs
@@ -43,6 +43,7 @@ const REQUIRED_OPERATIONS = [
 const ADMIN_ROUTES = [
   "/content",
   "/content/review",
+  "/content/drafts",
   "/content/preview",
   "/content/operations",
   "/proof",

--- a/scripts/admin/passkey-proof.mjs
+++ b/scripts/admin/passkey-proof.mjs
@@ -10,6 +10,7 @@ const ROUTES = [
   "/",
   "/content",
   "/content/review",
+  "/content/drafts",
   "/content/preview",
   "/content/operations",
   "/needs-ani",
@@ -83,7 +84,7 @@ const routeBoundary = summarizeBoundary(routes);
 const missingAuditEvents = REQUIRED_AUDIT_EVENTS.filter(
   (eventType) => !auditEvents[eventType],
 );
-const accessRemovalBlockers = accessRemovalBlockerItems({
+const removalBlockers = accessRemovalBlockerItems({
   schemaReady,
   credentialCount,
   sessionCount,
@@ -92,7 +93,7 @@ const accessRemovalBlockers = accessRemovalBlockerItems({
 const cloudflareAccessStillActive = routeBoundary === "cloudflare_access";
 const appNativeRouteBoundaryReady = routeBoundary === "app_native_passkey";
 const missingProof = missingProofItems({
-  accessRemovalBlockers,
+  accessRemovalBlockers: removalBlockers,
   routeBoundary,
 });
 
@@ -114,13 +115,13 @@ const proof = {
       Number(auditEvents[eventType] ?? 0),
     ]),
   ),
-  access_removal_blockers: accessRemovalBlockers,
+  access_removal_blockers: removalBlockers,
   cloudflare_access_still_active: cloudflareAccessStillActive,
   missing_proof: missingProof,
   ready_for_access_removal:
-    accessRemovalBlockers.length === 0 && cloudflareAccessStillActive,
+    removalBlockers.length === 0 && cloudflareAccessStillActive,
   post_access_removal_verified:
-    accessRemovalBlockers.length === 0 && appNativeRouteBoundaryReady,
+    removalBlockers.length === 0 && appNativeRouteBoundaryReady,
   routes,
   route_boundary: routeBoundary,
   next_safe_action: nextSafeAction({
@@ -248,10 +249,7 @@ function nextSafeAction({
   return "inspect route boundary before changing Access";
 }
 
-function missingProofItems({
-  accessRemovalBlockers,
-  routeBoundary,
-}) {
+function missingProofItems({ accessRemovalBlockers, routeBoundary }) {
   const missing = [...accessRemovalBlockers];
   if (routeBoundary === "cloudflare_access") return missing;
   if (routeBoundary !== "app_native_passkey") {

--- a/scripts/ci/admin-route-parity.test.mjs
+++ b/scripts/ci/admin-route-parity.test.mjs
@@ -21,6 +21,12 @@ const ROUTES = [
     nav: true,
   },
   {
+    route: "/content/drafts",
+    file: "apps/admin/src/pages/content/drafts.astro",
+    nav: true,
+    smoke: false,
+  },
+  {
     route: "/content/preview",
     file: "apps/admin/src/pages/content/preview.astro",
     nav: true,


### PR DESCRIPTION
## summary
- add /content/drafts as a protected Astro admin route with disabled editor controls for D1-backed content draft operations
- wire the route into admin nav, route parity, content proof, passkey proof, and platform docs
- keep save, publish, D1 writes, auth changes, DNS changes, workflow changes, and outbound actions absent

## verification
- pnpm turbo typecheck --filter=@anipotts/admin...
- pnpm turbo build --filter=@anipotts/admin...
- node scripts/ci/compute-deploy-targets.mjs /tmp/admin-content-drafts-route-files.txt => admin=true, all other targets false
- prettier --check on touched files
- git diff --check
- pnpm test:deploy-targets
- pnpm test:security-review
- pnpm test:workflows
- pnpm test:admin-routes
- pnpm test:workspace
- node scripts/ci/security-review.mjs --required /tmp/admin-content-drafts-route-files.txt && node scripts/ci/security-review.mjs /tmp/admin-content-drafts-route-files.txt => security_review=true, passed for 3 sensitive files
- node --check scripts/admin/content-proof.mjs
- node --check scripts/admin/passkey-proof.mjs
- local /content/drafts unauthenticated route proof returned 302 to /auth/passkey
- pnpm --silent proof:admin-content => missing_proof=[] with /content/drafts route boundary covered
- pnpm --silent proof:admin-passkey => still blocked by missing first passkey proof

## live impact
Expected after merge: admin deploy only. No D1 migration, no write endpoint, no content mutation, no publish event, no auth/DNS/env/secrets change, no worker deploy, no www deploy, no admin-solid deploy.

Note: workflow smoke lists were not changed in this PR because the available git credential cannot push workflow-file edits. The route is still covered by route parity, content proof, passkey proof, local unauthenticated proof, and post-deploy manual curl proof.