### PR TITLE
seed first detail page content rows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -150,7 +150,7 @@ jobs:
       - name: Smoke www routes
         run: |
           set -euo pipefail
-          for path in / /newsletter /newsletter/archive /making /orchestrating /projects /writing; do
+          for path in / /newsletter /newsletter/archive /making /orchestrating /projects /projects/quantercise /writing /writing/saturdays-are-for-claude-code; do
             ok=false
             for _ in $(seq 1 6); do
               code="$(curl -sS -o /dev/null -w '%{http_code}' "https://anipotts.com${path}")"

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -32,7 +32,7 @@ jobs:
         if: inputs.target == 'www'
         run: |
           set -euo pipefail
-          for path in / /newsletter /newsletter/archive /making /orchestrating /projects /writing; do
+          for path in / /newsletter /newsletter/archive /making /orchestrating /projects /projects/quantercise /writing /writing/saturdays-are-for-claude-code; do
             code="$(curl -sS -o /dev/null -w '%{http_code}' "https://anipotts.com${path}")"
             echo "https://anipotts.com${path} -> ${code}"
             test "$code" = "200"

--- a/apps/www/src/components/CmsMarkdown.astro
+++ b/apps/www/src/components/CmsMarkdown.astro
@@ -1,0 +1,176 @@
+---
+type InlineSegment =
+  | { kind: "text"; text: string }
+  | { kind: "em"; text: string }
+  | { kind: "link"; text: string; href: string };
+
+type MarkdownBlock =
+  | { kind: "heading"; level: 2 | 3; segments: InlineSegment[] }
+  | { kind: "paragraph"; segments: InlineSegment[] }
+  | { kind: "list"; items: InlineSegment[][] };
+
+interface Props {
+  body: string;
+}
+
+const { body } = Astro.props;
+const blocks = parseMarkdownBlocks(body);
+
+function parseMarkdownBlocks(raw: string): MarkdownBlock[] {
+  return raw
+    .trim()
+    .split(/\n{2,}/)
+    .map((block) => block.trim())
+    .filter(Boolean)
+    .map(parseBlock);
+}
+
+function parseBlock(block: string): MarkdownBlock {
+  const lines = block
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const first = lines[0] ?? "";
+  const heading = first.match(/^(#{2,3})\s+(.+)$/);
+
+  if (heading && lines.length === 1) {
+    return {
+      kind: "heading",
+      level: heading[1].length as 2 | 3,
+      segments: parseInline(heading[2]),
+    };
+  }
+
+  if (lines.length > 0 && lines.every((line) => line.startsWith("- "))) {
+    return {
+      kind: "list",
+      items: lines.map((line) => parseInline(line.slice(2).trim())),
+    };
+  }
+
+  return {
+    kind: "paragraph",
+    segments: parseInline(lines.join(" ")),
+  };
+}
+
+function parseInline(text: string): InlineSegment[] {
+  const segments: InlineSegment[] = [];
+  const pattern = /\[([^\]]+)\]\(([^)\s]+)\)|_([^_]+)_/g;
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = pattern.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      segments.push({ kind: "text", text: text.slice(lastIndex, match.index) });
+    }
+
+    if (match[1] && match[2]) {
+      const href = match[2].trim();
+      if (isSafeHref(href)) {
+        segments.push({ kind: "link", text: match[1], href });
+      } else {
+        segments.push({ kind: "text", text: `${match[1]} (${href})` });
+      }
+    } else if (match[3]) {
+      segments.push({ kind: "em", text: match[3] });
+    }
+
+    lastIndex = pattern.lastIndex;
+  }
+
+  if (lastIndex < text.length) {
+    segments.push({ kind: "text", text: text.slice(lastIndex) });
+  }
+
+  return segments;
+}
+
+function isSafeHref(href: string): boolean {
+  if (href.startsWith("/")) return !href.startsWith("//");
+  return href.startsWith("https://") || href.startsWith("mailto:");
+}
+---
+
+{
+  blocks.map((block) => {
+    if (block.kind === "heading") {
+      const Heading = `h${block.level}` as "h2" | "h3";
+      return (
+        <Heading>
+          {block.segments.map((segment) =>
+            segment.kind === "link" ? (
+              <a
+                href={segment.href}
+                target={segment.href.startsWith("/") ? undefined : "_blank"}
+                rel={
+                  segment.href.startsWith("/")
+                    ? undefined
+                    : "noopener noreferrer"
+                }
+              >
+                {segment.text}
+              </a>
+            ) : segment.kind === "em" ? (
+              <em>{segment.text}</em>
+            ) : (
+              segment.text
+            ),
+          )}
+        </Heading>
+      );
+    }
+
+    if (block.kind === "list") {
+      return (
+        <ul>
+          {block.items.map((segments) => (
+            <li>
+              {segments.map((segment) =>
+                segment.kind === "link" ? (
+                  <a
+                    href={segment.href}
+                    target={segment.href.startsWith("/") ? undefined : "_blank"}
+                    rel={
+                      segment.href.startsWith("/")
+                        ? undefined
+                        : "noopener noreferrer"
+                    }
+                  >
+                    {segment.text}
+                  </a>
+                ) : segment.kind === "em" ? (
+                  <em>{segment.text}</em>
+                ) : (
+                  segment.text
+                ),
+              )}
+            </li>
+          ))}
+        </ul>
+      );
+    }
+
+    return (
+      <p>
+        {block.segments.map((segment) =>
+          segment.kind === "link" ? (
+            <a
+              href={segment.href}
+              target={segment.href.startsWith("/") ? undefined : "_blank"}
+              rel={
+                segment.href.startsWith("/") ? undefined : "noopener noreferrer"
+              }
+            >
+              {segment.text}
+            </a>
+          ) : segment.kind === "em" ? (
+            <em>{segment.text}</em>
+          ) : (
+            segment.text
+          ),
+        )}
+      </p>
+    );
+  })
+}

--- a/apps/www/src/pages/projects/[slug].astro
+++ b/apps/www/src/pages/projects/[slug].astro
@@ -1,6 +1,7 @@
 ---
 import { render } from "astro:content";
 import Shell from "../../layouts/Shell.astro";
+import CmsMarkdown from "../../components/CmsMarkdown.astro";
 import { Icon } from "astro-icon/components";
 import { projectSlug, visibleProjects } from "../../lib/content";
 import { setDB } from "@anipotts/lib/db";
@@ -22,10 +23,6 @@ const rendered =
 const Content = rendered?.Content;
 const hasBody = Boolean(project.body?.trim());
 const d = project.data;
-const cmsParagraphs = project.body
-  .split(/\n{2,}/)
-  .map((paragraph) => paragraph.trim())
-  .filter(Boolean);
 ---
 
 <Shell
@@ -83,11 +80,7 @@ const cmsParagraphs = project.body
     {
       hasBody ? (
         <div class="article-body">
-          {Content ? (
-            <Content />
-          ) : (
-            cmsParagraphs.map((paragraph) => <p>{paragraph}</p>)
-          )}
+          {Content ? <Content /> : <CmsMarkdown body={project.body} />}
         </div>
       ) : (
         <p class="overview">{d.description}</p>

--- a/apps/www/src/pages/writing/[slug].astro
+++ b/apps/www/src/pages/writing/[slug].astro
@@ -1,6 +1,7 @@
 ---
 import { render } from "astro:content";
 import Shell from "../../layouts/Shell.astro";
+import CmsMarkdown from "../../components/CmsMarkdown.astro";
 import { Icon } from "astro-icon/components";
 import {
   formatDate,
@@ -25,10 +26,6 @@ const rendered =
 const Content = rendered?.Content;
 const d = item.data;
 const minutes = readingTime(item.body ?? "");
-const cmsParagraphs = item.body
-  .split(/\n{2,}/)
-  .map((paragraph) => paragraph.trim())
-  .filter(Boolean);
 
 const articleLd = {
   "@context": "https://schema.org",
@@ -84,13 +81,7 @@ const articleLd = {
     </header>
 
     <div data-rise class="article-body">
-      {
-        Content ? (
-          <Content />
-        ) : (
-          cmsParagraphs.map((paragraph) => <p>{paragraph}</p>)
-        )
-      }
+      {Content ? <Content /> : <CmsMarkdown body={item.body} />}
     </div>
   </article>
 </Shell>

--- a/docs/platform-architecture.md
+++ b/docs/platform-architecture.md
@@ -283,5 +283,11 @@ Rules:
     section labels, loop cards, and public-tool cards. Covered by
     `drizzle/migrations/0030_expand_orchestrating_page_content.sql`; route
     fallback remains in `@anipotts/content/public`.
-33. reduce deploy workflow inputs to retained production targets after rollback
+33. seed the first individual project and writing detail records into
+    `page_content` while preserving source fallbacks. Covered by
+    `drizzle/migrations/0031_seed_detail_page_content.sql` for
+    `/projects/quantercise` and `/writing/saturdays-are-for-claude-code`.
+    This proves the detail-record path without adding save APIs, publish
+    writes, sends, source rewrites, or external mutations.
+34. reduce deploy workflow inputs to retained production targets after rollback
     no longer needs `apps/admin-solid`.

--- a/drizzle/migrations/0031_seed_detail_page_content.sql
+++ b/drizzle/migrations/0031_seed_detail_page_content.sql
@@ -1,0 +1,171 @@
+-- 0031_seed_detail_page_content.sql
+-- Seed first individual project and writing detail records into page_content.
+--
+-- This preserves the current public markdown/frontmatter rendering for one
+-- project detail page and one writing detail page while proving the structured
+-- detail-record path. It does not add save APIs, publish writes, newsletter
+-- sends, source rewrites, Cloudflare Access changes, or external mutations.
+--
+-- Rollback:
+--   DELETE FROM page_content
+--   WHERE id IN (
+--     'page-project-quantercise-v1-2026-06-29',
+--     'page-writing-saturdays-are-for-claude-code-v1-2026-06-29'
+--   );
+--   DELETE FROM content_draft_operations
+--   WHERE operation_id IN (
+--     'content-draft-project-quantercise-detail-2026-06-29',
+--     'content-draft-writing-saturdays-detail-2026-06-29'
+--   );
+
+INSERT OR IGNORE INTO page_content (
+  id,
+  page_key,
+  content,
+  version,
+  published,
+  updated_at,
+  updated_by,
+  created_at,
+  version_history
+) VALUES (
+  'page-project-quantercise-v1-2026-06-29',
+  'project:quantercise',
+  '{"slug":"quantercise","title":"quantercise","status":"live","year":"2024-","range":"Ongoing","tags":["next.js","typescript","postgres","drizzle","stripe","python"],"summary":"quant prep with postgres, drizzle, stripe, and sandboxed python grading.","body":"Quantercise started as my own quant interview prep tool and turned into a full product: 400+ problems, real-time Python execution, math rendering, progress tracking, and payments.","links":[{"label":"live site","url":"https://quantercise.com"}],"featured":true,"order":100,"visible":true}',
+  1,
+  1,
+  '2026-06-29T07:30:00Z',
+  'codex',
+  '2026-06-29T07:30:00Z',
+  '[{"event":"seeded","source":"drizzle/migrations/0031_seed_detail_page_content.sql","summary":"Seeded project:quantercise as structured detail page_content while preserving markdown fallback."}]'
+);
+
+INSERT OR IGNORE INTO page_content (
+  id,
+  page_key,
+  content,
+  version,
+  published,
+  updated_at,
+  updated_by,
+  created_at,
+  version_history
+) VALUES (
+  'page-writing-saturdays-are-for-claude-code-v1-2026-06-29',
+  'writing:saturdays-are-for-claude-code',
+  '{"slug":"saturdays-are-for-claude-code","title":"saturdays are for claude code","date":"2026-04-13","tags":["claude-code","press","workflow","building"],"preview":"business insider interviewed me about ai usage limits. the useful part was less the quote and more the workflow it forced.","body":"The original Business Insider piece is here: [Saturdays are for Claude: How AI limits are reshaping the workday](https://www.businessinsider.com/ai-usage-limits-causing-some-to-restructure-their-workday-2026-4).\n\nA reporter from Business Insider reached out a couple weeks ago. He was writing about how usage limits on AI tools are changing the way people work. Somebody pointed him to me because I''ve been pretty vocal about how I use Claude Code.\n\nHe nailed the broad strokes. I do plan my work around session limits. I do save the hardest tasks for when I''m far from the cap. And yes, Saturdays are for Claude Code. That quote is real. My friends think I''m joking when I say that. I''m not.\n\nBut there''s stuff the article couldn''t capture because it''s a 1200-word piece about multiple people, not a deep dive on one workflow.\n\n## The actual numbers\n\nI track everything. Every session, every tool call, every dollar.\n\nMy median Claude Code session runs about 31 minutes wall clock. But Claude is only _actively working_ for about 15 of those minutes. The rest is me: reading diffs, making decisions, approving tool calls. The bottleneck is never the AI. It''s me.\n\nActive tool rate holds steady at about 3.3 calls per minute for any session over 10 minutes. Claude doesn''t slow down in long sessions. I do. Wall-time tool rate drops 8.8x from short sessions to marathons. That''s 100% human idle time.\n\nSessions under 30 minutes are the sweet spot. Past an hour, more than half hit context limits and need compaction. That''s when you lose coherence. So the usage limit forcing you to stop isn''t just about tokens. It''s preventing the session quality degradation that happens naturally anyway.\n\nYou can see the broader agent workflow on [my orchestrating page](/orchestrating). It''s live, updated from my actual session logs.\n\n## Why the limit is a feature\n\nThe article framed limits as a constraint. And for the other people interviewed, it clearly is. One guy described panic when his team hits the cap. I get that.\n\nBut for me, the forced pause has become genuinely useful. When I hit the limit I stop and review. Not because I want to. Because I have to. And every time, I catch something I would have missed if I''d kept going. A file I over-abstracted. A test I forgot. An approach that''s working but not the right one.\n\nThe best sessions aren''t the ones where Claude runs the longest. They''re the ones where I front-loaded the context, kept the scope tight, and let it execute a focused plan. You learn that pretty fast when sessions cost real money (or cap your allowance).\n\n## What I''m building with it\n\nI''ve logged over 1,000 hours of Claude Code across 600+ sessions. Right now I''m running 5 Claude Code sessions across different projects in a given week. The admin dashboard for this site, a quantitative interview prep app, a Mac Mini monitoring system, and open source tooling for other Claude Code users. I built [Claudemon](/writing/i-built-a-monitor-for-my-claude-code-sessions) to watch all of them from one place.\n\nThe irony of getting interviewed about usage limits is that my entire workflow is designed to be maximally efficient with those limits. Specific prompts. Tight session scopes. [End-of-day todos written as agent instructions](/writing/stop-ending-your-day-with-fix-the-bug). Parallel agents in worktrees. None of this is because I''m trying to game the system. It''s because it produces better code.\n\nThe limits just made me figure that out faster.","sourceLinks":[{"label":"source","url":"https://www.businessinsider.com/ai-usage-limits-causing-some-to-restructure-their-workday-2026-4"}],"visible":true,"order":50}',
+  1,
+  1,
+  '2026-06-29T07:30:00Z',
+  'codex',
+  '2026-06-29T07:30:00Z',
+  '[{"event":"seeded","source":"drizzle/migrations/0031_seed_detail_page_content.sql","summary":"Seeded writing:saturdays-are-for-claude-code as structured detail page_content while preserving markdown fallback."}]'
+);
+
+INSERT OR IGNORE INTO content_draft_operations (
+  operation_id,
+  kind,
+  surface,
+  route,
+  source_ref,
+  field_path,
+  current_value_ref,
+  proposed_value,
+  status,
+  risk_level,
+  authority_state,
+  required_approval_ids,
+  allowed_actions,
+  forbidden_actions,
+  preview_targets,
+  proof_ids,
+  evidence_uri,
+  redaction,
+  created_by,
+  created_at,
+  updated_at,
+  expires_at,
+  rollback_ref,
+  reviewer_note,
+  metadata
+) VALUES (
+  'content-draft-project-quantercise-detail-2026-06-29',
+  'content_draft',
+  'public_site',
+  '/projects/quantercise',
+  'D1 page_content:project:quantercise seeded by drizzle/migrations/0031_seed_detail_page_content.sql, fallback apps/www/src/content/projects/quantercise.md',
+  'projects.quantercise.detail',
+  'published_page_content:project:quantercise',
+  'Review future edits to the Quantercise title, summary, body, links, tags, and visibility through preview-only operations before any save path edits page_content.',
+  'previewed',
+  'medium',
+  'detail_page_content_preview_only_no_write',
+  '[]',
+  '["render_preview","request_review"]',
+  '["save","publish","deploy","rewrite_markdown","sync_external"]',
+  '["/content/review","/content/preview","/projects/quantercise"]',
+  '["content.projects.quantercise.page-content","admin.content.preview.d1"]',
+  'repo://apps/www/src/content/projects/quantercise.md',
+  'public_copy_only',
+  'agent',
+  '2026-06-29T07:30:00Z',
+  '2026-06-29T07:30:00Z',
+  '2026-07-29T07:30:00Z',
+  'source_markdown:apps/www/src/content/projects/quantercise.md',
+  'First project detail row seeded as inert preview metadata. No source rewrite, save route, or publish event is created.',
+  '{"source_migration":"drizzle/migrations/0031_seed_detail_page_content.sql"}'
+);
+
+INSERT OR IGNORE INTO content_draft_operations (
+  operation_id,
+  kind,
+  surface,
+  route,
+  source_ref,
+  field_path,
+  current_value_ref,
+  proposed_value,
+  status,
+  risk_level,
+  authority_state,
+  required_approval_ids,
+  allowed_actions,
+  forbidden_actions,
+  preview_targets,
+  proof_ids,
+  evidence_uri,
+  redaction,
+  created_by,
+  created_at,
+  updated_at,
+  expires_at,
+  rollback_ref,
+  reviewer_note,
+  metadata
+) VALUES (
+  'content-draft-writing-saturdays-detail-2026-06-29',
+  'content_draft',
+  'public_site',
+  '/writing/saturdays-are-for-claude-code',
+  'D1 page_content:writing:saturdays-are-for-claude-code seeded by drizzle/migrations/0031_seed_detail_page_content.sql, fallback apps/www/src/content/writing/saturdays-are-for-claude-code.md',
+  'writing.saturdays_are_for_claude_code.detail',
+  'published_page_content:writing:saturdays-are-for-claude-code',
+  'Review future edits to the Saturdays are for Claude Code title, summary, body, source link, tags, and publish visibility through preview-only operations before any save path edits page_content.',
+  'previewed',
+  'medium',
+  'detail_page_content_preview_only_no_write',
+  '[]',
+  '["render_preview","request_review"]',
+  '["save","publish","send","schedule","rewrite_markdown","sync_provider"]',
+  '["/content/review","/content/preview","/writing/saturdays-are-for-claude-code"]',
+  '["content.writing.saturdays.page-content","admin.content.preview.d1"]',
+  'repo://apps/www/src/content/writing/saturdays-are-for-claude-code.md',
+  'public_copy_only',
+  'agent',
+  '2026-06-29T07:30:00Z',
+  '2026-06-29T07:30:00Z',
+  '2026-07-29T07:30:00Z',
+  'source_markdown:apps/www/src/content/writing/saturdays-are-for-claude-code.md',
+  'First writing detail row seeded as inert preview metadata. No source rewrite, send, save route, or publish event is created.',
+  '{"source_migration":"drizzle/migrations/0031_seed_detail_page_content.sql"}'
+);

--- a/packages/content/src/admin/content.ts
+++ b/packages/content/src/admin/content.ts
@@ -321,15 +321,19 @@ export const contentInventory: ContentInventoryItem[] = [
     id: "projects.detail_body",
     surface: "projects",
     title: "project detail body",
-    source_ref: "apps/www/src/content/projects/*.md body",
+    source_ref:
+      "D1 page_content:project:quantercise seeded by drizzle/migrations/0031_seed_detail_page_content.sql for the first detail row, fallback apps/www/src/content/projects/*.md body",
     current_value:
-      "Project bodies plus optional technical and roadmap arrays drive detail pages where present.",
+      "Quantercise now has a structured detail page_content row. Other project bodies plus optional technical and roadmap arrays still fall back to Astro markdown.",
     editability: "ready",
     risk_level: "medium",
     next_safe_action:
-      "Add read-only markdown preview before body editing because detail pages carry public claims.",
+      "Extend detail page_content rows one project at a time before adding any save path, because detail pages carry public claims.",
     required_authority: [],
-    proof_ids: ["content.projects.body.schema"],
+    proof_ids: [
+      "content.projects.body.schema",
+      "content.projects.quantercise.page-content",
+    ],
   },
   {
     id: "projects.duplicate_source",
@@ -378,15 +382,19 @@ export const contentInventory: ContentInventoryItem[] = [
     id: "writing.body",
     surface: "writing",
     title: "writing body",
-    source_ref: "apps/www/src/content/writing/*.md body",
+    source_ref:
+      "D1 page_content:writing:saturdays-are-for-claude-code seeded by drizzle/migrations/0031_seed_detail_page_content.sql for the first detail row, fallback apps/www/src/content/writing/*.md body",
     current_value:
-      "Published article bodies are markdown files in the Astro writing collection.",
+      "Saturdays are for Claude Code now has a structured detail page_content row. Other published article bodies still fall back to Astro markdown.",
     editability: "ready",
     risk_level: "medium",
     next_safe_action:
-      "Use preview-only diffs before edits; publishing and outbound syndication stay separate.",
+      "Extend detail page_content rows one writing item at a time; publishing and outbound syndication stay separate.",
     required_authority: [],
-    proof_ids: ["content.writing.body.source"],
+    proof_ids: [
+      "content.writing.body.source",
+      "content.writing.saturdays.page-content",
+    ],
   },
   {
     id: "writing.claude_stats_link",

--- a/packages/content/src/admin/operations.ts
+++ b/packages/content/src/admin/operations.ts
@@ -123,7 +123,7 @@ export type ContentOperationTable = {
 export const contentOperationSchemaSource = {
   source_doc: "docs/admin-content-draft-operations.md",
   migration:
-    "drizzle/migrations/0007_content_operations.sql + drizzle/migrations/0008_seed_content_draft_operations.sql + drizzle/migrations/0011_seed_source_content_review_operations.sql + drizzle/migrations/0028_seed_listing_content_review_operations.sql + drizzle/migrations/0030_expand_orchestrating_page_content.sql",
+    "drizzle/migrations/0007_content_operations.sql + drizzle/migrations/0008_seed_content_draft_operations.sql + drizzle/migrations/0011_seed_source_content_review_operations.sql + drizzle/migrations/0028_seed_listing_content_review_operations.sql + drizzle/migrations/0030_expand_orchestrating_page_content.sql + drizzle/migrations/0031_seed_detail_page_content.sql",
   schema: "packages/lib/src/db/schema.ts",
   mode: "d1_schema_no_write_endpoint",
 };
@@ -422,6 +422,49 @@ export const contentOperationTemplates: ContentOperation[] = [
       "Seeded as an inert review operation. No source files or public routes are changed.",
   },
   {
+    operation_id: "content-draft-project-quantercise-detail-2026-06-29",
+    kind: "content_draft",
+    surface: "public_site",
+    route: "/projects/quantercise",
+    source_ref:
+      "D1 page_content:project:quantercise seeded by drizzle/migrations/0031_seed_detail_page_content.sql, fallback apps/www/src/content/projects/quantercise.md",
+    field_path: "projects.quantercise.detail",
+    current_value_ref: "published_page_content:project:quantercise",
+    proposed_value:
+      "Review future edits to the Quantercise title, summary, body, links, tags, and visibility through preview-only operations before any save path edits page_content.",
+    status: "previewed",
+    risk_level: "medium",
+    authority_state: "detail_page_content_preview_only_no_write",
+    required_approval_ids: [],
+    allowed_actions: ["render_preview", "request_review"],
+    forbidden_actions: [
+      "save",
+      "publish",
+      "deploy",
+      "rewrite_markdown",
+      "sync_external",
+    ],
+    preview_targets: [
+      "/content/review",
+      "/content/preview",
+      "/projects/quantercise",
+    ],
+    proof_ids: [
+      "content.projects.quantercise.page-content",
+      "admin.content.preview.d1",
+    ],
+    evidence_uri: "repo://apps/www/src/content/projects/quantercise.md",
+    redaction: "public_copy_only",
+    created_by: "agent",
+    created_at: "2026-06-29T07:30:00Z",
+    updated_at: "2026-06-29T07:30:00Z",
+    expires_at: "2026-07-29T07:30:00Z",
+    rollback_ref:
+      "source_markdown:apps/www/src/content/projects/quantercise.md",
+    reviewer_note:
+      "First project detail row seeded as inert preview metadata. No source rewrite, save route, or publish event is created.",
+  },
+  {
     operation_id: "content-draft-writing-newsletter-backfill-2026-06-28",
     kind: "content_draft",
     surface: "newsletter",
@@ -458,6 +501,52 @@ export const contentOperationTemplates: ContentOperation[] = [
     rollback_ref: "source_markdown_collection",
     reviewer_note:
       "Seeded as an inert review operation. No newsletter provider action, send, schedule, or source mutation is created.",
+  },
+  {
+    operation_id: "content-draft-writing-saturdays-detail-2026-06-29",
+    kind: "content_draft",
+    surface: "public_site",
+    route: "/writing/saturdays-are-for-claude-code",
+    source_ref:
+      "D1 page_content:writing:saturdays-are-for-claude-code seeded by drizzle/migrations/0031_seed_detail_page_content.sql, fallback apps/www/src/content/writing/saturdays-are-for-claude-code.md",
+    field_path: "writing.saturdays_are_for_claude_code.detail",
+    current_value_ref:
+      "published_page_content:writing:saturdays-are-for-claude-code",
+    proposed_value:
+      "Review future edits to the Saturdays are for Claude Code title, summary, body, source link, tags, and publish visibility through preview-only operations before any save path edits page_content.",
+    status: "previewed",
+    risk_level: "medium",
+    authority_state: "detail_page_content_preview_only_no_write",
+    required_approval_ids: [],
+    allowed_actions: ["render_preview", "request_review"],
+    forbidden_actions: [
+      "save",
+      "publish",
+      "send",
+      "schedule",
+      "rewrite_markdown",
+      "sync_provider",
+    ],
+    preview_targets: [
+      "/content/review",
+      "/content/preview",
+      "/writing/saturdays-are-for-claude-code",
+    ],
+    proof_ids: [
+      "content.writing.saturdays.page-content",
+      "admin.content.preview.d1",
+    ],
+    evidence_uri:
+      "repo://apps/www/src/content/writing/saturdays-are-for-claude-code.md",
+    redaction: "public_copy_only",
+    created_by: "agent",
+    created_at: "2026-06-29T07:30:00Z",
+    updated_at: "2026-06-29T07:30:00Z",
+    expires_at: "2026-07-29T07:30:00Z",
+    rollback_ref:
+      "source_markdown:apps/www/src/content/writing/saturdays-are-for-claude-code.md",
+    reviewer_note:
+      "First writing detail row seeded as inert preview metadata. No source rewrite, send, save route, or publish event is created.",
   },
   {
     operation_id: "content-draft-making-index-copy-2026-06-29",

--- a/scripts/admin/content-proof.mjs
+++ b/scripts/admin/content-proof.mjs
@@ -14,8 +14,10 @@ const REQUIRED_PAGE_KEYS = [
   "newsletter",
   "newsletter_archive",
   "orchestrating",
+  "project:quantercise",
   "projects",
   "writing",
+  "writing:saturdays-are-for-claude-code",
 ];
 const LISTING_PAGE_PROOF = {
   making: { heroLink: false, search: false },
@@ -33,7 +35,9 @@ const REQUIRED_OPERATIONS = [
   "content-draft-homepage-summary-2026-06-28",
   "content-draft-newsletter-copy-2026-06-28",
   "content-draft-project-card-fields-2026-06-28",
+  "content-draft-project-quantercise-detail-2026-06-29",
   "content-draft-writing-newsletter-backfill-2026-06-28",
+  "content-draft-writing-saturdays-detail-2026-06-29",
   "content-draft-making-index-copy-2026-06-29",
   "content-draft-projects-index-copy-2026-06-29",
   "content-draft-writing-index-copy-2026-06-29",
@@ -55,8 +59,20 @@ const PUBLIC_ROUTES = [
   "/making",
   "/orchestrating",
   "/projects",
+  "/projects/quantercise",
   "/writing",
+  "/writing/saturdays-are-for-claude-code",
 ];
+const DETAIL_PAGE_PROOF = {
+  "project:quantercise": {
+    route: "/projects/quantercise",
+    slug: "quantercise",
+  },
+  "writing:saturdays-are-for-claude-code": {
+    route: "/writing/saturdays-are-for-claude-code",
+    slug: "saturdays-are-for-claude-code",
+  },
+};
 
 const checkedAt = new Date().toISOString();
 
@@ -126,7 +142,11 @@ SELECT
   coalesce(json_type(content, '$.panel_copy'), 'missing') AS listing_panel_copy_type,
   coalesce(json_type(content, '$.search_placeholder'), 'missing') AS listing_search_placeholder_type,
   coalesce(json_type(content, '$.hero_link_label'), 'missing') AS listing_hero_link_label_type,
-  json_extract(content, '$.hero_link_href') AS listing_hero_link_href
+  json_extract(content, '$.hero_link_href') AS listing_hero_link_href,
+  json_extract(content, '$.slug') AS detail_slug,
+  coalesce(json_type(content, '$.title'), 'missing') AS detail_title_type,
+  coalesce(json_type(content, '$.body'), 'missing') AS detail_body_type,
+  coalesce(json_type(content, '$.visible'), 'missing') AS detail_visible_type
 FROM page_content
 ORDER BY page_key ASC, version DESC;
 `);
@@ -241,6 +261,20 @@ const missingListingFields = Object.entries(LISTING_PAGE_PROOF).flatMap(
       .map(([field]) => `${pageKey}_${field}`);
   },
 );
+const missingDetailFields = Object.entries(DETAIL_PAGE_PROOF).flatMap(
+  ([pageKey, options]) => {
+    const row = pageRows.find(
+      (pageRow) =>
+        String(pageRow.page_key) === pageKey && Number(pageRow.published) === 1,
+    );
+    return Object.entries(detailProofFieldTypes(row, options))
+      .filter(
+        ([, type]) =>
+          type !== "text" && type !== "integer" && type !== "boolean",
+      )
+      .map(([field]) => `${pageKey}_${field}`);
+  },
+);
 
 const missingProof = [
   ...missingPageKeys.map((pageKey) => `published_page_content:${pageKey}`),
@@ -255,6 +289,7 @@ const missingProof = [
   ...(homeMentionCount === 5 ? [] : ["home_mentions"]),
   ...missingNewsletterFields,
   ...missingListingFields,
+  ...missingDetailFields,
   ...missingOperations.map((operationId) => `content_operation:${operationId}`),
   ...staleOperationSources.map(
     (operationId) => `stale_content_operation_source:${operationId}`,
@@ -323,6 +358,14 @@ const proof = {
     listing_field_types:
       String(row.page_key) in LISTING_PAGE_PROOF
         ? listingProofFieldTypes(row, LISTING_PAGE_PROOF[String(row.page_key)])
+        : null,
+    detail_slug:
+      String(row.page_key) in DETAIL_PAGE_PROOF
+        ? (row.detail_slug ?? null)
+        : null,
+    detail_field_types:
+      String(row.page_key) in DETAIL_PAGE_PROOF
+        ? detailProofFieldTypes(row, DETAIL_PAGE_PROOF[String(row.page_key)])
         : null,
   })),
   content_draft_operations: operationRows.map((row) => ({
@@ -494,6 +537,29 @@ function listingProofFieldTypes(row, options) {
   }
 
   return fields;
+}
+
+function detailProofFieldTypes(row, options) {
+  if (!row) {
+    return {
+      slug: "missing",
+      title: "missing",
+      body: "missing",
+      visible: "missing",
+    };
+  }
+
+  return {
+    slug: row.detail_slug === options.slug ? "text" : "missing",
+    title: row.detail_title_type,
+    body: row.detail_body_type,
+    visible:
+      row.detail_visible_type === "true" ||
+      row.detail_visible_type === "false" ||
+      row.detail_visible_type === "integer"
+        ? "boolean"
+        : "missing",
+  };
 }
 
 function isSafeProofHref(href) {

--- a/scripts/ci/content-platform.test.mjs
+++ b/scripts/ci/content-platform.test.mjs
@@ -43,9 +43,11 @@ const EXPECTED_OPERATION_IDS = [
   "content-draft-newsletter-copy-2026-06-28",
   "content-draft-orchestrating-hero-copy-2026-06-29",
   "content-draft-project-card-fields-2026-06-28",
+  "content-draft-project-quantercise-detail-2026-06-29",
   "content-draft-projects-index-copy-2026-06-29",
   "content-draft-writing-index-copy-2026-06-29",
   "content-draft-writing-newsletter-backfill-2026-06-28",
+  "content-draft-writing-saturdays-detail-2026-06-29",
 ];
 
 const UNSAFE_ALLOWED_ACTIONS = new Set([

--- a/scripts/ci/public-route-parity.test.mjs
+++ b/scripts/ci/public-route-parity.test.mjs
@@ -13,7 +13,15 @@ const PUBLIC_ROUTES = [
   { route: "/making", file: "apps/www/src/pages/making.astro" },
   { route: "/orchestrating", file: "apps/www/src/pages/orchestrating.astro" },
   { route: "/projects", file: "apps/www/src/pages/projects/index.astro" },
+  {
+    route: "/projects/quantercise",
+    file: "apps/www/src/pages/projects/[slug].astro",
+  },
   { route: "/writing", file: "apps/www/src/pages/writing/index.astro" },
+  {
+    route: "/writing/saturdays-are-for-claude-code",
+    file: "apps/www/src/pages/writing/[slug].astro",
+  },
 ];
 
 const deployWorkflow = readFileSync(".github/workflows/deploy.yml", "utf8");


### PR DESCRIPTION
## summary

- seed first structured D1 detail rows for `project:quantercise` and `writing:saturdays-are-for-claude-code`
- add inert admin content-draft operations for preview/review only
- render D1 markdown-lite bodies safely on public project and writing detail pages
- extend content proof, route parity tests, and deploy smoke coverage for the two detail routes

## migration

`drizzle/migrations/0031_seed_detail_page_content.sql` was applied to remote D1 `anipotts-db` before this PR so the current live app can read the rows. The migration is idempotent and includes rollback comments for the seeded page_content and content_draft_operations rows.

## target proof

`node scripts/ci/compute-deploy-targets.mjs /tmp/detail-page-seeds-files.txt`:

```
www=true
admin=true
admin_solid=false
ingest=false
newsletter=false
state=false
weekly_email=false
```

## verification

- `pnpm turbo typecheck --filter=@anipotts/www...`
- `pnpm turbo build --filter=@anipotts/www...`
- `pnpm turbo typecheck --filter=@anipotts/admin...`
- `pnpm turbo build --filter=@anipotts/admin...`
- `pnpm --filter @anipotts/content build`
- `pnpm --filter @anipotts/content typecheck`
- `pnpm --silent test:content-platform`
- `pnpm --silent test:public-routes`
- `pnpm --silent test:admin-routes`
- `pnpm --silent test:deploy-targets`
- `pnpm --silent test:workflows`
- `pnpm --silent test:security-review`
- `pnpm --silent test:public-boundary`
- `pnpm --silent proof:admin-content`
- `git diff --check HEAD~1 HEAD`

## live impact

Expected deploy targets after merge: public `www` and Astro `admin`. No admin-solid, workers, ingest, newsletter send, state worker, or weekly-email deploy target should run.
