### PR TITLE
chore: guard active local paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Validate public route smoke parity
         run: pnpm test:public-routes
 
+      - name: Validate active path hygiene
+        run: pnpm test:path-hygiene
+
       - name: Validate content platform invariants
         run: pnpm test:content-platform
 

--- a/docs/platform-architecture.md
+++ b/docs/platform-architecture.md
@@ -8,6 +8,10 @@ structured content/state model, and one predictable CI/CD path.
 `pnpm test:workspace` enforces the active app, package, and worker inventory so
 archived surfaces do not re-enter the workspace quietly.
 
+`pnpm test:path-hygiene` keeps active repo files off retired local account paths.
+Historical references may remain under `docs/archive`, but live scripts and
+launchd templates must point at `/Users/anipotts`.
+
 ## target state
 
 | Surface        | Target                              | Status              | Next action                                           |

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "test:content-platform": "pnpm --filter @anipotts/content build && node scripts/ci/content-platform.test.mjs",
     "test:public-boundary": "node scripts/ci/public-app-boundary.test.mjs",
     "test:public-routes": "node scripts/ci/public-route-parity.test.mjs",
+    "test:path-hygiene": "node scripts/ci/path-hygiene.test.mjs",
     "test:workspace": "node scripts/ci/workspace-inventory.test.mjs",
     "test:workflows": "node scripts/ci/workflow-inventory.test.mjs",
     "test:security-review": "node scripts/ci/security-review.test.mjs",

--- a/scripts/ci/path-hygiene.test.mjs
+++ b/scripts/ci/path-hygiene.test.mjs
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { readFileSync, statSync } from "node:fs";
+
+const ALLOW_PREFIXES = ["docs/archive/"];
+const RETIRED_ACCOUNT_PATH = "/Users/" + "rudy";
+const FORBIDDEN_ACTIVE_LITERALS = [
+  {
+    value: RETIRED_ACCOUNT_PATH,
+    message:
+      "active repo files must not point at the retired local account path",
+  },
+];
+
+const files = execFileSync("git", ["ls-files"], { encoding: "utf8" })
+  .split(/\r?\n/)
+  .filter(Boolean);
+
+for (const file of files) {
+  if (ALLOW_PREFIXES.some((prefix) => file.startsWith(prefix))) {
+    continue;
+  }
+  if (statSync(file).size > 2 * 1024 * 1024) continue;
+
+  const source = readFileSync(file, "utf8");
+  for (const literal of FORBIDDEN_ACTIVE_LITERALS) {
+    assert.equal(
+      source.includes(literal.value),
+      false,
+      `${file}: ${literal.message}`,
+    );
+  }
+}

--- a/scripts/mini/README.md
+++ b/scripts/mini/README.md
@@ -7,7 +7,7 @@ Scripts that run on `ap-mini` and POST events to the state worker
 
 ```bash
 # 1. Pull the repo on Mini (one time)
-ssh mini "cd ~/Code/projects && git clone https://github.com/anipotts/anipotts.com.git"
+ssh mini "cd ~/Code/projects && git clone https://github.com/anipotts/anipotts.com.git anipotts-com"
 
 # 2. Generate a publish key (any random string)
 KEY=$(openssl rand -hex 32)
@@ -17,7 +17,7 @@ ssh mini "mkdir -p ~/.anipotts && echo '$KEY' > ~/.anipotts/state-publish.key &&
 echo -n "$KEY" | wrangler secret put STATE_PUBLISH_KEY --config workers/state/wrangler.toml
 
 # 4. Symlink the plist into LaunchAgents on Mini
-ssh mini 'ln -sf ~/Code/projects/anipotts.com/scripts/mini/com.anipotts.publisher.commits.plist ~/Library/LaunchAgents/com.anipotts.publisher.commits.plist'
+ssh mini 'ln -sf ~/Code/projects/anipotts-com/scripts/mini/com.anipotts.publisher.commits.plist ~/Library/LaunchAgents/com.anipotts.publisher.commits.plist'
 
 # 5. Patch the launchd plist to source the key (one time)
 # launchd plists do not interpolate from files, so wrap the script in a

--- a/scripts/mini/com.anipotts.publisher.commits.plist
+++ b/scripts/mini/com.anipotts.publisher.commits.plist
@@ -8,7 +8,7 @@
     <key>ProgramArguments</key>
     <array>
         <string>/opt/homebrew/bin/bun</string>
-        <string>/Users/rudy/Code/projects/anipotts.com/scripts/mini/commit-publisher.ts</string>
+        <string>/Users/anipotts/Code/projects/anipotts-com/scripts/mini/commit-publisher.ts</string>
     </array>
 
     <key>EnvironmentVariables</key>
@@ -18,7 +18,7 @@
         <key>STATE_API</key>
         <string>https://api.anipotts.com</string>
         <key>COMMIT_ROOTS</key>
-        <string>/Users/rudy/Code/projects</string>
+        <string>/Users/anipotts/Code/projects</string>
     </dict>
 
     <key>StartInterval</key>
@@ -28,9 +28,9 @@
     <true/>
 
     <key>StandardOutPath</key>
-    <string>/Users/rudy/Library/Logs/anipotts/commit-publisher.out.log</string>
+    <string>/Users/anipotts/Library/Logs/anipotts/commit-publisher.out.log</string>
 
     <key>StandardErrorPath</key>
-    <string>/Users/rudy/Library/Logs/anipotts/commit-publisher.err.log</string>
+    <string>/Users/anipotts/Library/Logs/anipotts/commit-publisher.err.log</string>
 </dict>
 </plist>


### PR DESCRIPTION
## summary
- update active mini commit-publisher docs/templates from retired local account paths to /Users/anipotts and the anipotts-com repo directory
- add a tracked path-hygiene test so active repo files cannot regress to retired local account paths
- wire the check into CI and document the active-path rule

## verification
- pnpm test:path-hygiene
- pnpm test:workspace
- pnpm test:workflows
- pnpm test:deploy-targets
- pnpm test:security-review
- pnpm test:public-routes
- pnpm test:public-boundary
- pnpm test:admin-routes
- pnpm test:content-platform
- pnpm format:check
- git diff --check

## deploy impact
- expected deploy targets: none
- no live launchd, root, DNS, env, secret, app deploy, or Cloudflare mutation
