### PR TITLE
feat: share admin passkey proof contract

### DIFF
--- a/apps/admin/src/lib/passkey-auth.ts
+++ b/apps/admin/src/lib/passkey-auth.ts
@@ -11,6 +11,16 @@ import type {
   RegistrationResponseJSON,
   WebAuthnCredential,
 } from "@simplewebauthn/server";
+import {
+  buildPasskeyProofItems,
+  emptyPasskeyAuditEvents,
+  nextPasskeyStatusAction,
+  passkeyAccessRemovalBlockers,
+  REQUIRED_PASSKEY_AUDIT_EVENTS,
+  type PasskeyAuditEvents,
+  type PasskeyProofItem,
+  type RequiredPasskeyAuditEvent,
+} from "@anipotts/content/admin";
 
 export const PASSKEY_SESSION_COOKIE = "admin_passkey_session";
 
@@ -25,13 +35,6 @@ const USER_ID = "ani";
 const USER_NAME = "ani@admin.anipotts.com";
 const USER_DISPLAY_NAME = "Ani";
 const ACCESS_JWT_HEADER = "cf-access-jwt-assertion";
-const REQUIRED_PASSKEY_AUDIT_EVENTS = [
-  "passkey.credential.registered",
-  "passkey.session.created",
-  "passkey.session.revoked",
-  "passkey.credential.revoked",
-  "passkey.authentication.denied",
-] as const;
 
 type D1Result<T = unknown> = {
   results?: T[];
@@ -90,19 +93,9 @@ type AccessIdentity = {
   hint: string | null;
 };
 
-type RequiredPasskeyAuditEvent = (typeof REQUIRED_PASSKEY_AUDIT_EVENTS)[number];
-
 type PasskeyAuditEventRow = {
   event_type: string;
   count: number;
-};
-
-export type PasskeyProofItem = {
-  id: string;
-  label: string;
-  count: number;
-  complete: boolean;
-  next_safe_action: string;
 };
 
 export type PasskeyContext = {
@@ -160,8 +153,12 @@ export async function getPasskeyStatus(
   const db = dbFromContext(context);
   const accessIdentity = await resolveAccessIdentity(context);
   if (!db) {
-    const auditEvents = emptyAuditEvents();
-    const blockers = accessRemovalBlockerItems(0, false, auditEvents);
+    const auditEvents = emptyPasskeyAuditEvents();
+    const blockers = passkeyAccessRemovalBlockers({
+      credentialCount: 0,
+      hasSession: false,
+      auditEvents,
+    });
     return {
       available: false,
       mode: "missing_db",
@@ -185,7 +182,7 @@ export async function getPasskeyStatus(
 
   let credentialCount = 0;
   let auditCount = 0;
-  let auditEvents = emptyAuditEvents();
+  let auditEvents = emptyPasskeyAuditEvents();
   let session: SessionRow | null = null;
   try {
     credentialCount = await countActiveCredentials(db);
@@ -194,8 +191,12 @@ export async function getPasskeyStatus(
     session = await getSession(context, db);
   } catch (error) {
     if (!isMissingPasskeyTable(error)) throw error;
-    const missingAuditEvents = emptyAuditEvents();
-    const blockers = accessRemovalBlockerItems(0, false, missingAuditEvents);
+    const missingAuditEvents = emptyPasskeyAuditEvents();
+    const blockers = passkeyAccessRemovalBlockers({
+      credentialCount: 0,
+      hasSession: false,
+      auditEvents: missingAuditEvents,
+    });
     return {
       available: false,
       mode: "missing_db",
@@ -218,11 +219,11 @@ export async function getPasskeyStatus(
   }
   const canRegister =
     Boolean(session) || (credentialCount === 0 && accessIdentity.verified);
-  const blockers = accessRemovalBlockerItems(
+  const blockers = passkeyAccessRemovalBlockers({
     credentialCount,
-    Boolean(session),
+    hasSession: Boolean(session),
     auditEvents,
-  );
+  });
 
   return {
     available: true,
@@ -244,11 +245,11 @@ export async function getPasskeyStatus(
     ),
     access_removal_blockers: blockers,
     ready_for_access_removal: blockers.length === 0,
-    next_safe_action: passkeyStatusNextAction(
-      Boolean(session),
+    next_safe_action: nextPasskeyStatusAction({
+      hasSession: Boolean(session),
       credentialCount,
-      accessIdentity,
-    ),
+      accessIdentityVerified: accessIdentity.verified,
+    }),
   };
 }
 
@@ -632,8 +633,8 @@ async function countAuditEvents(db: D1Database): Promise<number> {
 
 async function readRequiredAuditEvents(
   db: D1Database,
-): Promise<Record<RequiredPasskeyAuditEvent, number>> {
-  const eventCounts = emptyAuditEvents();
+): Promise<PasskeyAuditEvents> {
+  const eventCounts = emptyPasskeyAuditEvents();
   const placeholders = REQUIRED_PASSKEY_AUDIT_EVENTS.map(() => "?").join(", ");
   const result = await db
     .prepare(
@@ -646,8 +647,9 @@ async function readRequiredAuditEvents(
     .all<PasskeyAuditEventRow>();
 
   for (const row of result.results ?? []) {
-    if (isRequiredAuditEvent(row.event_type)) {
-      eventCounts[row.event_type] = Number(row.count ?? 0);
+    const eventType = row.event_type as RequiredPasskeyAuditEvent;
+    if (REQUIRED_PASSKEY_AUDIT_EVENTS.includes(eventType)) {
+      eventCounts[eventType] = Number(row.count ?? 0);
     }
   }
 
@@ -806,109 +808,6 @@ async function resolveAccessIdentity(
   } catch {
     return { verified: false, hint: null };
   }
-}
-
-function passkeyStatusNextAction(
-  hasSession: boolean,
-  credentialCount: number,
-  accessIdentity: AccessIdentity,
-): string {
-  if (hasSession) return "passkey session active";
-  if (credentialCount === 0 && accessIdentity.verified) {
-    return "register the first passkey with verified Cloudflare Access identity";
-  }
-  if (credentialCount === 0) {
-    return "authenticate through Cloudflare Access before first passkey registration";
-  }
-  return "authenticate with the registered passkey";
-}
-
-function emptyAuditEvents(): Record<RequiredPasskeyAuditEvent, number> {
-  return Object.fromEntries(
-    REQUIRED_PASSKEY_AUDIT_EVENTS.map((eventType) => [eventType, 0]),
-  ) as Record<RequiredPasskeyAuditEvent, number>;
-}
-
-function buildPasskeyProofItems(
-  credentialCount: number,
-  hasSession: boolean,
-  auditEvents: Record<RequiredPasskeyAuditEvent, number>,
-): PasskeyProofItem[] {
-  return [
-    {
-      id: "active_credential",
-      label: "active credential",
-      count: credentialCount,
-      complete: credentialCount > 0,
-      next_safe_action: "register the first platform passkey",
-    },
-    {
-      id: "active_session",
-      label: "active session",
-      count: hasSession ? 1 : 0,
-      complete: hasSession,
-      next_safe_action: "authenticate with the registered passkey",
-    },
-    {
-      id: "passkey.credential.registered",
-      label: "registration audit",
-      count: auditEvents["passkey.credential.registered"],
-      complete: auditEvents["passkey.credential.registered"] > 0,
-      next_safe_action: "register the first platform passkey",
-    },
-    {
-      id: "passkey.session.created",
-      label: "login audit",
-      count: auditEvents["passkey.session.created"],
-      complete: auditEvents["passkey.session.created"] > 0,
-      next_safe_action: "authenticate with the registered passkey",
-    },
-    {
-      id: "passkey.session.revoked",
-      label: "logout audit",
-      count: auditEvents["passkey.session.revoked"],
-      complete: auditEvents["passkey.session.revoked"] > 0,
-      next_safe_action: "logout once, then authenticate again",
-    },
-    {
-      id: "passkey.credential.revoked",
-      label: "credential revoke audit",
-      count: auditEvents["passkey.credential.revoked"],
-      complete: auditEvents["passkey.credential.revoked"] > 0,
-      next_safe_action:
-        "revoke the current passkey while Cloudflare Access remains active",
-    },
-    {
-      id: "passkey.authentication.denied",
-      label: "revoked credential denial audit",
-      count: auditEvents["passkey.authentication.denied"],
-      complete: auditEvents["passkey.authentication.denied"] > 0,
-      next_safe_action:
-        "attempt authenticate after revocation, then register a replacement",
-    },
-  ];
-}
-
-function accessRemovalBlockerItems(
-  credentialCount: number,
-  hasSession: boolean,
-  auditEvents: Record<RequiredPasskeyAuditEvent, number>,
-): string[] {
-  const blockers: string[] = [];
-  if (credentialCount === 0) blockers.push("active_credential");
-  if (!hasSession) blockers.push("active_session");
-  for (const eventType of REQUIRED_PASSKEY_AUDIT_EVENTS) {
-    if (auditEvents[eventType] === 0) blockers.push(eventType);
-  }
-  return blockers;
-}
-
-function isRequiredAuditEvent(
-  eventType: string,
-): eventType is RequiredPasskeyAuditEvent {
-  return REQUIRED_PASSKEY_AUDIT_EVENTS.includes(
-    eventType as RequiredPasskeyAuditEvent,
-  );
 }
 
 function maskEmail(email: string): string {

--- a/packages/content/src/admin/index.ts
+++ b/packages/content/src/admin/index.ts
@@ -2,6 +2,7 @@ export * from "./content.js";
 export * from "./needs.js";
 export * from "./newsletter.js";
 export * from "./operations.js";
+export * from "./passkey.js";
 export * from "./proof.js";
 export * from "./runtime.js";
 export * from "./source-content.js";

--- a/packages/content/src/admin/passkey.ts
+++ b/packages/content/src/admin/passkey.ts
@@ -1,0 +1,234 @@
+export const REQUIRED_PASSKEY_AUDIT_EVENTS = [
+  "passkey.credential.registered",
+  "passkey.session.created",
+  "passkey.session.revoked",
+  "passkey.credential.revoked",
+  "passkey.authentication.denied",
+] as const;
+
+export const expectedPasskeyTables = [
+  "admin_passkey_audit",
+  "admin_passkey_challenges",
+  "admin_passkey_credentials",
+  "admin_passkey_sessions",
+] as const;
+
+export const manualPasskeyEnrollmentSequence = [
+  "open /auth/passkey through Cloudflare Access",
+  "click register passkey and finish the platform biometric prompt",
+  "click authenticate to create an app-native admin session",
+  "reload a protected route to prove session persistence",
+  "logout once, then authenticate again",
+  "revoke the current passkey while Cloudflare Access remains active",
+  "authenticate once while revoked to record denial, then register and authenticate a replacement passkey",
+] as const;
+
+export type RequiredPasskeyAuditEvent =
+  (typeof REQUIRED_PASSKEY_AUDIT_EVENTS)[number];
+
+export type PasskeyAuditEvents = Record<RequiredPasskeyAuditEvent, number>;
+
+export type PasskeyRouteBoundary =
+  | "cloudflare_access"
+  | "app_native_passkey"
+  | "unknown";
+
+export type PasskeyProofItem = {
+  id: string;
+  label: string;
+  count: number;
+  complete: boolean;
+  next_safe_action: string;
+};
+
+export function emptyPasskeyAuditEvents(): PasskeyAuditEvents {
+  return Object.fromEntries(
+    REQUIRED_PASSKEY_AUDIT_EVENTS.map((eventType) => [eventType, 0]),
+  ) as PasskeyAuditEvents;
+}
+
+export function normalizePasskeyAuditEvents(
+  auditEvents: Partial<Record<string, unknown>>,
+): PasskeyAuditEvents {
+  const normalized = emptyPasskeyAuditEvents();
+  for (const eventType of REQUIRED_PASSKEY_AUDIT_EVENTS) {
+    const count = auditEvents[eventType];
+    normalized[eventType] =
+      typeof count === "number" && Number.isFinite(count) ? count : 0;
+  }
+  return normalized;
+}
+
+export function missingRequiredPasskeyAuditEvents(
+  auditEvents: Partial<Record<string, unknown>>,
+): RequiredPasskeyAuditEvent[] {
+  const normalized = normalizePasskeyAuditEvents(auditEvents);
+  return REQUIRED_PASSKEY_AUDIT_EVENTS.filter(
+    (eventType) => normalized[eventType] === 0,
+  );
+}
+
+export function buildPasskeyProofItems(
+  credentialCount: number,
+  hasSession: boolean,
+  auditEvents: Partial<Record<string, unknown>>,
+): PasskeyProofItem[] {
+  const normalized = normalizePasskeyAuditEvents(auditEvents);
+  return [
+    {
+      id: "active_credential",
+      label: "active credential",
+      count: credentialCount,
+      complete: credentialCount > 0,
+      next_safe_action: "register the first platform passkey",
+    },
+    {
+      id: "active_session",
+      label: "active session",
+      count: hasSession ? 1 : 0,
+      complete: hasSession,
+      next_safe_action: "authenticate with the registered passkey",
+    },
+    {
+      id: "passkey.credential.registered",
+      label: "registration audit",
+      count: normalized["passkey.credential.registered"],
+      complete: normalized["passkey.credential.registered"] > 0,
+      next_safe_action: "register the first platform passkey",
+    },
+    {
+      id: "passkey.session.created",
+      label: "login audit",
+      count: normalized["passkey.session.created"],
+      complete: normalized["passkey.session.created"] > 0,
+      next_safe_action: "authenticate with the registered passkey",
+    },
+    {
+      id: "passkey.session.revoked",
+      label: "logout audit",
+      count: normalized["passkey.session.revoked"],
+      complete: normalized["passkey.session.revoked"] > 0,
+      next_safe_action: "logout once, then authenticate again",
+    },
+    {
+      id: "passkey.credential.revoked",
+      label: "credential revoke audit",
+      count: normalized["passkey.credential.revoked"],
+      complete: normalized["passkey.credential.revoked"] > 0,
+      next_safe_action:
+        "revoke the current passkey while Cloudflare Access remains active",
+    },
+    {
+      id: "passkey.authentication.denied",
+      label: "revoked credential denial audit",
+      count: normalized["passkey.authentication.denied"],
+      complete: normalized["passkey.authentication.denied"] > 0,
+      next_safe_action:
+        "attempt authenticate after revocation, then register a replacement",
+    },
+  ];
+}
+
+export function passkeyAccessRemovalBlockers({
+  schemaReady = true,
+  credentialCount,
+  sessionCount,
+  hasSession,
+  auditEvents,
+  missingAuditEvents,
+}: {
+  schemaReady?: boolean;
+  credentialCount: number;
+  sessionCount?: number;
+  hasSession?: boolean;
+  auditEvents?: Partial<Record<string, unknown>>;
+  missingAuditEvents?: readonly string[];
+}): string[] {
+  const blockers: string[] = [];
+  const sessionReady = hasSession ?? Number(sessionCount ?? 0) > 0;
+  const missingEvents =
+    missingAuditEvents ?? missingRequiredPasskeyAuditEvents(auditEvents ?? {});
+
+  if (!schemaReady) blockers.push("schema_ready");
+  if (credentialCount === 0) blockers.push("active_credential");
+  if (!sessionReady) blockers.push("active_session");
+  blockers.push(...missingEvents);
+  return blockers;
+}
+
+export function passkeyMissingProofItems({
+  accessRemovalBlockers,
+  routeBoundary,
+}: {
+  accessRemovalBlockers: readonly string[];
+  routeBoundary: PasskeyRouteBoundary;
+}): string[] {
+  const missing = [...accessRemovalBlockers];
+  if (routeBoundary === "cloudflare_access") return missing;
+  if (routeBoundary !== "app_native_passkey") {
+    missing.push("app_native_route_boundary");
+  }
+  return missing;
+}
+
+export function nextPasskeyProofAction({
+  schemaReady = true,
+  credentialCount,
+  sessionCount,
+  missingAuditEvents,
+  routeBoundary = "unknown",
+}: {
+  schemaReady?: boolean;
+  credentialCount: number;
+  sessionCount: number;
+  missingAuditEvents: readonly string[];
+  routeBoundary?: PasskeyRouteBoundary;
+}): string {
+  if (!schemaReady) {
+    return "apply drizzle/migrations/0006_admin_passkeys.sql before enrollment";
+  }
+  if (credentialCount === 0) {
+    return "open /auth/passkey behind Cloudflare Access and register the first platform passkey";
+  }
+  if (sessionCount === 0) {
+    return "authenticate with the registered passkey and prove a durable app-native session";
+  }
+  if (missingAuditEvents.includes("passkey.session.revoked")) {
+    return "logout once to record session revocation, then authenticate again before Access removal";
+  }
+  if (missingAuditEvents.includes("passkey.credential.revoked")) {
+    return "revoke the current passkey while Cloudflare Access remains active, then register a replacement";
+  }
+  if (missingAuditEvents.includes("passkey.authentication.denied")) {
+    return "record revoked-credential denial proof while Cloudflare Access remains active";
+  }
+  if (missingAuditEvents.length > 0) {
+    return `record missing passkey audit proof: ${missingAuditEvents.join(", ")}`;
+  }
+  if (routeBoundary === "cloudflare_access") {
+    return "passkey proof is staged; remove Cloudflare Access and rerun this proof";
+  }
+  if (routeBoundary === "app_native_passkey") {
+    return "record app-native unauthenticated block and authenticated route render proof";
+  }
+  return "inspect route boundary before changing Access";
+}
+
+export function nextPasskeyStatusAction({
+  hasSession,
+  credentialCount,
+  accessIdentityVerified,
+}: {
+  hasSession: boolean;
+  credentialCount: number;
+  accessIdentityVerified: boolean;
+}): string {
+  if (hasSession) return "passkey session active";
+  if (credentialCount === 0 && accessIdentityVerified) {
+    return "register the first passkey with verified Cloudflare Access identity";
+  }
+  if (credentialCount === 0) {
+    return "authenticate through Cloudflare Access before first passkey registration";
+  }
+  return "authenticate with the registered passkey";
+}

--- a/packages/content/src/admin/proof.ts
+++ b/packages/content/src/admin/proof.ts
@@ -1,3 +1,9 @@
+import {
+  missingRequiredPasskeyAuditEvents,
+  nextPasskeyProofAction,
+  REQUIRED_PASSKEY_AUDIT_EVENTS,
+} from "./passkey.js";
+
 export type ProofStatus = "verified" | "blocked" | "pending";
 export type ProofKind = "deploy" | "route" | "auth" | "repo" | "gate";
 
@@ -81,13 +87,6 @@ const baseProofEntries: ProofEntry[] = [
   },
 ];
 
-const requiredPasskeyAuditEvents = [
-  "passkey.credential.registered",
-  "passkey.session.created",
-  "passkey.session.revoked",
-  "passkey.credential.revoked",
-  "passkey.authentication.denied",
-] as const;
 const REQUIRED_PUBLISHED_PAGE_CONTENT_ROWS = 7;
 const REQUIRED_CONTENT_DRAFT_OPERATIONS = 9;
 
@@ -259,18 +258,22 @@ async function readPasskeyProof(
         "WHERE revoked_at IS NULL AND expires_at > ?",
         [now],
       ),
-      ...requiredPasskeyAuditEvents.map((eventType) =>
+      ...REQUIRED_PASSKEY_AUDIT_EVENTS.map((eventType) =>
         countRows(db, "admin_passkey_audit", "WHERE event_type = ?", [
           eventType,
         ]),
       ),
     ]);
-    const auditSummary = requiredPasskeyAuditEvents.map(
-      (eventType, index) => `${eventType}=${auditEventCounts[index] ?? 0}`,
+    const auditEvents = Object.fromEntries(
+      REQUIRED_PASSKEY_AUDIT_EVENTS.map((eventType, index) => [
+        eventType,
+        auditEventCounts[index] ?? 0,
+      ]),
     );
-    const missingAuditEvents = requiredPasskeyAuditEvents.filter(
-      (_eventType, index) => (auditEventCounts[index] ?? 0) === 0,
+    const auditSummary = REQUIRED_PASSKEY_AUDIT_EVENTS.map(
+      (eventType) => `${eventType}=${auditEvents[eventType] ?? 0}`,
     );
+    const missingAuditEvents = missingRequiredPasskeyAuditEvents(auditEvents);
     const proven =
       credentials > 0 && sessions > 0 && missingAuditEvents.length === 0;
     return {
@@ -285,7 +288,11 @@ async function readPasskeyProof(
       redaction: "metadata_only",
       next_safe_action: proven
         ? "Run route-boundary proof, then remove Cloudflare Access and prove app-native blocking."
-        : nextPasskeyProofAction(credentials, sessions, missingAuditEvents),
+        : nextPasskeyProofAction({
+            credentialCount: credentials,
+            sessionCount: sessions,
+            missingAuditEvents,
+          }),
     };
   } catch (error) {
     return {
@@ -327,29 +334,6 @@ function proofEntryFromRow(row: ProofEventRow): ProofEntry {
     redaction: parseRedaction(row.redaction),
     next_safe_action: row.next_safe_action,
   };
-}
-
-function nextPasskeyProofAction(
-  credentials: number,
-  sessions: number,
-  missingAuditEvents: readonly string[],
-): string {
-  if (credentials === 0) {
-    return "Register the first passkey behind Cloudflare Access.";
-  }
-  if (sessions === 0) {
-    return "Authenticate with the registered passkey and prove a durable session.";
-  }
-  if (missingAuditEvents.includes("passkey.session.revoked")) {
-    return "Logout once to record revocation, then authenticate again before Access removal.";
-  }
-  if (missingAuditEvents.includes("passkey.credential.revoked")) {
-    return "Revoke the current passkey while Cloudflare Access remains active, then register a replacement.";
-  }
-  if (missingAuditEvents.includes("passkey.authentication.denied")) {
-    return "Record revoked-credential denial proof while Cloudflare Access remains active.";
-  }
-  return `Record missing audit proof: ${missingAuditEvents.join(", ")}.`;
 }
 
 function parseProofKind(kind: string): ProofKind {

--- a/scripts/admin/passkey-proof.mjs
+++ b/scripts/admin/passkey-proof.mjs
@@ -2,6 +2,23 @@
 
 import { execFileSync } from "node:child_process";
 
+const REPO_ROOT = new URL("../../", import.meta.url);
+execFileSync("pnpm", ["--filter", "@anipotts/content", "build"], {
+  cwd: REPO_ROOT,
+  stdio: "ignore",
+});
+const {
+  expectedPasskeyTables,
+  manualPasskeyEnrollmentSequence,
+  missingRequiredPasskeyAuditEvents,
+  nextPasskeyProofAction,
+  passkeyAccessRemovalBlockers,
+  passkeyMissingProofItems,
+  REQUIRED_PASSKEY_AUDIT_EVENTS,
+} = await import(
+  new URL("../../packages/content/dist/admin/index.js", import.meta.url).href
+);
+
 const ADMIN_ORIGIN =
   process.env.ADMIN_ORIGIN?.replace(/\/$/, "") ?? "https://admin.anipotts.com";
 const D1_DATABASE = process.env.ADMIN_D1_DATABASE ?? "anipotts-db";
@@ -25,22 +42,6 @@ const ROUTES = [
 ];
 
 const checkedAt = new Date().toISOString();
-const REQUIRED_AUDIT_EVENTS = [
-  "passkey.credential.registered",
-  "passkey.session.created",
-  "passkey.session.revoked",
-  "passkey.credential.revoked",
-  "passkey.authentication.denied",
-];
-const MANUAL_ENROLLMENT_SEQUENCE = [
-  "open /auth/passkey through Cloudflare Access",
-  "click register passkey and finish the platform biometric prompt",
-  "click authenticate to create an app-native admin session",
-  "reload a protected route to prove session persistence",
-  "logout once, then authenticate again",
-  "revoke the current passkey while Cloudflare Access remains active",
-  "authenticate once while revoked to record denial, then register and authenticate a replacement passkey",
-];
 
 const tableSql = `
 SELECT name
@@ -69,13 +70,6 @@ GROUP BY event_type
 ORDER BY event_type;
 `;
 
-const expectedTables = [
-  "admin_passkey_audit",
-  "admin_passkey_challenges",
-  "admin_passkey_credentials",
-  "admin_passkey_sessions",
-];
-
 const tables = runD1(tableSql).map((row) => String(row.name));
 const counts = Object.fromEntries(
   runD1(countSql).map((row) => [String(row.table_name), Number(row.count)]),
@@ -85,23 +79,23 @@ const auditEvents = Object.fromEntries(
 );
 const routes = await Promise.all(ROUTES.map(probeRoute));
 
-const schemaReady = expectedTables.every((table) => tables.includes(table));
+const schemaReady = expectedPasskeyTables.every((table) =>
+  tables.includes(table),
+);
 const credentialCount = counts.credentials ?? 0;
 const sessionCount = counts.sessions ?? 0;
 const auditCount = counts.audit ?? 0;
 const routeBoundary = summarizeBoundary(routes);
-const missingAuditEvents = REQUIRED_AUDIT_EVENTS.filter(
-  (eventType) => !auditEvents[eventType],
-);
-const removalBlockers = accessRemovalBlockerItems({
+const missingAuditEvents = missingRequiredPasskeyAuditEvents(auditEvents);
+const removalBlockers = passkeyAccessRemovalBlockers({
   schemaReady,
   credentialCount,
   sessionCount,
-  missingAuditEvents,
+  auditEvents,
 });
 const cloudflareAccessStillActive = routeBoundary === "cloudflare_access";
 const appNativeRouteBoundaryReady = routeBoundary === "app_native_passkey";
-const missingProof = missingProofItems({
+const missingProof = passkeyMissingProofItems({
   accessRemovalBlockers: removalBlockers,
   routeBoundary,
 });
@@ -119,7 +113,7 @@ const proof = {
   },
   audit_events: auditEvents,
   required_audit_events: Object.fromEntries(
-    REQUIRED_AUDIT_EVENTS.map((eventType) => [
+    REQUIRED_PASSKEY_AUDIT_EVENTS.map((eventType) => [
       eventType,
       Number(auditEvents[eventType] ?? 0),
     ]),
@@ -134,11 +128,11 @@ const proof = {
   manual_enrollment: {
     url: `${ADMIN_ORIGIN}/auth/passkey`,
     requires_browser_passkey_prompt: removalBlockers.length > 0,
-    sequence: MANUAL_ENROLLMENT_SEQUENCE,
+    sequence: manualPasskeyEnrollmentSequence,
   },
   routes,
   route_boundary: routeBoundary,
-  next_safe_action: nextSafeAction({
+  next_safe_action: nextPasskeyProofAction({
     schemaReady,
     credentialCount,
     sessionCount,
@@ -164,7 +158,7 @@ function runD1(command) {
       command,
     ],
     {
-      cwd: new URL("../../", import.meta.url),
+      cwd: REPO_ROOT,
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"],
     },
@@ -224,64 +218,4 @@ function summarizeBoundary(routes) {
   if (boundaries.has("cloudflare_access")) return "cloudflare_access";
   if (boundaries.has("app_native_passkey")) return "app_native_passkey";
   return "unknown";
-}
-
-function nextSafeAction({
-  schemaReady,
-  credentialCount,
-  sessionCount,
-  missingAuditEvents,
-  routeBoundary,
-}) {
-  if (!schemaReady) {
-    return "apply drizzle/migrations/0006_admin_passkeys.sql before enrollment";
-  }
-  if (credentialCount === 0) {
-    return "open /auth/passkey behind Cloudflare Access and register the first platform passkey";
-  }
-  if (sessionCount === 0) {
-    return "authenticate with the registered passkey and prove a durable app-native session";
-  }
-  if (missingAuditEvents.includes("passkey.session.revoked")) {
-    return "logout once to record session revocation, then authenticate again before Access removal";
-  }
-  if (missingAuditEvents.includes("passkey.credential.revoked")) {
-    return "revoke the current passkey while Cloudflare Access remains active, then register a replacement";
-  }
-  if (missingAuditEvents.includes("passkey.authentication.denied")) {
-    return "record revoked-credential denial proof while Cloudflare Access remains active";
-  }
-  if (missingAuditEvents.length > 0) {
-    return `record missing passkey audit proof: ${missingAuditEvents.join(", ")}`;
-  }
-  if (routeBoundary === "cloudflare_access") {
-    return "passkey proof is staged; remove Cloudflare Access and rerun this proof";
-  }
-  if (routeBoundary === "app_native_passkey") {
-    return "record app-native unauthenticated block and authenticated route render proof";
-  }
-  return "inspect route boundary before changing Access";
-}
-
-function missingProofItems({ accessRemovalBlockers, routeBoundary }) {
-  const missing = [...accessRemovalBlockers];
-  if (routeBoundary === "cloudflare_access") return missing;
-  if (routeBoundary !== "app_native_passkey") {
-    missing.push("app_native_route_boundary");
-  }
-  return missing;
-}
-
-function accessRemovalBlockerItems({
-  schemaReady,
-  credentialCount,
-  sessionCount,
-  missingAuditEvents,
-}) {
-  const missing = [];
-  if (!schemaReady) missing.push("schema_ready");
-  if (credentialCount === 0) missing.push("active_credential");
-  if (sessionCount === 0) missing.push("active_session");
-  missing.push(...missingAuditEvents);
-  return missing;
 }

--- a/scripts/ci/content-platform.test.mjs
+++ b/scripts/ci/content-platform.test.mjs
@@ -2,15 +2,25 @@
 
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 import {
+  buildPasskeyProofItems,
   countProofEntries,
   contentInventorySource,
   disabledRuntimeOverlayResponse,
+  expectedPasskeyTables,
+  manualPasskeyEnrollmentSequence,
+  missingRequiredPasskeyAuditEvents,
   needsAniBuckets,
   needsAniItemsFromJson,
+  nextPasskeyProofAction,
+  nextPasskeyStatusAction,
+  passkeyAccessRemovalBlockers,
+  passkeyMissingProofItems,
   proofSource,
   recordsFromSourceModules,
   readProofEntries,
+  REQUIRED_PASSKEY_AUDIT_EVENTS,
   RUNTIME_FEED_PATH,
   runtimeOverlayErrorResponse,
   runtimeOverlayResponseFromFeed,
@@ -76,6 +86,124 @@ assert.deepEqual(
 );
 assert.equal(needsFixture.length, 1);
 assert.equal(needsFixture[0]?.id, "need-test-action");
+
+assert.deepEqual(
+  REQUIRED_PASSKEY_AUDIT_EVENTS,
+  [
+    "passkey.credential.registered",
+    "passkey.session.created",
+    "passkey.session.revoked",
+    "passkey.credential.revoked",
+    "passkey.authentication.denied",
+  ],
+  "passkey audit events must stay stable for Access removal proof",
+);
+assert.deepEqual(
+  expectedPasskeyTables,
+  [
+    "admin_passkey_audit",
+    "admin_passkey_challenges",
+    "admin_passkey_credentials",
+    "admin_passkey_sessions",
+  ],
+  "passkey proof must check every required D1 table",
+);
+assert.equal(manualPasskeyEnrollmentSequence.length, 7);
+
+const passkeyAuditEvents = {
+  "passkey.credential.registered": 1,
+  "passkey.session.created": 1,
+  "passkey.session.revoked": 0,
+  "passkey.credential.revoked": 0,
+  "passkey.authentication.denied": 0,
+};
+assert.deepEqual(missingRequiredPasskeyAuditEvents(passkeyAuditEvents), [
+  "passkey.session.revoked",
+  "passkey.credential.revoked",
+  "passkey.authentication.denied",
+]);
+assert.deepEqual(
+  passkeyAccessRemovalBlockers({
+    credentialCount: 1,
+    sessionCount: 1,
+    auditEvents: passkeyAuditEvents,
+  }),
+  [
+    "passkey.session.revoked",
+    "passkey.credential.revoked",
+    "passkey.authentication.denied",
+  ],
+);
+assert.deepEqual(
+  passkeyAccessRemovalBlockers({
+    schemaReady: false,
+    credentialCount: 0,
+    sessionCount: 0,
+    auditEvents: {},
+  }),
+  [
+    "schema_ready",
+    "active_credential",
+    "active_session",
+    ...REQUIRED_PASSKEY_AUDIT_EVENTS,
+  ],
+);
+assert.deepEqual(
+  passkeyMissingProofItems({
+    accessRemovalBlockers: ["active_credential"],
+    routeBoundary: "unknown",
+  }),
+  ["active_credential", "app_native_route_boundary"],
+);
+assert.equal(
+  nextPasskeyProofAction({
+    credentialCount: 0,
+    sessionCount: 0,
+    missingAuditEvents: REQUIRED_PASSKEY_AUDIT_EVENTS,
+  }),
+  "open /auth/passkey behind Cloudflare Access and register the first platform passkey",
+);
+assert.equal(
+  nextPasskeyProofAction({
+    credentialCount: 1,
+    sessionCount: 1,
+    missingAuditEvents: [],
+    routeBoundary: "cloudflare_access",
+  }),
+  "passkey proof is staged; remove Cloudflare Access and rerun this proof",
+);
+assert.equal(
+  nextPasskeyStatusAction({
+    hasSession: false,
+    credentialCount: 0,
+    accessIdentityVerified: true,
+  }),
+  "register the first passkey with verified Cloudflare Access identity",
+);
+assert.deepEqual(
+  buildPasskeyProofItems(1, true, passkeyAuditEvents).map((item) => [
+    item.id,
+    item.complete,
+  ]),
+  [
+    ["active_credential", true],
+    ["active_session", true],
+    ["passkey.credential.registered", true],
+    ["passkey.session.created", true],
+    ["passkey.session.revoked", false],
+    ["passkey.credential.revoked", false],
+    ["passkey.authentication.denied", false],
+  ],
+);
+
+const passkeyProofScript = readFileSync(
+  "scripts/admin/passkey-proof.mjs",
+  "utf8",
+);
+assert.ok(passkeyProofScript.includes("REQUIRED_PASSKEY_AUDIT_EVENTS"));
+assert.ok(passkeyProofScript.includes("expectedPasskeyTables"));
+assert.equal(passkeyProofScript.includes("const REQUIRED_AUDIT_EVENTS"), false);
+assert.equal(passkeyProofScript.includes("function nextSafeAction"), false);
 
 const disabledRuntime = disabledRuntimeOverlayResponse();
 assert.equal(disabledRuntime.mode, "disabled");


### PR DESCRIPTION
## summary

- centralize admin passkey proof events, table names, blockers, checklist items, and next-action rules in `@anipotts/content/admin`
- refactor the Astro admin passkey status path and proof route to use the shared contract
- refactor `proof:admin-passkey` to import the shared contract after building `@anipotts/content`
- add content-platform tests that guard the passkey proof contract and prevent proof-script drift

## verification

- `pnpm test:content-platform`
- `pnpm turbo typecheck --filter=@anipotts/admin...`
- `pnpm turbo build --filter=@anipotts/admin...`
- `pnpm test:deploy-targets`
- `pnpm test:admin-routes`
- `pnpm test:security-review`
- `pnpm --silent proof:admin-passkey`
- `pnpm --silent proof:admin-content`
- `pnpm format:check`
- `git diff --check`

## deploy scope

- expected affected target: admin
- no write path, DNS, env, secret, D1 migration, or Cloudflare Access policy change
- passkey proof still reports no active credential/session, so Access removal remains blocked until biometric enrollment proof exists
