### PR TITLE
test: guard public app boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Validate admin route parity
         run: pnpm test:admin-routes
 
+      - name: Validate public app boundary
+        run: pnpm test:public-boundary
+
       - name: Validate content platform invariants
         run: pnpm test:content-platform
 

--- a/docs/platform-architecture.md
+++ b/docs/platform-architecture.md
@@ -65,6 +65,13 @@ covered while passkey proof and Access removal are completed, then remove
 `pnpm test:admin-routes` enforces the route files, admin navigation, deploy
 smoke list, and manual smoke list for this parity set.
 
+`pnpm test:public-boundary` enforces the public app boundary for `apps/www`.
+The public app may render public CMS/D1 content, run newsletter subscribe
+endpoints, redirect `/admin/*` to `admin.anipotts.com`, and proxy PostHog
+analytics through `/ingest/*`. It must not add admin routes, admin API routes,
+passkey logic, Cloudflare Access identity handling, proof tables, content draft
+operation tables, or publish-event tables.
+
 | Route                                               | Purpose                              |
 | --------------------------------------------------- | ------------------------------------ |
 | `/`                                                 | operator overview                    |

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "test:deploy-targets": "node scripts/ci/compute-deploy-targets.test.mjs",
     "test:admin-routes": "node scripts/ci/admin-route-parity.test.mjs",
     "test:content-platform": "pnpm --filter @anipotts/content build && node scripts/ci/content-platform.test.mjs",
+    "test:public-boundary": "node scripts/ci/public-app-boundary.test.mjs",
     "test:workspace": "node scripts/ci/workspace-inventory.test.mjs",
     "test:workflows": "node scripts/ci/workflow-inventory.test.mjs",
     "test:security-review": "node scripts/ci/security-review.test.mjs",

--- a/scripts/ci/public-app-boundary.test.mjs
+++ b/scripts/ci/public-app-boundary.test.mjs
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+
+const WWW_ROOT = "apps/www";
+const WWW_SRC = join(WWW_ROOT, "src");
+const WWW_PAGES = join(WWW_SRC, "pages");
+
+const ALLOWED_API_ROUTES = [
+  "health",
+  "icon",
+  "newsletter/confirm",
+  "newsletter/subscribe",
+  "newsletter/unsubscribe",
+  "newsletter/webhooks/resend",
+  "search",
+  "subscribe",
+];
+
+const FORBIDDEN_PAGE_SEGMENTS = new Set([
+  "admin",
+  "auth",
+  "fleet",
+  "handoffs",
+  "mutations",
+  "ops",
+  "proof",
+  "repos",
+]);
+
+const FORBIDDEN_SOURCE_PATTERNS = [
+  {
+    pattern: /@anipotts\/content\/admin\b/,
+    message: "apps/www must not import admin content package entrypoints",
+  },
+  {
+    pattern: /@anipotts\/lib\/admin\b/,
+    message: "apps/www must not import admin lib entrypoints",
+  },
+  {
+    pattern: /\badmin_passkey_[a-z_]+\b/,
+    message: "apps/www must not touch admin passkey tables directly",
+  },
+  {
+    pattern: /\badmin_proof_events\b/,
+    message: "apps/www must not touch admin proof tables directly",
+  },
+  {
+    pattern: /\bcontent_draft_operations\b/,
+    message: "apps/www must not touch admin content draft operations directly",
+  },
+  {
+    pattern: /\bcontent_publish_events\b/,
+    message: "apps/www must not touch content publish events directly",
+  },
+  {
+    pattern: /\bcontent_records\b/,
+    message: "apps/www must not touch future content write records directly",
+  },
+  {
+    pattern: /Cf-Access-Jwt-Assertion/i,
+    message: "apps/www must not read Cloudflare Access identity headers",
+  },
+  {
+    pattern: /\bACCESS_POLICY_AUD\b/,
+    message: "apps/www must not depend on admin Access policy config",
+  },
+  {
+    pattern: /\bACCESS_TEAM_DOMAIN\b/,
+    message: "apps/www must not depend on admin Access team config",
+  },
+  {
+    pattern: /\/api\/admin\//,
+    message: "apps/www must not call or expose admin API routes",
+  },
+];
+
+const files = listFiles(WWW_SRC);
+const pageFiles = files.filter((file) => file.startsWith(`${WWW_PAGES}/`));
+const apiRoutes = pageFiles
+  .filter((file) => file.startsWith(`${WWW_PAGES}/api/`))
+  .map((file) => stripPageExtension(relative(`${WWW_PAGES}/api`, file)))
+  .sort();
+
+assert.deepEqual(
+  apiRoutes,
+  ALLOWED_API_ROUTES,
+  "apps/www API surface must stay public-only and explicitly allowlisted",
+);
+
+for (const file of pageFiles) {
+  const routePath = stripPageExtension(relative(WWW_PAGES, file));
+  const firstSegment = routePath.split("/")[0];
+  assert.equal(
+    FORBIDDEN_PAGE_SEGMENTS.has(firstSegment),
+    false,
+    `${file} puts an admin/control segment under the public app`,
+  );
+}
+
+const ingestProxy = "apps/www/src/pages/ingest/[...path].ts";
+assert.ok(existsSync(ingestProxy), "posthog ingest proxy must be explicit");
+const ingestSource = readFileSync(ingestProxy, "utf8");
+assert.match(
+  ingestSource,
+  /posthog reverse proxy/i,
+  "ingest proxy must stay documented as analytics-only",
+);
+assert.match(
+  ingestSource,
+  /us-assets\.i\.posthog\.com/,
+  "ingest static asset proxy must target PostHog assets",
+);
+assert.match(
+  ingestSource,
+  /us\.i\.posthog\.com/,
+  "ingest event proxy must target PostHog ingest",
+);
+for (const pattern of [
+  /\bD1Database\b/,
+  /\bDB\b/,
+  /\.prepare\(/,
+  /\bNEWSLETTER_QUEUE\b/,
+  /@anipotts\/lib\/admin\b/,
+]) {
+  assert.equal(
+    pattern.test(ingestSource),
+    false,
+    `ingest proxy must not grow local state or admin behavior: ${pattern}`,
+  );
+}
+
+const sourceFiles = files.filter((file) =>
+  /\.(astro|[cm]?[jt]sx?)$/.test(file),
+);
+for (const file of sourceFiles) {
+  if (file.startsWith(`${WWW_SRC}/content/`)) continue;
+  const source = readFileSync(file, "utf8");
+  for (const { pattern, message } of FORBIDDEN_SOURCE_PATTERNS) {
+    assert.equal(pattern.test(source), false, `${file}: ${message}`);
+  }
+}
+
+const wrangler = readFileSync("apps/www/wrangler.toml", "utf8");
+for (const marker of [
+  "ACCESS_POLICY_AUD",
+  "ACCESS_TEAM_DOMAIN",
+  "ADMIN_PASSKEY",
+  "admin.anipotts.com",
+]) {
+  assert.equal(
+    wrangler.includes(marker),
+    false,
+    `apps/www wrangler config must not include admin boundary marker ${marker}`,
+  );
+}
+
+function listFiles(root) {
+  const entries = readdirSync(root, { withFileTypes: true });
+  return entries.flatMap((entry) => {
+    const path = join(root, entry.name);
+    if (entry.isDirectory()) return listFiles(path);
+    if (entry.isFile() || statSync(path).isFile()) return [path];
+    return [];
+  });
+}
+
+function stripPageExtension(file) {
+  return file.replace(/\.(astro|[cm]?[jt]sx?)$/, "");
+}


### PR DESCRIPTION
## summary
- add `pnpm test:public-boundary` to keep `apps/www` public-only
- allow only the current public API surface plus the documented PostHog `/ingest/*` proxy
- wire the guard into CI and document the boundary in `docs/platform-architecture.md`

## verification
- `pnpm test:public-boundary`
- `pnpm test:admin-routes`
- `pnpm test:content-platform`
- `pnpm test:workspace`
- `pnpm test:workflows`
- `pnpm test:deploy-targets`
- `pnpm test:security-review`
- changed-file security review against 4 changed files
- `pnpm format:check`
- `git diff --check`

## deploy
- no app deploy target expected: CI/docs/root script guard only
