### PR TITLE
feat: share needs ani schema

### DIFF
--- a/apps/admin/src/data/needs.ts
+++ b/apps/admin/src/data/needs.ts
@@ -1,53 +1,15 @@
 import syscallNeedsJson from "./static/needs-ani.syscalls.json";
+import {
+  needsAniBuckets,
+  needsAniItemsFromJson,
+} from "@anipotts/content/admin";
 
-export type NeedType =
-  | "approve"
-  | "choose"
-  | "provide"
-  | "perform"
-  | "review-delete";
+export type {
+  NeedBucket,
+  NeedsAniItem,
+  NeedType,
+} from "@anipotts/content/admin";
 
-export type NeedBucket =
-  | "unblockable_now"
-  | "waiting_on_account_or_device"
-  | "review_delete_packets";
+export { needsAniBuckets };
 
-export type NeedsAniItem = {
-  id: string;
-  type: NeedType;
-  bucket: NeedBucket;
-  owner: string;
-  status: "open" | "closed";
-  why: string;
-  ani_action: string;
-  agent_next: string;
-  primary_action: string;
-  proof: string;
-  source: string;
-  expires_stale: string;
-  requires_ani: boolean;
-};
-
-export const needsAniItems = syscallNeedsJson as NeedsAniItem[];
-
-export const needsAniBuckets: Array<{
-  bucket: NeedBucket;
-  title: string;
-  detail: string;
-}> = [
-  {
-    bucket: "unblockable_now",
-    title: "unblockable now",
-    detail: "decisions that let a chief continue immediately",
-  },
-  {
-    bucket: "waiting_on_account_or_device",
-    title: "account or device",
-    detail: "requires local auth, account UI, or a device-side step",
-  },
-  {
-    bucket: "review_delete_packets",
-    title: "review delete",
-    detail: "source or local cleanup choices with proof requirements",
-  },
-];
+export const needsAniItems = needsAniItemsFromJson(syscallNeedsJson);

--- a/packages/content/src/admin/index.ts
+++ b/packages/content/src/admin/index.ts
@@ -1,4 +1,5 @@
 export * from "./content.js";
+export * from "./needs.js";
 export * from "./newsletter.js";
 export * from "./operations.js";
 export * from "./proof.js";

--- a/packages/content/src/admin/needs.ts
+++ b/packages/content/src/admin/needs.ts
@@ -1,0 +1,103 @@
+export type NeedType =
+  | "approve"
+  | "choose"
+  | "provide"
+  | "perform"
+  | "review-delete";
+
+export type NeedBucket =
+  | "unblockable_now"
+  | "waiting_on_account_or_device"
+  | "review_delete_packets";
+
+export type NeedsAniItem = {
+  id: string;
+  type: NeedType;
+  bucket: NeedBucket;
+  owner: string;
+  status: "open" | "closed";
+  why: string;
+  ani_action: string;
+  agent_next: string;
+  primary_action: string;
+  proof: string;
+  source: string;
+  expires_stale: string;
+  requires_ani: boolean;
+};
+
+export type NeedsAniBucketGroup = {
+  bucket: NeedBucket;
+  title: string;
+  detail: string;
+};
+
+const needTypes = new Set<NeedType>([
+  "approve",
+  "choose",
+  "provide",
+  "perform",
+  "review-delete",
+]);
+
+const needBuckets = new Set<NeedBucket>([
+  "unblockable_now",
+  "waiting_on_account_or_device",
+  "review_delete_packets",
+]);
+
+export const needsAniBuckets: NeedsAniBucketGroup[] = [
+  {
+    bucket: "unblockable_now",
+    title: "unblockable now",
+    detail: "decisions that let a chief continue immediately",
+  },
+  {
+    bucket: "waiting_on_account_or_device",
+    title: "account or device",
+    detail: "requires local auth, account UI, or a device-side step",
+  },
+  {
+    bucket: "review_delete_packets",
+    title: "review delete",
+    detail: "source or local cleanup choices with proof requirements",
+  },
+];
+
+export function needsAniItemsFromJson(value: unknown): NeedsAniItem[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter(isNeedsAniItem);
+}
+
+function isNeedsAniItem(value: unknown): value is NeedsAniItem {
+  if (!value || typeof value !== "object") return false;
+  const item = value as Record<string, unknown>;
+
+  return (
+    isString(item.id) &&
+    isNeedType(item.type) &&
+    isNeedBucket(item.bucket) &&
+    isString(item.owner) &&
+    (item.status === "open" || item.status === "closed") &&
+    isString(item.why) &&
+    isString(item.ani_action) &&
+    isString(item.agent_next) &&
+    isString(item.primary_action) &&
+    isString(item.proof) &&
+    isString(item.source) &&
+    isString(item.expires_stale) &&
+    typeof item.requires_ani === "boolean"
+  );
+}
+
+function isString(value: unknown): value is string {
+  return typeof value === "string";
+}
+
+function isNeedType(value: unknown): value is NeedType {
+  return isString(value) && needTypes.has(value as NeedType);
+}
+
+function isNeedBucket(value: unknown): value is NeedBucket {
+  return isString(value) && needBuckets.has(value as NeedBucket);
+}

--- a/scripts/ci/content-platform.test.mjs
+++ b/scripts/ci/content-platform.test.mjs
@@ -5,6 +5,8 @@ import { execFileSync } from "node:child_process";
 import {
   countProofEntries,
   contentInventorySource,
+  needsAniBuckets,
+  needsAniItemsFromJson,
   proofSource,
   recordsFromSourceModules,
   readProofEntries,
@@ -39,6 +41,37 @@ const UNSAFE_ALLOWED_ACTIONS = new Set([
   "sync_provider",
   "sync_external",
 ]);
+
+const needsFixture = needsAniItemsFromJson([
+  {
+    agent_next: "continue after approval",
+    ani_action: "approve test action",
+    bucket: "unblockable_now",
+    expires_stale: "2026-07-01",
+    id: "need-test-action",
+    owner: "chief/site",
+    primary_action: "approve test action",
+    proof: "",
+    requires_ani: true,
+    source: "coord/NEEDS-ANI.md",
+    status: "open",
+    type: "approve",
+    why: "valid row should render",
+  },
+  {
+    id: "invalid-row",
+    type: "send",
+    bucket: "unblockable_now",
+  },
+]);
+
+assert.deepEqual(
+  needsAniBuckets.map((group) => group.bucket),
+  ["unblockable_now", "waiting_on_account_or_device", "review_delete_packets"],
+  "needs-ani buckets must stay stable for the admin route",
+);
+assert.equal(needsFixture.length, 1);
+assert.equal(needsFixture[0]?.id, "need-test-action");
 
 const sourceRecords = [
   ...recordsFromSourceModules("projects", {


### PR DESCRIPTION
## summary
- move needs-ani queue types, bucket metadata, and JSON coercion into @anipotts/content/admin
- keep apps/admin responsible only for importing the static syscall JSON feed
- add content-platform coverage for stable bucket groups and invalid-row filtering

## verification
- pnpm --filter @anipotts/content build
- pnpm turbo typecheck --filter=@anipotts/admin...
- pnpm turbo build --filter=@anipotts/admin...
- pnpm test:content-platform
- pnpm test:admin-routes
- pnpm test:deploy-targets
- pnpm test:security-review
- pnpm --silent proof:admin-content
- pnpm --silent proof:admin-passkey
- pnpm format:check
- git diff --check
- node scripts/ci/security-review.mjs --required /tmp/anipotts-com-changed-files.txt

## live impact
- no live mutation from this branch
- expected deploy target after merge: admin only
- queue remains read-only