### PR TITLE
ci: unify deploy target detection

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -79,35 +79,31 @@ jobs:
     name: Detect changed paths
     runs-on: ubuntu-latest
     outputs:
-      www: ${{ steps.filter.outputs.www }}
-      admin: ${{ steps.filter.outputs.admin }}
-      ingest: ${{ steps.filter.outputs.ingest }}
-      newsletter: ${{ steps.filter.outputs.newsletter }}
-      state: ${{ steps.filter.outputs.state }}
-      weekly-email: ${{ steps.filter.outputs.weekly-email }}
+      www: ${{ steps.targets.outputs.www || 'false' }}
+      admin: ${{ steps.targets.outputs.admin || 'false' }}
+      ingest: ${{ steps.targets.outputs.ingest || 'false' }}
+      newsletter: ${{ steps.targets.outputs.newsletter || 'false' }}
+      state: ${{ steps.targets.outputs.state || 'false' }}
+      weekly-email: ${{ steps.targets.outputs.weekly_email || 'false' }}
     steps:
       - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
-        if: github.event_name == 'push'
-        id: filter
         with:
-          filters: |
-            www:
-              - "apps/www/**"
-              - "packages/lib/**"
-              - "packages/styles/**"
-              - "packages/types/**"
-            admin:
-              - "apps/admin/**"
-              - "packages/content/**"
-            ingest:
-              - "workers/ingest/**"
-            newsletter:
-              - "workers/newsletter/**"
-            state:
-              - "workers/state/**"
-            weekly-email:
-              - "workers/weekly-email/**"
+          fetch-depth: 0
+
+      - name: Compute deploy targets
+        if: github.event_name == 'push'
+        id: targets
+        run: |
+          set -euo pipefail
+          files="$RUNNER_TEMP/deploy-changed-files.txt"
+
+          if [ "${{ github.event.before }}" = "0000000000000000000000000000000000000000" ]; then
+            git diff-tree --no-commit-id --name-only -r "${{ github.sha }}" > "$files"
+          else
+            git diff --name-only "${{ github.event.before }}" "${{ github.sha }}" > "$files"
+          fi
+
+          node scripts/ci/compute-deploy-targets.mjs "$files" | tee "$GITHUB_OUTPUT"
 
   deploy-www:
     name: Deploy www

--- a/docs/platform-architecture.md
+++ b/docs/platform-architecture.md
@@ -168,6 +168,9 @@ Rules:
   workflow-dispatch only for rollback while passkey proof is incomplete.
 - `packages/lib` and `packages/styles` changes deploy `www` only because
   `apps/admin` does not depend on them.
+- `agent-automerge.yml` and `deploy.yml` both use
+  `scripts/ci/compute-deploy-targets.mjs`; target rules should not be duplicated
+  in workflow-local path filters.
 - `deploy.yml` records route proof inside the `www` and `admin` deploy jobs.
   `pnpm test:public-routes` keeps deploy smoke, manual smoke, and content proof
   aligned on the public route set: `/`, `/newsletter`, `/newsletter/archive`,

--- a/scripts/ci/compute-deploy-targets.test.mjs
+++ b/scripts/ci/compute-deploy-targets.test.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import { computeDeployTargets } from "./compute-deploy-targets.mjs";
 
 const empty = {
@@ -30,6 +31,12 @@ expectTargets(
     ".github/ISSUE_TEMPLATE/bug.md",
     "LICENSE",
   ],
+  {},
+);
+
+expectTargets(
+  "worker docs plus workflow-only changes do not deploy",
+  ["workers/state/README.md", ".github/workflows/deploy.yml"],
   {},
 );
 
@@ -71,6 +78,14 @@ expectTargets(
 );
 
 expectTargets(
+  "worker readme with worker source deploys exact worker",
+  ["workers/state/README.md", "workers/state/src/index.ts"],
+  {
+    state: true,
+  },
+);
+
+expectTargets(
   "shared runtime packages deploy www only",
   ["packages/lib/src/cms/index.ts", "packages/styles/src/tokens.css"],
   { www: true },
@@ -86,4 +101,17 @@ expectTargets(
   "mixed app and worker changes preserve exact targets",
   ["apps/admin/src/pages/proof.astro", "workers/newsletter/src/index.ts"],
   { admin: true, newsletter: true },
+);
+
+const deployWorkflow = readFileSync(".github/workflows/deploy.yml", "utf8");
+
+assert.ok(
+  deployWorkflow.includes("node scripts/ci/compute-deploy-targets.mjs"),
+  "deploy.yml must use the shared deploy target calculator",
+);
+
+assert.equal(
+  deployWorkflow.includes("dorny/paths-filter"),
+  false,
+  "deploy.yml must not duplicate target rules through paths-filter",
 );


### PR DESCRIPTION
## summary
- make `deploy.yml` use `scripts/ci/compute-deploy-targets.mjs` for push deploy detection
- remove the duplicated `dorny/paths-filter` target list from deploy workflow logic
- add tests that prevent workflow-local path filters from coming back and cover docs/workflow-only no-deploy cases

## verification
- `pnpm test:deploy-targets`
- `pnpm test:workflows`
- `pnpm test:security-review`
- `pnpm test:public-routes`
- `pnpm test:admin-routes`
- `pnpm test:public-boundary`
- `pnpm test:content-platform`
- `pnpm test:workspace`
- changed-file security review against 3 changed files
- `pnpm format:check`
- `git diff --check`

## deploy
- no app deploy target expected: workflow/test/docs only
