### PR TITLE
fix: make content package exports importable

### DIFF
--- a/packages/content/src/admin/index.ts
+++ b/packages/content/src/admin/index.ts
@@ -1,3 +1,3 @@
-export * from "./content";
-export * from "./newsletter";
-export * from "./operations";
+export * from "./content.js";
+export * from "./newsletter.js";
+export * from "./operations.js";

--- a/packages/content/src/index.ts
+++ b/packages/content/src/index.ts
@@ -1,1 +1,1 @@
-export * from "./admin";
+export * from "./admin/index.js";

--- a/scripts/ci/content-platform.test.mjs
+++ b/scripts/ci/content-platform.test.mjs
@@ -1,10 +1,13 @@
 #!/usr/bin/env node
 
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { contentInventorySource } from "../../packages/content/dist/admin/index.js";
 import {
   contentOperationTables,
   contentOperationTemplates,
 } from "../../packages/content/dist/admin/operations.js";
+import { contentInventorySource as rootContentInventorySource } from "../../packages/content/dist/index.js";
 
 const EXPECTED_OPERATION_IDS = [
   "content-draft-homepage-summary-2026-06-28",
@@ -29,6 +32,27 @@ const UNSAFE_ALLOWED_ACTIONS = new Set([
   "sync_provider",
   "sync_external",
 ]);
+
+assert.equal(
+  contentInventorySource.mode,
+  "read_only_static_plus_d1_page_content",
+);
+assert.equal(
+  rootContentInventorySource.mode,
+  "read_only_static_plus_d1_page_content",
+);
+assert.equal(
+  execFileSync(
+    process.execPath,
+    [
+      "-e",
+      "import('@anipotts/content/admin').then((mod) => process.stdout.write(mod.contentInventorySource.mode))",
+    ],
+    { cwd: "apps/admin", encoding: "utf8" },
+  ),
+  "read_only_static_plus_d1_page_content",
+  "apps/admin must be able to import @anipotts/content/admin from the built package export",
+);
 
 assert.deepEqual(
   contentOperationTemplates.map((operation) => operation.operation_id).sort(),


### PR DESCRIPTION
## summary
- emit explicit .js re-exports from @anipotts/content root and admin entrypoints
- extend the content-platform invariant to import built root/admin entrypoints and verify apps/admin can resolve @anipotts/content/admin
- preserve the 9-operation inert content fallback check from PR #191

## verification
- pnpm test:content-platform
- pnpm turbo typecheck --filter=@anipotts/admin...
- pnpm turbo build --filter=@anipotts/admin...
- pnpm test:security-review
- node scripts/ci/security-review.mjs with changed files
- pnpm format:check
- git diff --check
- pnpm test:deploy-targets

## deploy
- expected deploy target: admin=true only
- no save API, publish route, send path, source mutation, env change, DNS change, or Access change
