### PR TITLE
feat: preview source content bodies

### DIFF
--- a/apps/admin/src/data/source-content.ts
+++ b/apps/admin/src/data/source-content.ts
@@ -16,6 +16,9 @@ export type SourceContentRecord = {
   source_ref: string;
   summary: string;
   body_words: number;
+  body_state: string;
+  body_section_count: number;
+  body_preview: string;
   fields: SourceContentField[];
   next_safe_action: string;
 };
@@ -99,10 +102,13 @@ function recordFromRaw(
       asString(frontmatter.description) ||
       "no summary field",
     body_words: countWords(source.body),
+    body_state: bodyState(surface, source.body),
+    body_section_count: countMarkdownSections(source.body),
+    body_preview: markdownPreview(source.body),
     fields,
     next_safe_action:
       surface === "projects"
-        ? "review project frontmatter and body before modeling a draft operation"
+        ? "review project frontmatter, detail body, and structured sections before modeling a draft operation"
         : "review title, summary, tags, and body before newsletter backfill",
   };
 }
@@ -185,6 +191,31 @@ function asString(value: unknown): string {
 
 function countWords(body: string): number {
   return body.trim().split(/\s+/).filter(Boolean).length;
+}
+
+function countMarkdownSections(body: string): number {
+  return body.split("\n").filter((line) => /^#{2,6}\s+\S/.test(line.trim()))
+    .length;
+}
+
+function bodyState(surface: SourceSurface, body: string): string {
+  const words = countWords(body);
+  if (words === 0 && surface === "projects") return "frontmatter only";
+  if (words === 0) return "empty body";
+  if (words < 80) return "short body";
+  return "body ready for preview";
+}
+
+function markdownPreview(body: string): string {
+  const normalized = body
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .join(" ");
+  if (!normalized) return "no markdown body yet";
+  return normalized.length > 220
+    ? `${normalized.slice(0, 217).trimEnd()}...`
+    : normalized;
 }
 
 function formatFieldValue(value: unknown): string {

--- a/apps/admin/src/pages/content/index.astro
+++ b/apps/admin/src/pages/content/index.astro
@@ -165,10 +165,22 @@ const pageContentState = await readPageContentInventoryStore(
                 <dd>{record.summary}</dd>
               </div>
               <div>
+                <dt>body state</dt>
+                <dd>{record.body_state}</dd>
+              </div>
+              <div>
+                <dt>sections</dt>
+                <dd>{record.body_section_count}</dd>
+              </div>
+              <div>
                 <dt>next</dt>
                 <dd>{record.next_safe_action}</dd>
               </div>
             </dl>
+            <div class="body-preview">
+              <span>markdown body preview</span>
+              <p>{record.body_preview}</p>
+            </div>
             <div class="field-grid" aria-label={`${record.slug} source fields`}>
               {record.fields.slice(0, 14).map((field) => (
                 <div class="field-chip">

--- a/apps/admin/src/styles/admin.css
+++ b/apps/admin/src/styles/admin.css
@@ -518,14 +518,16 @@ dd {
 }
 
 .field-chip span,
-.field-gap span {
+.field-gap span,
+.body-preview span {
   color: var(--muted);
   font-size: 11px;
   text-transform: uppercase;
 }
 
 .field-chip strong,
-.field-gap p {
+.field-gap p,
+.body-preview p {
   min-width: 0;
   margin: 0;
   overflow-wrap: anywhere;
@@ -551,6 +553,15 @@ dd {
   border: 1px solid #4a3b28;
   background: #181510;
   padding: 10px;
+}
+
+.body-preview {
+  display: grid;
+  gap: 6px;
+  margin-top: 12px;
+  border: 1px solid var(--border);
+  background: #111;
+  padding: 12px;
 }
 
 .lane-grid {

--- a/docs/content-admin-editor-brief.md
+++ b/docs/content-admin-editor-brief.md
@@ -28,6 +28,9 @@ or any live write path.
 Admin `/content` now renders the D1 `page_content` rows and bundled read-only
 metadata from the project and writing markdown collections. It still does not
 add a save endpoint, publish endpoint, provider sync, or source file mutation.
+The source collection rows include markdown body state, section count, and a
+short body preview so project detail and writing body edits can be reviewed
+before any editor write path exists.
 Admin `/content/drafts` renders the first inert draft-editor shape with disabled
 controls backed by `page_content` and `content_draft_operations`. It is an
 editor surface model only, not a write path.


### PR DESCRIPTION
## summary
- add markdown body state, section count, and short body preview to admin source-content records
- render those read-only body previews on admin /content for project and writing sources
- document that /content now exposes source markdown body shape before any editor write path exists

## verification
- pnpm turbo typecheck --filter=@anipotts/admin...
- pnpm turbo build --filter=@anipotts/admin...
- pnpm --silent proof:admin-content
- pnpm test:admin-routes
- pnpm test:deploy-targets
- pnpm test:security-review
- pnpm test:content-platform
- pnpm format:check
- git diff --check

## deploy impact
- expected deploy target: admin=true only
- no save endpoint, publish endpoint, provider sync, source mutation, D1 migration, env, secret, DNS, Access change, or legacy deploy
