### PR TITLE
feat: clarify passkey enrollment handoff

### DIFF
--- a/apps/admin/src/pages/auth/passkey.astro
+++ b/apps/admin/src/pages/auth/passkey.astro
@@ -55,6 +55,53 @@ import AdminLayout from "../../layouts/AdminLayout.astro";
     proven.
   </p>
 
+  <section class="handoff-board" aria-labelledby="passkey-handoff-heading">
+    <div class="section-header">
+      <div>
+        <p>operator handoff</p>
+        <h2 id="passkey-handoff-heading">biometric proof sequence</h2>
+      </div>
+      <span>requires a real browser passkey prompt</span>
+    </div>
+    <ol class="handoff-list">
+      <li>
+        <strong>open this route through Cloudflare Access</strong>
+        <small>Access identity unlocks the first credential registration.</small
+        >
+      </li>
+      <li>
+        <strong>register passkey</strong>
+        <small
+          >finish the platform biometric prompt and wait for D1 status.</small
+        >
+      </li>
+      <li>
+        <strong>authenticate</strong>
+        <small>create the first app-native admin session.</small>
+      </li>
+      <li>
+        <strong>open a protected route</strong>
+        <small>reload content or proof to prove session persistence.</small>
+      </li>
+      <li>
+        <strong>logout, then authenticate again</strong>
+        <small
+          >record session revocation and recovery before Access removal.</small
+        >
+      </li>
+      <li>
+        <strong>revoke current passkey</strong>
+        <small>keep Access on so a replacement can be registered safely.</small>
+      </li>
+      <li>
+        <strong>authenticate once while revoked, then replace it</strong>
+        <small
+          >record denial proof, register a replacement, and sign in again.</small
+        >
+      </li>
+    </ol>
+  </section>
+
   <section class="runbook-board" aria-labelledby="passkey-runbook-heading">
     <div class="section-header">
       <div>

--- a/apps/admin/src/styles/admin.css
+++ b/apps/admin/src/styles/admin.css
@@ -295,6 +295,7 @@ th {
   margin-top: 12px;
 }
 
+.handoff-board,
 .runbook-board,
 .proof-checklist {
   margin-top: 24px;
@@ -302,23 +303,27 @@ th {
   background: var(--panel);
 }
 
+.handoff-board .section-header,
 .runbook-board .section-header,
 .proof-checklist .section-header {
   padding: 16px;
   border-bottom: 1px solid var(--border);
 }
 
+.handoff-list,
 .runbook-list,
 .proof-list {
   display: grid;
 }
 
+.handoff-list,
 .runbook-list {
   margin: 0;
   padding: 0;
   list-style: none;
 }
 
+.handoff-list li,
 .runbook-step,
 .proof-item {
   display: grid;
@@ -334,11 +339,21 @@ th {
   grid-template-columns: 34px minmax(0, 1fr);
 }
 
+.handoff-list li {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.handoff-list li:not(:last-child) {
+  border-bottom: 1px solid var(--border);
+}
+
 .runbook-step:last-child,
 .proof-item:last-child {
   border-bottom: 0;
 }
 
+.handoff-list strong,
+.handoff-list small,
 .runbook-step strong,
 .runbook-step small,
 .proof-item strong,
@@ -346,6 +361,7 @@ th {
   display: block;
 }
 
+.handoff-list small,
 .runbook-step small,
 .proof-item small {
   color: var(--muted);

--- a/scripts/admin/passkey-proof.mjs
+++ b/scripts/admin/passkey-proof.mjs
@@ -32,6 +32,15 @@ const REQUIRED_AUDIT_EVENTS = [
   "passkey.credential.revoked",
   "passkey.authentication.denied",
 ];
+const MANUAL_ENROLLMENT_SEQUENCE = [
+  "open /auth/passkey through Cloudflare Access",
+  "click register passkey and finish the platform biometric prompt",
+  "click authenticate to create an app-native admin session",
+  "reload a protected route to prove session persistence",
+  "logout once, then authenticate again",
+  "revoke the current passkey while Cloudflare Access remains active",
+  "authenticate once while revoked to record denial, then register and authenticate a replacement passkey",
+];
 
 const tableSql = `
 SELECT name
@@ -122,6 +131,11 @@ const proof = {
     removalBlockers.length === 0 && cloudflareAccessStillActive,
   post_access_removal_verified:
     removalBlockers.length === 0 && appNativeRouteBoundaryReady,
+  manual_enrollment: {
+    url: `${ADMIN_ORIGIN}/auth/passkey`,
+    requires_browser_passkey_prompt: removalBlockers.length > 0,
+    sequence: MANUAL_ENROLLMENT_SEQUENCE,
+  },
   routes,
   route_boundary: routeBoundary,
   next_safe_action: nextSafeAction({


### PR DESCRIPTION
## summary
- add a visible biometric proof sequence to the admin passkey page
- include the same browser-required enrollment sequence in proof:admin-passkey JSON
- keep Cloudflare Access active and leave auth behavior unchanged

## verification
- pnpm turbo typecheck --filter=@anipotts/admin...
- pnpm turbo build --filter=@anipotts/admin...
- pnpm --silent proof:admin-passkey
- pnpm test:admin-routes
- pnpm test:deploy-targets
- pnpm test:security-review
- pnpm format:check
- git diff --check

## deploy impact
- expected deploy target: admin=true only
- no Cloudflare Access removal
- no DNS, env, secret, D1 migration, write path, outbound action, root, launchd, or legacy admin-solid deploy
