### PR TITLE
ci: smoke admin content drafts route

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -210,7 +210,7 @@ jobs:
       - name: Smoke admin unauthenticated block
         run: |
           set -euo pipefail
-          for path in /auth/passkey / /content /content/review /content/preview /content/operations /newsletter /newsletter/first-thing-agents-need-control-plane /needs-ani /proof /repos /handoffs /fleet /mutations /ops/destructive; do
+          for path in /auth/passkey / /content /content/review /content/drafts /content/preview /content/operations /newsletter /newsletter/first-thing-agents-need-control-plane /needs-ani /proof /repos /handoffs /fleet /mutations /ops/destructive; do
             ok=false
             for _ in $(seq 1 6); do
               code="$(curl -sS -o /dev/null -w '%{http_code}' "https://admin.anipotts.com${path}")"

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -43,7 +43,7 @@ jobs:
         if: inputs.target == 'admin'
         run: |
           set -euo pipefail
-          for path in /auth/passkey / /content /content/review /content/preview /content/operations /newsletter /newsletter/first-thing-agents-need-control-plane /needs-ani /proof /repos /handoffs /fleet /mutations /ops/destructive; do
+          for path in /auth/passkey / /content /content/review /content/drafts /content/preview /content/operations /newsletter /newsletter/first-thing-agents-need-control-plane /needs-ani /proof /repos /handoffs /fleet /mutations /ops/destructive; do
             code="$(curl -sS -o /dev/null -w '%{http_code}' "https://admin.anipotts.com${path}")"
             echo "https://admin.anipotts.com${path} -> ${code}"
             case "$path:$code" in

--- a/scripts/ci/admin-route-parity.test.mjs
+++ b/scripts/ci/admin-route-parity.test.mjs
@@ -24,7 +24,6 @@ const ROUTES = [
     route: "/content/drafts",
     file: "apps/admin/src/pages/content/drafts.astro",
     nav: true,
-    smoke: false,
   },
   {
     route: "/content/preview",


### PR DESCRIPTION
## summary
- add /content/drafts to the deploy admin unauthenticated smoke route set
- add /content/drafts to the manual smoke workflow route set
- require the route in admin route parity smoke coverage again

## verification
- pnpm exec prettier --write .github/workflows/deploy.yml .github/workflows/smoke.yml scripts/ci/admin-route-parity.test.mjs
- git diff --check
- node scripts/ci/compute-deploy-targets.mjs /tmp/admin-drafts-smoke-files.txt => all targets false
- pnpm test:workflows
- pnpm test:admin-routes
- pnpm test:deploy-targets
- pnpm test:security-review
- pnpm test:workspace
- node scripts/ci/security-review.mjs --required /tmp/admin-drafts-smoke-files.txt && node scripts/ci/security-review.mjs /tmp/admin-drafts-smoke-files.txt

## live impact
Workflow-only smoke coverage. Expected deploy targets: none. No app code, D1, auth, DNS, secrets, env, worker, www, admin, or admin-solid deploy.