### PR TITLE
harden passkey replacement registration

### DIFF
--- a/apps/admin/src/lib/passkey-auth.ts
+++ b/apps/admin/src/lib/passkey-auth.ts
@@ -332,7 +332,17 @@ export async function verifyRegistration(
     .prepare(
       `INSERT INTO admin_passkey_credentials
         (id, user_id, credential_id, public_key, counter, transports, device_type, backed_up, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(credential_id) DO UPDATE SET
+        user_id = excluded.user_id,
+        public_key = excluded.public_key,
+        counter = excluded.counter,
+        transports = excluded.transports,
+        device_type = excluded.device_type,
+        backed_up = excluded.backed_up,
+        last_used_at = NULL,
+        revoked_at = NULL,
+        updated_at = excluded.updated_at`,
     )
     .bind(
       randomId(),

--- a/scripts/ci/content-platform.test.mjs
+++ b/scripts/ci/content-platform.test.mjs
@@ -224,6 +224,19 @@ assert.ok(passkeyProofScript.includes("expectedPasskeyTables"));
 assert.equal(passkeyProofScript.includes("const REQUIRED_AUDIT_EVENTS"), false);
 assert.equal(passkeyProofScript.includes("function nextSafeAction"), false);
 
+const passkeyAuthSource = readFileSync(
+  "apps/admin/src/lib/passkey-auth.ts",
+  "utf8",
+);
+assert.ok(
+  passkeyAuthSource.includes("ON CONFLICT(credential_id) DO UPDATE SET"),
+  "passkey registration must support re-registering a revoked platform credential",
+);
+assert.ok(
+  passkeyAuthSource.includes("revoked_at = NULL"),
+  "passkey replacement registration must reactivate a previously revoked credential",
+);
+
 const disabledRuntime = disabledRuntimeOverlayResponse();
 assert.equal(disabledRuntime.mode, "disabled");
 assert.equal(disabledRuntime.available, false);


### PR DESCRIPTION
## summary

- make passkey registration conflict-safe for a revoked credential id
- preserve replacement flow for the required revoke, denial, re-register proof sequence
- add a CI assertion that this fallback remains in the admin auth implementation

## why

The Access-removal proof asks us to revoke the current platform passkey, record denial, then register a replacement. Some platform authenticators may return the same credential id when re-registering for the same RP/user. The existing unique constraint could turn that proof step into a dead end. This updates registration to reactivate that credential id on conflict instead of failing.

## deploy target expectation

- expected target: admin only
- expected skipped targets: www, admin-solid, state, ingest, newsletter, weekly-email

## verification

- pnpm --filter @anipotts/admin build
- pnpm --filter @anipotts/admin typecheck
- pnpm --silent test:content-platform
- pnpm --silent test:admin-routes
- pnpm --silent test:security-review
- git diff --check
- git diff --check HEAD~1 HEAD

## safety

- no Cloudflare Access policy change
- no DNS change
- no secret/env change
- no write path beyond existing passkey registration/session audit tables
