### PR TITLE
ci: cover stable public smoke routes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Validate public app boundary
         run: pnpm test:public-boundary
 
+      - name: Validate public route smoke parity
+        run: pnpm test:public-routes
+
       - name: Validate content platform invariants
         run: pnpm test:content-platform
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -154,7 +154,7 @@ jobs:
       - name: Smoke www routes
         run: |
           set -euo pipefail
-          for path in / /projects /writing /newsletter; do
+          for path in / /newsletter /newsletter/archive /making /orchestrating /projects /writing; do
             ok=false
             for _ in $(seq 1 6); do
               code="$(curl -sS -o /dev/null -w '%{http_code}' "https://anipotts.com${path}")"

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -32,7 +32,7 @@ jobs:
         if: inputs.target == 'www'
         run: |
           set -euo pipefail
-          for path in / /projects /writing /newsletter; do
+          for path in / /newsletter /newsletter/archive /making /orchestrating /projects /writing; do
             code="$(curl -sS -o /dev/null -w '%{http_code}' "https://anipotts.com${path}")"
             echo "https://anipotts.com${path} -> ${code}"
             test "$code" = "200"

--- a/docs/platform-architecture.md
+++ b/docs/platform-architecture.md
@@ -169,6 +169,9 @@ Rules:
 - `packages/lib` and `packages/styles` changes deploy `www` only because
   `apps/admin` does not depend on them.
 - `deploy.yml` records route proof inside the `www` and `admin` deploy jobs.
+  `pnpm test:public-routes` keeps deploy smoke, manual smoke, and content proof
+  aligned on the public route set: `/`, `/newsletter`, `/newsletter/archive`,
+  `/making`, `/orchestrating`, `/projects`, and `/writing`.
 - D1 migrations run as reviewed migration steps before app deploy.
 - `security-review.yml` does not call Anthropic, Claude Code, or any external
   model API. It scans sensitive diffs for literal secrets, disabled LLM review

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "lint": "turbo lint",
     "typecheck": "turbo typecheck",
     "clean": "turbo clean && rm -rf node_modules",
-    "format": "prettier --write \"**/*.{astro,ts,tsx,md,json}\"",
-    "format:check": "prettier --check \"**/*.{astro,ts,tsx,md,json}\"",
+    "format": "prettier --write \"**/*.{astro,ts,tsx,mjs,md,json}\"",
+    "format:check": "prettier --check \"**/*.{astro,ts,tsx,mjs,md,json}\"",
     "dev:www": "turbo dev --filter=@anipotts/www",
     "proof:admin-passkey": "node scripts/admin/passkey-proof.mjs",
     "proof:admin-content": "node scripts/admin/content-proof.mjs",
@@ -30,6 +30,7 @@
     "test:admin-routes": "node scripts/ci/admin-route-parity.test.mjs",
     "test:content-platform": "pnpm --filter @anipotts/content build && node scripts/ci/content-platform.test.mjs",
     "test:public-boundary": "node scripts/ci/public-app-boundary.test.mjs",
+    "test:public-routes": "node scripts/ci/public-route-parity.test.mjs",
     "test:workspace": "node scripts/ci/workspace-inventory.test.mjs",
     "test:workflows": "node scripts/ci/workflow-inventory.test.mjs",
     "test:security-review": "node scripts/ci/security-review.test.mjs",
@@ -49,6 +50,12 @@
       "prettier --write"
     ],
     "packages/**/*.{ts,tsx}": [
+      "prettier --write"
+    ],
+    "scripts/**/*.mjs": [
+      "prettier --write"
+    ],
+    "packages/**/*.mjs": [
       "prettier --write"
     ],
     "*.{json,md,yml}": [

--- a/packages/config/tailwind/base.config.mjs
+++ b/packages/config/tailwind/base.config.mjs
@@ -17,7 +17,7 @@ export default {
         },
         signal: {
           green: "#4ade80", // green-400
-          red: "#ef4444",   // red-500
+          red: "#ef4444", // red-500
         },
         border: {
           DEFAULT: "var(--border)",
@@ -49,17 +49,15 @@ export default {
         heading: ["var(--font-display)", "var(--font-mono)", "monospace"],
       },
       animation: {
-        'signal-pulse': 'signal-pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite',
+        "signal-pulse": "signal-pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite",
       },
       keyframes: {
-        'signal-pulse': {
-          '0%, 100%': { opacity: '1' },
-          '50%': { opacity: '0.4' },
-        }
-      }
+        "signal-pulse": {
+          "0%, 100%": { opacity: "1" },
+          "50%": { opacity: "0.4" },
+        },
+      },
     },
   },
-  plugins: [
-    require('@tailwindcss/typography'),
-  ],
+  plugins: [require("@tailwindcss/typography")],
 };

--- a/scripts/ci/admin-route-parity.test.mjs
+++ b/scripts/ci/admin-route-parity.test.mjs
@@ -173,10 +173,9 @@ function extractShellForRoutes(source) {
 
 function extractStringList(source, name) {
   const match =
-    source.match(new RegExp(`const ${name} = new Set\\(\\[([\\s\\S]*?)\\]\\);`)) ??
-    source.match(new RegExp(`const ${name} = \\[([\\s\\S]*?)\\];`));
+    source.match(
+      new RegExp(`const ${name} = new Set\\(\\[([\\s\\S]*?)\\]\\);`),
+    ) ?? source.match(new RegExp(`const ${name} = \\[([\\s\\S]*?)\\];`));
   assert.ok(match, `missing middleware list ${name}`);
-  return [...match[1].matchAll(/"([^"]+)"/g)]
-    .map((item) => item[1])
-    .sort();
+  return [...match[1].matchAll(/"([^"]+)"/g)].map((item) => item[1]).sort();
 }

--- a/scripts/ci/public-route-parity.test.mjs
+++ b/scripts/ci/public-route-parity.test.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+
+const PUBLIC_ROUTES = [
+  { route: "/", file: "apps/www/src/pages/index.astro" },
+  { route: "/newsletter", file: "apps/www/src/pages/newsletter.astro" },
+  {
+    route: "/newsletter/archive",
+    file: "apps/www/src/pages/newsletter/archive.astro",
+  },
+  { route: "/making", file: "apps/www/src/pages/making.astro" },
+  { route: "/orchestrating", file: "apps/www/src/pages/orchestrating.astro" },
+  { route: "/projects", file: "apps/www/src/pages/projects/index.astro" },
+  { route: "/writing", file: "apps/www/src/pages/writing/index.astro" },
+];
+
+const deployWorkflow = readFileSync(".github/workflows/deploy.yml", "utf8");
+const smokeWorkflow = readFileSync(".github/workflows/smoke.yml", "utf8");
+const contentProof = readFileSync("scripts/admin/content-proof.mjs", "utf8");
+
+const expected = PUBLIC_ROUTES.map((item) => item.route).sort();
+const deploySmokeRoutes = extractRoutesFromStep(
+  deployWorkflow,
+  "Smoke www routes",
+);
+const manualSmokeRoutes = extractRoutesFromStep(
+  smokeWorkflow,
+  "Smoke public site",
+);
+const contentProofRoutes = extractConstList(contentProof, "PUBLIC_ROUTES");
+
+for (const { route, file } of PUBLIC_ROUTES) {
+  assert.ok(existsSync(file), `${route} missing route file ${file}`);
+}
+
+assert.deepEqual(
+  deploySmokeRoutes,
+  expected,
+  "deploy.yml public smoke routes must match the stable public route proof set",
+);
+
+assert.deepEqual(
+  manualSmokeRoutes,
+  expected,
+  "smoke.yml public smoke routes must match the stable public route proof set",
+);
+
+assert.deepEqual(
+  contentProofRoutes,
+  expected,
+  "content-proof public route probes must match the stable public route proof set",
+);
+
+function extractRoutesFromStep(source, stepName) {
+  const stepStart = source.indexOf(`name: ${stepName}`);
+  assert.notEqual(stepStart, -1, `missing workflow step ${stepName}`);
+  const fromStep = source.slice(stepStart);
+  const match = fromStep.match(/for path in ([^;]+); do/);
+  assert.ok(match, `${stepName} must use an explicit public route loop`);
+  return match[1]
+    .trim()
+    .split(/\s+/)
+    .filter((route) => route.startsWith("/"))
+    .sort();
+}
+
+function extractConstList(source, name) {
+  const match = source.match(new RegExp(`const ${name} = \\[([\\s\\S]*?)\\];`));
+  assert.ok(match, `missing const list ${name}`);
+  return [...match[1].matchAll(/"([^"]+)"/g)].map((item) => item[1]).sort();
+}

--- a/scripts/ci/security-review.test.mjs
+++ b/scripts/ci/security-review.test.mjs
@@ -32,10 +32,7 @@ assert.equal(
   true,
 );
 
-assert.equal(
-  requiresSecurityReview(["docs/platform-architecture.md"]),
-  false,
-);
+assert.equal(requiresSecurityReview(["docs/platform-architecture.md"]), false);
 
 const fakeFiles = new Map([
   [
@@ -71,17 +68,11 @@ const findings = reviewFiles(
   readFake,
 );
 
-assert.deepEqual(
-  findings.map((finding) => finding.rule).sort(),
-  [
-    "anthropic-api-key",
-    "drop-table",
-    "inline-secret-assignment",
-    "openai-or-similar-key",
-  ],
-);
+assert.deepEqual(findings.map((finding) => finding.rule).sort(), [
+  "anthropic-api-key",
+  "drop-table",
+  "inline-secret-assignment",
+  "openai-or-similar-key",
+]);
 
-assert.deepEqual(
-  reviewFiles([".github/workflows/deploy.yml"], readFake),
-  [],
-);
+assert.deepEqual(reviewFiles([".github/workflows/deploy.yml"], readFake), []);

--- a/scripts/claude/generate-claude-stats.mjs
+++ b/scripts/claude/generate-claude-stats.mjs
@@ -221,10 +221,9 @@ function calculateFastestCommitCadence(repos) {
   for (const repo of repos) {
     let output;
     try {
-      output = execSync(
-        `git -C "${repo}" log ${sinceArg} --pretty=%ct`,
-        { stdio: ["ignore", "pipe", "ignore"] },
-      )
+      output = execSync(`git -C "${repo}" log ${sinceArg} --pretty=%ct`, {
+        stdio: ["ignore", "pipe", "ignore"],
+      })
         .toString()
         .trim();
     } catch (error) {
@@ -261,8 +260,7 @@ function calculateFastestCommitCadence(repos) {
 const MAX_SESSION_MINUTES = 360;
 
 const mineDbPath =
-  process.env.MINE_DB_PATH ||
-  path.join(os.homedir(), ".claude", "mine.db");
+  process.env.MINE_DB_PATH || path.join(os.homedir(), ".claude", "mine.db");
 
 /** Query mine.db for authoritative headline stats (sessions, hours, streak). */
 function queryMineDb() {
@@ -280,9 +278,13 @@ function queryMineDb() {
         WHERE is_subagent = 0
       "`,
       { stdio: ["ignore", "pipe", "ignore"] },
-    ).toString().trim();
+    )
+      .toString()
+      .trim();
 
-    const [sessions, hoursWall, hoursActive, toolCalls] = raw.split("|").map(Number);
+    const [sessions, hoursWall, hoursActive, toolCalls] = raw
+      .split("|")
+      .map(Number);
 
     // Subagent stats
     const subRaw = execSync(
@@ -291,7 +293,9 @@ function queryMineDb() {
         FROM sessions WHERE is_subagent = 1
       "`,
       { stdio: ["ignore", "pipe", "ignore"] },
-    ).toString().trim();
+    )
+      .toString()
+      .trim();
     const [subSessions, subToolCalls] = subRaw.split("|").map(Number);
 
     // Streak (consecutive days with activity ending today or yesterday)
@@ -309,7 +313,9 @@ function queryMineDb() {
         SELECT COUNT(*) FROM streak WHERE days_ago = rn - 1 OR (rn = 1 AND days_ago <= 1)
       "`,
       { stdio: ["ignore", "pipe", "ignore"] },
-    ).toString().trim();
+    )
+      .toString()
+      .trim();
     const streakDays = Number(streakRaw) || 0;
 
     // Project count
@@ -318,7 +324,9 @@ function queryMineDb() {
         SELECT COUNT(DISTINCT project_name) FROM sessions WHERE is_subagent = 0
       "`,
       { stdio: ["ignore", "pipe", "ignore"] },
-    ).toString().trim();
+    )
+      .toString()
+      .trim();
     const projectCount = Number(projectsRaw) || 0;
 
     return {
@@ -331,7 +339,10 @@ function queryMineDb() {
       subagents: { sessions: subSessions, toolCalls: subToolCalls },
     };
   } catch (error) {
-    console.warn("Could not query mine.db, falling back to JSONL scan:", error.message);
+    console.warn(
+      "Could not query mine.db, falling back to JSONL scan:",
+      error.message,
+    );
     return null;
   }
 }
@@ -396,7 +407,10 @@ async function main() {
     for (const f of session.filesMutated) allFiles.add(f);
 
     // Accumulate hours (capped per session to exclude stale/overnight)
-    const cappedMinutes = Math.min(session.durationMinutes, MAX_SESSION_MINUTES);
+    const cappedMinutes = Math.min(
+      session.durationMinutes,
+      MAX_SESSION_MINUTES,
+    );
     totalHoursUsed += cappedMinutes / 60;
 
     const dailyEntry = dailyMap.get(dayKey) || { toolCalls: 0, files: 0 };
@@ -487,9 +501,10 @@ async function main() {
       project: session.project,
       start: session.startTime.toISOString(),
       end: session.endTime.toISOString(),
-      durationMinutes: Math.round(
-        Math.min(session.durationMinutes, MAX_SESSION_MINUTES) * 10,
-      ) / 10,
+      durationMinutes:
+        Math.round(
+          Math.min(session.durationMinutes, MAX_SESSION_MINUTES) * 10,
+        ) / 10,
       toolCalls: session.toolCalls,
       filesMutated: session.filesMutated.size,
     })),


### PR DESCRIPTION
## summary
- expand deploy/manual www smoke to cover `/newsletter/archive`, `/making`, and `/orchestrating` in addition to the prior public routes
- add `pnpm test:public-routes` so deploy smoke, manual smoke, and content proof stay aligned
- include `.mjs` files in format coverage and format existing `.mjs` drift

## verification
- `pnpm test:public-routes`
- `pnpm test:public-boundary`
- `pnpm test:admin-routes`
- `pnpm test:content-platform`
- `pnpm test:workspace`
- `pnpm test:workflows`
- `pnpm test:deploy-targets`
- `pnpm test:security-review`
- changed-file security review against 10 changed files
- `pnpm format:check`
- `git diff --check`

## deploy
- no app deploy target expected: workflow/test/docs formatting guard only
