### PR TITLE
feat: share admin runtime feed schema

### DIFF
--- a/apps/admin/src/data/runtime.ts
+++ b/apps/admin/src/data/runtime.ts
@@ -1,60 +1,21 @@
-import type { NeedsAniItem } from "./needs";
+import {
+  disabledRuntimeOverlayResponse,
+  RUNTIME_FEED_PATH,
+  runtimeOverlayErrorResponse,
+  runtimeOverlayResponseFromFeed,
+  type RuntimeOverlayResponse,
+} from "@anipotts/content/admin";
 
-export const RUNTIME_FEED_PATH =
-  "/Users/anipotts/Infra/state/runtime/admin/admin-feed.current.json";
-
-export type RuntimeRepoOverlay = {
-  repo_state_id: string;
-  repo: string;
-  repo_root_label: string;
-  machine: string;
-  git_available: boolean;
-  branch: string | null;
-  head_sha: string | null;
-  upstream: string | null;
-  upstream_sha: string | null;
-  ahead: number | null;
-  behind: number | null;
-  dirty_tracked_count: number | null;
-  untracked_count: number | null;
-  deploy_impact: "none" | "local_only" | "preview" | "production" | "unknown";
-  live_runtime_role: string;
-  notes: string;
-};
-
-export type RuntimeSafety = {
-  dirty_filenames_included: boolean;
-  file_contents_included: boolean;
-  health_payloads_included: boolean;
-  mode: string;
-  secret_values_included: boolean;
-};
-
-export type RuntimeOverlayResponse = {
-  available: boolean;
-  mode: "local_dev" | "disabled" | "missing" | "error";
-  generated_at: string | null;
-  machine: string | null;
-  source_path: string;
-  safety: RuntimeSafety | null;
-  overlays: RuntimeRepoOverlay[];
-  needs_ani_queue: NeedsAniItem[];
-  error?: string;
-};
-
-type RuntimeFeedFile = {
-  generated_at?: string;
-  machine?: string;
-  runtime?: {
-    needs_ani_queue?: NeedsAniItem[];
-    repo_state_overlays?: RuntimeRepoOverlay[];
-    safety?: RuntimeSafety;
-  };
-};
+export {
+  RUNTIME_FEED_PATH,
+  type RuntimeOverlayResponse,
+  type RuntimeRepoOverlay,
+  type RuntimeSafety,
+} from "@anipotts/content/admin";
 
 export async function loadRuntimeOverlayResponse(): Promise<RuntimeOverlayResponse> {
   if (!import.meta.env.DEV) {
-    return disabledResponse();
+    return disabledRuntimeOverlayResponse();
   }
 
   try {
@@ -63,44 +24,8 @@ export async function loadRuntimeOverlayResponse(): Promise<RuntimeOverlayRespon
       /* @vite-ignore */ nodeFsModule
     )) as typeof import("node:fs/promises");
     const raw = await readFile(RUNTIME_FEED_PATH, "utf8");
-    const feed = JSON.parse(raw) as RuntimeFeedFile;
-
-    return {
-      available: true,
-      mode: "local_dev",
-      generated_at: feed.generated_at ?? null,
-      machine: feed.machine ?? null,
-      source_path: RUNTIME_FEED_PATH,
-      safety: feed.runtime?.safety ?? null,
-      overlays: feed.runtime?.repo_state_overlays ?? [],
-      needs_ani_queue: feed.runtime?.needs_ani_queue ?? [],
-    };
+    return runtimeOverlayResponseFromFeed(JSON.parse(raw));
   } catch (error) {
-    const code =
-      typeof error === "object" && error && "code" in error
-        ? String(error.code)
-        : "";
-
-    return {
-      ...disabledResponse(),
-      mode: code === "ENOENT" ? "missing" : "error",
-      error:
-        error instanceof Error
-          ? error.message
-          : "unknown runtime feed read failure",
-    };
+    return runtimeOverlayErrorResponse(error);
   }
-}
-
-export function disabledResponse(): RuntimeOverlayResponse {
-  return {
-    available: false,
-    mode: "disabled",
-    generated_at: null,
-    machine: null,
-    source_path: RUNTIME_FEED_PATH,
-    safety: null,
-    overlays: [],
-    needs_ani_queue: [],
-  };
 }

--- a/packages/content/src/admin/index.ts
+++ b/packages/content/src/admin/index.ts
@@ -3,4 +3,5 @@ export * from "./needs.js";
 export * from "./newsletter.js";
 export * from "./operations.js";
 export * from "./proof.js";
+export * from "./runtime.js";
 export * from "./source-content.js";

--- a/packages/content/src/admin/runtime.ts
+++ b/packages/content/src/admin/runtime.ts
@@ -1,0 +1,209 @@
+import { needsAniItemsFromJson, type NeedsAniItem } from "./needs.js";
+
+export const RUNTIME_FEED_PATH =
+  "/Users/anipotts/Infra/state/runtime/admin/admin-feed.current.json";
+
+export type RuntimeDeployImpact =
+  | "none"
+  | "local_only"
+  | "preview"
+  | "production"
+  | "unknown";
+
+export type RuntimeOverlayMode = "local_dev" | "disabled" | "missing" | "error";
+
+export type RuntimeRepoOverlay = {
+  repo_state_id: string;
+  repo: string;
+  repo_root_label: string;
+  machine: string;
+  git_available: boolean;
+  branch: string | null;
+  head_sha: string | null;
+  upstream: string | null;
+  upstream_sha: string | null;
+  ahead: number | null;
+  behind: number | null;
+  dirty_tracked_count: number | null;
+  untracked_count: number | null;
+  deploy_impact: RuntimeDeployImpact;
+  live_runtime_role: string;
+  notes: string;
+};
+
+export type RuntimeSafety = {
+  dirty_filenames_included: boolean;
+  file_contents_included: boolean;
+  health_payloads_included: boolean;
+  mode: string;
+  secret_values_included: boolean;
+};
+
+export type RuntimeOverlayResponse = {
+  available: boolean;
+  mode: RuntimeOverlayMode;
+  generated_at: string | null;
+  machine: string | null;
+  source_path: string;
+  safety: RuntimeSafety | null;
+  overlays: RuntimeRepoOverlay[];
+  needs_ani_queue: NeedsAniItem[];
+  error?: string;
+};
+
+export type RuntimeFeedFile = {
+  generated_at?: string;
+  machine?: string;
+  runtime?: {
+    needs_ani_queue?: unknown;
+    repo_state_overlays?: unknown;
+    safety?: unknown;
+  };
+};
+
+const deployImpacts = new Set<RuntimeDeployImpact>([
+  "none",
+  "local_only",
+  "preview",
+  "production",
+  "unknown",
+]);
+
+export function runtimeOverlayResponseFromFeed(
+  feed: unknown,
+  sourcePath = RUNTIME_FEED_PATH,
+): RuntimeOverlayResponse {
+  const file = isRecord(feed) ? (feed as RuntimeFeedFile) : {};
+  const runtime = isRecord(file.runtime) ? file.runtime : {};
+
+  return {
+    available: true,
+    mode: "local_dev",
+    generated_at: isString(file.generated_at) ? file.generated_at : null,
+    machine: isString(file.machine) ? file.machine : null,
+    source_path: sourcePath,
+    safety: runtimeSafetyFromJson(runtime.safety),
+    overlays: runtimeRepoOverlaysFromJson(runtime.repo_state_overlays),
+    needs_ani_queue: needsAniItemsFromJson(runtime.needs_ani_queue),
+  };
+}
+
+export function disabledRuntimeOverlayResponse(
+  sourcePath = RUNTIME_FEED_PATH,
+): RuntimeOverlayResponse {
+  return {
+    available: false,
+    mode: "disabled",
+    generated_at: null,
+    machine: null,
+    source_path: sourcePath,
+    safety: null,
+    overlays: [],
+    needs_ani_queue: [],
+  };
+}
+
+export function runtimeOverlayErrorResponse(
+  error: unknown,
+  sourcePath = RUNTIME_FEED_PATH,
+): RuntimeOverlayResponse {
+  const code = isRecord(error) && "code" in error ? String(error.code) : "";
+
+  return {
+    ...disabledRuntimeOverlayResponse(sourcePath),
+    mode: code === "ENOENT" ? "missing" : "error",
+    error:
+      error instanceof Error
+        ? error.message
+        : "unknown runtime feed read failure",
+  };
+}
+
+export function runtimeRepoOverlaysFromJson(
+  value: unknown,
+): RuntimeRepoOverlay[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((item) => {
+    const overlay = runtimeRepoOverlayFromJson(item);
+    return overlay ? [overlay] : [];
+  });
+}
+
+function runtimeRepoOverlayFromJson(value: unknown): RuntimeRepoOverlay | null {
+  if (!isRecord(value)) return null;
+
+  if (
+    !isString(value.repo_state_id) ||
+    !isString(value.repo) ||
+    !isString(value.repo_root_label) ||
+    !isString(value.machine) ||
+    typeof value.git_available !== "boolean" ||
+    !isString(value.live_runtime_role) ||
+    !isString(value.notes)
+  ) {
+    return null;
+  }
+
+  return {
+    repo_state_id: value.repo_state_id,
+    repo: value.repo,
+    repo_root_label: value.repo_root_label,
+    machine: value.machine,
+    git_available: value.git_available,
+    branch: stringOrNull(value.branch),
+    head_sha: stringOrNull(value.head_sha),
+    upstream: stringOrNull(value.upstream),
+    upstream_sha: stringOrNull(value.upstream_sha),
+    ahead: numberOrNull(value.ahead),
+    behind: numberOrNull(value.behind),
+    dirty_tracked_count: numberOrNull(value.dirty_tracked_count),
+    untracked_count: numberOrNull(value.untracked_count),
+    deploy_impact: deployImpactFromJson(value.deploy_impact),
+    live_runtime_role: value.live_runtime_role,
+    notes: value.notes,
+  };
+}
+
+function runtimeSafetyFromJson(value: unknown): RuntimeSafety | null {
+  if (!isRecord(value)) return null;
+
+  if (
+    typeof value.dirty_filenames_included !== "boolean" ||
+    typeof value.file_contents_included !== "boolean" ||
+    typeof value.health_payloads_included !== "boolean" ||
+    typeof value.secret_values_included !== "boolean" ||
+    !isString(value.mode)
+  ) {
+    return null;
+  }
+
+  return {
+    dirty_filenames_included: value.dirty_filenames_included,
+    file_contents_included: value.file_contents_included,
+    health_payloads_included: value.health_payloads_included,
+    mode: value.mode,
+    secret_values_included: value.secret_values_included,
+  };
+}
+
+function deployImpactFromJson(value: unknown): RuntimeDeployImpact {
+  return isString(value) && deployImpacts.has(value as RuntimeDeployImpact)
+    ? (value as RuntimeDeployImpact)
+    : "unknown";
+}
+
+function stringOrNull(value: unknown): string | null {
+  return isString(value) ? value : null;
+}
+
+function numberOrNull(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function isString(value: unknown): value is string {
+  return typeof value === "string";
+}

--- a/scripts/ci/content-platform.test.mjs
+++ b/scripts/ci/content-platform.test.mjs
@@ -5,11 +5,15 @@ import { execFileSync } from "node:child_process";
 import {
   countProofEntries,
   contentInventorySource,
+  disabledRuntimeOverlayResponse,
   needsAniBuckets,
   needsAniItemsFromJson,
   proofSource,
   recordsFromSourceModules,
   readProofEntries,
+  RUNTIME_FEED_PATH,
+  runtimeOverlayErrorResponse,
+  runtimeOverlayResponseFromFeed,
   summarizeSourceContentRecords,
 } from "../../packages/content/dist/admin/index.js";
 import {
@@ -72,6 +76,102 @@ assert.deepEqual(
 );
 assert.equal(needsFixture.length, 1);
 assert.equal(needsFixture[0]?.id, "need-test-action");
+
+const disabledRuntime = disabledRuntimeOverlayResponse();
+assert.equal(disabledRuntime.mode, "disabled");
+assert.equal(disabledRuntime.available, false);
+assert.equal(disabledRuntime.source_path, RUNTIME_FEED_PATH);
+assert.deepEqual(disabledRuntime.overlays, []);
+assert.deepEqual(disabledRuntime.needs_ani_queue, []);
+
+const runtimeOverlay = runtimeOverlayResponseFromFeed({
+  generated_at: "2026-06-29T12:00:00Z",
+  machine: "ap-mini.local",
+  runtime: {
+    needs_ani_queue: [
+      needsFixture[0],
+      {
+        id: "invalid-runtime-need",
+        type: "send",
+        bucket: "unblockable_now",
+      },
+    ],
+    repo_state_overlays: [
+      {
+        ahead: 0,
+        behind: 1,
+        branch: "main",
+        deploy_impact: "none",
+        dirty_tracked_count: 0,
+        git_available: true,
+        head_sha: "abc1234",
+        live_runtime_role: "public site source",
+        machine: "ap-mini.local",
+        notes: "metadata only",
+        repo: "anipotts-com",
+        repo_root_label: "~/Code/projects/anipotts-com",
+        repo_state_id: "runtime.repo.site.local",
+        untracked_count: 2,
+        upstream: "origin/main",
+        upstream_sha: "abc1234",
+      },
+      {
+        ahead: null,
+        behind: null,
+        branch: null,
+        deploy_impact: "future-unknown",
+        dirty_tracked_count: null,
+        git_available: false,
+        head_sha: null,
+        live_runtime_role: "runtime data tree",
+        machine: "ap-mini.local",
+        notes: "non-git runtime tree",
+        repo: "vitals",
+        repo_root_label: "~/Code/projects/vitals",
+        repo_state_id: "runtime.repo.vitals.local",
+        untracked_count: null,
+        upstream: null,
+        upstream_sha: null,
+      },
+      {
+        repo_state_id: "invalid-overlay",
+        repo: "missing required fields",
+      },
+    ],
+    safety: {
+      dirty_filenames_included: false,
+      file_contents_included: false,
+      health_payloads_included: false,
+      mode: "read_only_metadata",
+      secret_values_included: false,
+    },
+  },
+});
+
+assert.equal(runtimeOverlay.mode, "local_dev");
+assert.equal(runtimeOverlay.available, true);
+assert.equal(runtimeOverlay.generated_at, "2026-06-29T12:00:00Z");
+assert.equal(runtimeOverlay.machine, "ap-mini.local");
+assert.equal(runtimeOverlay.safety?.mode, "read_only_metadata");
+assert.equal(runtimeOverlay.safety?.secret_values_included, false);
+assert.equal(runtimeOverlay.safety?.file_contents_included, false);
+assert.equal(runtimeOverlay.overlays.length, 2);
+assert.equal(runtimeOverlay.overlays[0]?.repo, "anipotts-com");
+assert.equal(runtimeOverlay.overlays[0]?.behind, 1);
+assert.equal(runtimeOverlay.overlays[1]?.deploy_impact, "unknown");
+assert.equal(runtimeOverlay.needs_ani_queue.length, 1);
+assert.equal(runtimeOverlay.needs_ani_queue[0]?.id, "need-test-action");
+
+const missingRuntime = runtimeOverlayErrorResponse(
+  Object.assign(new Error("missing feed"), { code: "ENOENT" }),
+);
+assert.equal(missingRuntime.mode, "missing");
+assert.equal(missingRuntime.available, false);
+assert.equal(missingRuntime.error, "missing feed");
+
+const failedRuntime = runtimeOverlayErrorResponse(new Error("bad json"));
+assert.equal(failedRuntime.mode, "error");
+assert.equal(failedRuntime.error, "bad json");
 
 const sourceRecords = [
   ...recordsFromSourceModules("projects", {


### PR DESCRIPTION
## summary

- move the admin runtime feed schema and response shaping into `@anipotts/content/admin`
- keep `apps/admin` responsible only for the local-dev runtime file read
- add contract coverage for runtime overlay coercion, NEEDS-ANI filtering, disabled state, and error state

## verification

- `pnpm test:content-platform`
- `pnpm turbo typecheck --filter=@anipotts/admin...`
- `pnpm turbo build --filter=@anipotts/admin...`
- `pnpm test:deploy-targets`
- `pnpm test:admin-routes`
- `pnpm test:security-review`
- `pnpm --silent proof:admin-content`
- `pnpm --silent proof:admin-passkey`
- `pnpm format:check`
- `git diff --check`

## deploy scope

- expected affected target: admin
- no write path, auth policy, DNS, env, secret, or D1 mutation
