### PR TITLE
add inert page content editor route

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -206,7 +206,7 @@ jobs:
       - name: Smoke admin unauthenticated block
         run: |
           set -euo pipefail
-          for path in /auth/passkey / /content /content/review /content/drafts /content/preview /content/operations /newsletter /newsletter/first-thing-agents-need-control-plane /needs-ani /proof /repos /handoffs /fleet /mutations /ops/destructive; do
+          for path in /auth/passkey / /content /content/review /content/drafts /content/edit/home /content/preview /content/operations /newsletter /newsletter/first-thing-agents-need-control-plane /needs-ani /proof /repos /handoffs /fleet /mutations /ops/destructive; do
             ok=false
             for _ in $(seq 1 6); do
               code="$(curl -sS -o /dev/null -w '%{http_code}' "https://admin.anipotts.com${path}")"

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -43,7 +43,7 @@ jobs:
         if: inputs.target == 'admin'
         run: |
           set -euo pipefail
-          for path in /auth/passkey / /content /content/review /content/drafts /content/preview /content/operations /newsletter /newsletter/first-thing-agents-need-control-plane /needs-ani /proof /repos /handoffs /fleet /mutations /ops/destructive; do
+          for path in /auth/passkey / /content /content/review /content/drafts /content/edit/home /content/preview /content/operations /newsletter /newsletter/first-thing-agents-need-control-plane /needs-ani /proof /repos /handoffs /fleet /mutations /ops/destructive; do
             code="$(curl -sS -o /dev/null -w '%{http_code}' "https://admin.anipotts.com${path}")"
             echo "https://admin.anipotts.com${path} -> ${code}"
             case "$path:$code" in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,8 @@ For `admin.anipotts.com`, use this order:
 4. prove passkey register, login, logout, session persistence, and blocked
    failure paths
 5. prove `/auth/passkey`, `/`, `/content`, `/content/review`,
-   `/content/drafts`, `/content/preview`, `/content/operations`, `/newsletter`,
+   `/content/drafts`, `/content/edit/home`, `/content/preview`,
+   `/content/operations`, `/newsletter`,
    `/newsletter/first-thing-agents-need-control-plane`, `/needs-ani`, and
    `/proof`
 6. remove Cloudflare Access only after proof passes

--- a/apps/admin/src/pages/content/drafts.astro
+++ b/apps/admin/src/pages/content/drafts.astro
@@ -167,6 +167,14 @@ const writeRowsEmpty = writableRows.every((row) => row.rows === 0);
               </p>
               <h3>{row.summary}</h3>
             </div>
+            <div class="inline-actions">
+              <a
+                class="button secondary"
+                href={`/content/edit/${encodeURIComponent(row.page_key)}`}
+              >
+                open editor
+              </a>
+            </div>
             <div class="field-grid">
               {row.fields.slice(0, 12).map((field) => (
                 <label class="field-chip field-input-chip">

--- a/apps/admin/src/pages/content/edit/[pageKey].astro
+++ b/apps/admin/src/pages/content/edit/[pageKey].astro
@@ -1,0 +1,166 @@
+---
+import AdminLayout from "../../../layouts/AdminLayout.astro";
+import { readPageContentInventoryStore } from "../../../data/content";
+
+const pageKey = safeDecodePageKey(Astro.params.pageKey);
+const pageContentState = await readPageContentInventoryStore(
+  Astro.locals.runtime?.env.DB,
+);
+const pageRow = pageContentState.rows.find((row) => row.page_key === pageKey);
+
+if (!pageRow) {
+  Astro.response.status = 404;
+}
+
+function safeDecodePageKey(value: string | undefined): string {
+  if (!value) return "";
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+function textareaRows(value: string): number {
+  const lineCount = value.split("\n").length;
+  const lengthRows = Math.ceil(value.length / 78);
+  return Math.min(14, Math.max(3, lineCount, lengthRows));
+}
+---
+
+<AdminLayout
+  title={pageRow ? `edit ${pageRow.page_key}` : "content row missing"}
+  deck="Focused page_content editor shape. Fields are disabled until the audited save path exists."
+>
+  <section class="meta-strip" aria-label="content edit state">
+    <span>{pageContentState.mode}</span>
+    <span>{pageRow ? `${pageRow.field_count} fields` : "0 fields"}</span>
+    <span>{pageRow?.published ? "published" : "draft or missing"}</span>
+    <span>save disabled</span>
+    <span>publish disabled</span>
+  </section>
+
+  {
+    pageRow ? (
+      <>
+        <section class="table-card operation-card">
+          <div class="section-head">
+            <div>
+              <p>page_content record</p>
+              <h2>{pageRow.summary}</h2>
+            </div>
+            <span>read only</span>
+          </div>
+          <div class="record-list">
+            <article class="record-row">
+              <div>
+                <p>
+                  {pageRow.page_key} / v{pageRow.version}
+                </p>
+                <h3>{pageRow.source_ref}</h3>
+              </div>
+              <dl>
+                <div>
+                  <dt>published</dt>
+                  <dd>{pageRow.published ? "true" : "false"}</dd>
+                </div>
+                <div>
+                  <dt>updated</dt>
+                  <dd>{pageRow.updated_at || "unknown"}</dd>
+                </div>
+                <div>
+                  <dt>updated by</dt>
+                  <dd>{pageRow.updated_by || "unknown"}</dd>
+                </div>
+                <div>
+                  <dt>write state</dt>
+                  <dd>no save route, no publish route, no content mutation</dd>
+                </div>
+              </dl>
+            </article>
+          </div>
+        </section>
+
+        <section class="editor-panel" aria-labelledby="editor-fields-heading">
+          <div class="section-head">
+            <div>
+              <p>draft editor model</p>
+              <h2 id="editor-fields-heading">field review</h2>
+            </div>
+            <span>disabled controls</span>
+          </div>
+          <form
+            class="page-editor-form"
+            aria-label={`${pageRow.page_key} fields`}
+          >
+            {pageRow.fields.map((field) => (
+              <label class="page-editor-field">
+                <span>{field.path}</span>
+                <textarea rows={textareaRows(field.raw_value)} disabled>
+                  {field.raw_value}
+                </textarea>
+                <small>
+                  {field.kind} / source {pageRow.source_ref}
+                </small>
+              </label>
+            ))}
+            <div class="draft-control-row page-editor-actions">
+              <button class="button secondary" type="button" disabled>
+                save draft
+              </button>
+              <button class="button secondary" type="button" disabled>
+                request review
+              </button>
+              <button class="button secondary" type="button" disabled>
+                preview public route
+              </button>
+              <button class="button secondary danger" type="button" disabled>
+                publish
+              </button>
+            </div>
+          </form>
+        </section>
+
+        {pageRow.source_backed_fields.length > 0 && (
+          <section class="notice">
+            Source-backed gaps remain before this row can be treated as
+            complete:
+            {` ${pageRow.source_backed_fields.join(", ")}`}
+          </section>
+        )}
+
+        <nav class="inline-actions" aria-label="content editor navigation">
+          <a class="button secondary" href="/content">
+            back to inventory
+          </a>
+          <a class="button secondary" href="/content/drafts">
+            all draft controls
+          </a>
+          <a class="button secondary" href="/content/preview">
+            preview queue
+          </a>
+        </nav>
+      </>
+    ) : (
+      <section class="table-card operation-card">
+        <div class="section-head">
+          <div>
+            <p>missing page_content</p>
+            <h2>{pageKey || "unknown page key"}</h2>
+          </div>
+          <span>404</span>
+        </div>
+        <div class="record-list">
+          <article class="record-row">
+            <div>
+              <p>next safe action</p>
+              <h3>
+                Return to inventory and choose an existing D1 page_content row.
+              </h3>
+            </div>
+          </article>
+        </div>
+      </section>
+    )
+  }
+</AdminLayout>

--- a/apps/admin/src/pages/content/index.astro
+++ b/apps/admin/src/pages/content/index.astro
@@ -99,6 +99,14 @@ const pageContentState = await readPageContentInventoryStore(
                   <dd>no admin save or publish endpoint</dd>
                 </div>
               </dl>
+              <div class="inline-actions">
+                <a
+                  class="button secondary"
+                  href={`/content/edit/${encodeURIComponent(row.page_key)}`}
+                >
+                  open editor
+                </a>
+              </div>
               <div class="field-grid" aria-label={`${row.page_key} d1 fields`}>
                 {row.fields.slice(0, 16).map((field) => (
                   <div class="field-chip">

--- a/apps/admin/src/styles/admin.css
+++ b/apps/admin/src/styles/admin.css
@@ -414,7 +414,8 @@ th {
 
 .table-card,
 .proposal-row,
-.draft-editor-card {
+.draft-editor-card,
+.editor-panel {
   border: 1px solid var(--border);
   background: var(--panel);
 }
@@ -685,6 +686,58 @@ dd {
   display: flex;
   flex-wrap: wrap;
   gap: 10px;
+}
+
+.inline-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 14px;
+}
+
+.editor-panel {
+  margin-top: 24px;
+}
+
+.page-editor-form {
+  display: grid;
+  gap: 0;
+}
+
+.page-editor-field {
+  display: grid;
+  gap: 8px;
+  padding: 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.page-editor-field span,
+.page-editor-field small {
+  color: var(--muted);
+  font-size: 11px;
+  text-transform: uppercase;
+}
+
+.page-editor-field textarea {
+  width: 100%;
+  min-width: 0;
+  border: 1px solid var(--border);
+  background: #111;
+  color: var(--text);
+  padding: 10px;
+  font: inherit;
+  font-size: 13px;
+  line-height: 1.5;
+  resize: vertical;
+}
+
+.page-editor-field textarea:disabled {
+  cursor: not-allowed;
+  opacity: 0.76;
+}
+
+.page-editor-actions {
+  padding: 16px;
 }
 
 .draft-proof-grid {

--- a/docs/platform-architecture.md
+++ b/docs/platform-architecture.md
@@ -83,6 +83,7 @@ operation tables, or publish-event tables.
 | `/content`                                          | content inventory                    |
 | `/content/review`                                   | content proposal queue               |
 | `/content/drafts`                                   | inert draft editor surface           |
+| `/content/edit/:pageKey`                            | focused inert page_content editor    |
 | `/content/preview`                                  | draft preview                        |
 | `/content/operations`                               | read-only D1 content operation state |
 | `/newsletter`                                       | newsletter issue queue               |
@@ -122,9 +123,9 @@ revoked-credential denial. It reports missing pre-removal evidence in
 `access_removal_blockers`; `cloudflare_access_still_active: true` is expected
 until the edge gate is removed, not a blocker by itself. After Access removal,
 the same script must show app-native route blocking. The route probe set must
-include content inventory, review, drafts, preview, operations, newsletter
-queue, newsletter detail preview, needs-ani, proof, repos, handoffs, fleet,
-mutations, and destructive-ops routes.
+include content inventory, review, drafts, focused page editor, preview,
+operations, newsletter queue, newsletter detail preview, needs-ani, proof,
+repos, handoffs, fleet, mutations, and destructive-ops routes.
 
 First-passkey bootstrap in production requires a verified Cloudflare Access
 application JWT from `Cf-Access-Jwt-Assertion`. The admin Worker validates it

--- a/packages/content/src/admin/content.ts
+++ b/packages/content/src/admin/content.ts
@@ -76,6 +76,7 @@ export type PageContentInventoryRow = {
 export type PageContentInventoryField = {
   path: string;
   value: string;
+  raw_value: string;
   kind: string;
 };
 
@@ -540,6 +541,7 @@ function listLeafFields(
     {
       path: path || "value",
       value: formatFieldValue(value),
+      raw_value: formatRawFieldValue(value),
       kind: Array.isArray(value) ? "array" : typeof value,
     },
   ];
@@ -556,6 +558,19 @@ function formatFieldValue(value: unknown): string {
     return String(value);
   }
   return JSON.stringify(value) ?? String(value);
+}
+
+function formatRawFieldValue(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (typeof value === "boolean") {
+    return value ? "true" : "false";
+  }
+  if (typeof value === "number") {
+    return String(value);
+  }
+  return JSON.stringify(value, null, 2) ?? String(value);
 }
 
 function sourceBackedFields(

--- a/scripts/admin/content-proof.mjs
+++ b/scripts/admin/content-proof.mjs
@@ -76,6 +76,7 @@ const ADMIN_ROUTES = [
   "/content",
   "/content/review",
   "/content/drafts",
+  "/content/edit/home",
   "/content/preview",
   "/content/operations",
   "/proof",

--- a/scripts/admin/passkey-proof.mjs
+++ b/scripts/admin/passkey-proof.mjs
@@ -28,6 +28,7 @@ const ROUTES = [
   "/content",
   "/content/review",
   "/content/drafts",
+  "/content/edit/home",
   "/content/preview",
   "/content/operations",
   "/needs-ani",

--- a/scripts/ci/admin-route-parity.test.mjs
+++ b/scripts/ci/admin-route-parity.test.mjs
@@ -26,6 +26,11 @@ const ROUTES = [
     nav: true,
   },
   {
+    route: "/content/edit/home",
+    file: "apps/admin/src/pages/content/edit/[pageKey].astro",
+    nav: false,
+  },
+  {
     route: "/content/preview",
     file: "apps/admin/src/pages/content/preview.astro",
     nav: true,
@@ -80,6 +85,10 @@ const navSource = readFileSync("apps/admin/src/data/admin.ts", "utf8");
 const middlewareSource = readFileSync("apps/admin/src/middleware.ts", "utf8");
 const passkeySource = readFileSync(
   "apps/admin/src/pages/auth/passkey.astro",
+  "utf8",
+);
+const contentEditorSource = readFileSync(
+  "apps/admin/src/pages/content/edit/[pageKey].astro",
   "utf8",
 );
 const deployWorkflow = readFileSync(".github/workflows/deploy.yml", "utf8");
@@ -162,6 +171,18 @@ for (const marker of [
   assert.ok(
     passkeySource.includes(marker),
     `/auth/passkey missing proof runbook marker ${marker}`,
+  );
+}
+
+for (const marker of [
+  "readPageContentInventoryStore",
+  "save disabled",
+  "publish disabled",
+  "no save route, no publish route, no content mutation",
+]) {
+  assert.ok(
+    contentEditorSource.includes(marker),
+    `/content/edit/:pageKey missing inert editor marker ${marker}`,
   );
 }
 


### PR DESCRIPTION
## summary

- add `/content/edit/:pageKey` as a focused Astro admin editor surface for D1 `page_content` rows
- link the editor from `/content` and `/content/drafts`
- keep every field and action disabled until the audited save/publish path exists
- preserve compact inventory chips while exposing full raw field values to the focused editor
- add `/content/edit/home` to admin smoke, content proof, passkey proof, route parity, and docs

## deploy target expectation

- expected target: admin only
- expected skipped targets: www, admin-solid, state, ingest, newsletter, weekly-email

## verification

- pnpm --filter @anipotts/content build
- pnpm --filter @anipotts/admin typecheck
- pnpm --filter @anipotts/admin build
- pnpm --silent test:admin-routes
- pnpm --silent test:workflows
- pnpm --silent test:content-platform
- pnpm --silent test:security-review
- pnpm --silent proof:admin-content
- pnpm --silent proof:admin-passkey
- git diff --check HEAD~1 HEAD
- node scripts/ci/compute-deploy-targets.mjs /tmp/inert-editor-commit-files.txt
- node scripts/ci/security-review.mjs /tmp/inert-editor-commit-files.txt

## safety

- no save API
- no publish write
- no Cloudflare Access policy change
- no DNS change
- no secret/env change
- live proof shows `/content/edit/home` returns Cloudflare Access 302 while Access remains active
