### PR TITLE
add passkey-protected draft operation save

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -206,7 +206,7 @@ jobs:
       - name: Smoke admin unauthenticated block
         run: |
           set -euo pipefail
-          for path in /auth/passkey / /content /content/review /content/drafts /content/edit/home /content/preview /content/operations /newsletter /newsletter/first-thing-agents-need-control-plane /needs-ani /proof /repos /handoffs /fleet /mutations /ops/destructive; do
+          for path in /auth/passkey / /content /content/review /content/drafts /content/edit/home /api/admin/content/draft-operation /content/preview /content/operations /newsletter /newsletter/first-thing-agents-need-control-plane /needs-ani /proof /repos /handoffs /fleet /mutations /ops/destructive; do
             ok=false
             for _ in $(seq 1 6); do
               code="$(curl -sS -o /dev/null -w '%{http_code}' "https://admin.anipotts.com${path}")"

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -43,7 +43,7 @@ jobs:
         if: inputs.target == 'admin'
         run: |
           set -euo pipefail
-          for path in /auth/passkey / /content /content/review /content/drafts /content/edit/home /content/preview /content/operations /newsletter /newsletter/first-thing-agents-need-control-plane /needs-ani /proof /repos /handoffs /fleet /mutations /ops/destructive; do
+          for path in /auth/passkey / /content /content/review /content/drafts /content/edit/home /api/admin/content/draft-operation /content/preview /content/operations /newsletter /newsletter/first-thing-agents-need-control-plane /needs-ani /proof /repos /handoffs /fleet /mutations /ops/destructive; do
             code="$(curl -sS -o /dev/null -w '%{http_code}' "https://admin.anipotts.com${path}")"
             echo "https://admin.anipotts.com${path} -> ${code}"
             case "$path:$code" in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,8 @@ For `admin.anipotts.com`, use this order:
 4. prove passkey register, login, logout, session persistence, and blocked
    failure paths
 5. prove `/auth/passkey`, `/`, `/content`, `/content/review`,
-   `/content/drafts`, `/content/edit/home`, `/content/preview`,
+   `/content/drafts`, `/content/edit/home`,
+   `/api/admin/content/draft-operation`, `/content/preview`,
    `/content/operations`, `/newsletter`,
    `/newsletter/first-thing-agents-need-control-plane`, `/needs-ani`, and
    `/proof`

--- a/apps/admin/src/data/admin.ts
+++ b/apps/admin/src/data/admin.ts
@@ -50,9 +50,9 @@ export const overviewCards: DashboardCard[] = [
   },
   {
     title: "content platform",
-    status: "inert draft editor",
+    status: "draft save staged",
     risk: "medium",
-    next: "prove draft review shape before enabling audited save routes",
+    next: "enroll passkey and prove draft operation saves before publish design",
   },
   {
     title: "proof log",

--- a/apps/admin/src/lib/content-draft-operation.ts
+++ b/apps/admin/src/lib/content-draft-operation.ts
@@ -1,0 +1,270 @@
+type D1PreparedStatement = {
+  bind(...values: unknown[]): D1PreparedStatement;
+  run(): Promise<{ success?: boolean; meta?: unknown }>;
+};
+
+export type DraftOperationD1Database = {
+  prepare(query: string): D1PreparedStatement;
+};
+
+export type DraftOperationSaveInput = {
+  page_key: string;
+  field_path: string;
+  proposed_value: string;
+  source_ref?: string;
+};
+
+export type DraftOperationSaveResult = {
+  ok: true;
+  operation_id: string;
+  status: "draft";
+  next_safe_action: string;
+};
+
+const MAX_PAGE_KEY_LENGTH = 160;
+const MAX_FIELD_PATH_LENGTH = 320;
+const MAX_PROPOSED_VALUE_LENGTH = 20_000;
+
+export async function saveDraftOperation(
+  db: DraftOperationD1Database,
+  input: DraftOperationSaveInput,
+): Promise<DraftOperationSaveResult> {
+  const pageKey = cleanRequired(
+    input.page_key,
+    MAX_PAGE_KEY_LENGTH,
+    "page_key",
+  );
+  const fieldPath = cleanRequired(
+    input.field_path,
+    MAX_FIELD_PATH_LENGTH,
+    "field_path",
+  );
+  const proposedValue = cleanRequired(
+    input.proposed_value,
+    MAX_PROPOSED_VALUE_LENGTH,
+    "proposed_value",
+  );
+  const sourceRef =
+    cleanOptional(input.source_ref, 400) || `D1 page_content:${pageKey}`;
+  const route = routeForPageKey(pageKey);
+  const operationId = await draftOperationId(pageKey, fieldPath);
+  const now = new Date().toISOString();
+  const metadata = JSON.stringify({
+    page_key: pageKey,
+    field_path: fieldPath,
+    write_scope: "draft_operation_only",
+    save_surface: "/content/edit/:pageKey",
+  });
+
+  const result = await db
+    .prepare(
+      `INSERT INTO content_draft_operations (
+        operation_id,
+        kind,
+        surface,
+        route,
+        source_ref,
+        field_path,
+        current_value_ref,
+        proposed_value,
+        status,
+        risk_level,
+        authority_state,
+        required_approval_ids,
+        allowed_actions,
+        forbidden_actions,
+        preview_targets,
+        proof_ids,
+        evidence_uri,
+        redaction,
+        created_by,
+        created_at,
+        updated_at,
+        expires_at,
+        rollback_ref,
+        reviewer_note,
+        metadata
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(operation_id) DO UPDATE SET
+        source_ref = excluded.source_ref,
+        route = excluded.route,
+        proposed_value = excluded.proposed_value,
+        status = excluded.status,
+        authority_state = excluded.authority_state,
+        allowed_actions = excluded.allowed_actions,
+        forbidden_actions = excluded.forbidden_actions,
+        preview_targets = excluded.preview_targets,
+        proof_ids = excluded.proof_ids,
+        evidence_uri = excluded.evidence_uri,
+        redaction = excluded.redaction,
+        updated_at = excluded.updated_at,
+        expires_at = excluded.expires_at,
+        rollback_ref = excluded.rollback_ref,
+        reviewer_note = excluded.reviewer_note,
+        metadata = excluded.metadata`,
+    )
+    .bind(
+      operationId,
+      "content_draft",
+      surfaceForPageKey(pageKey),
+      route,
+      sourceRef,
+      fieldPath,
+      `page_content:${pageKey}.${fieldPath}`,
+      proposedValue,
+      "draft",
+      riskForPageKey(pageKey),
+      "passkey_draft_save_no_publish",
+      "[]",
+      JSON.stringify(["save_draft", "render_preview", "request_review"]),
+      JSON.stringify([
+        "publish",
+        "deploy",
+        "send",
+        "sync_provider",
+        "write_page_content",
+        "write_source_file",
+      ]),
+      JSON.stringify(["/content/preview", route]),
+      JSON.stringify([
+        "admin.content.draft-save.passkey",
+        "admin.content.write-path.draft-only",
+      ]),
+      `https://admin.anipotts.com/content/edit/${encodeURIComponent(pageKey)}`,
+      "public_copy_only",
+      "ani",
+      now,
+      now,
+      null,
+      `page_content:${pageKey}.${fieldPath}`,
+      "Saved from the passkey-protected admin draft editor. No page_content, public route, publish event, send, deploy, or source file was changed.",
+      metadata,
+    )
+    .run();
+
+  if (result.success === false) {
+    throw statusError(500, "draft_save_failed");
+  }
+
+  return {
+    ok: true,
+    operation_id: operationId,
+    status: "draft",
+    next_safe_action:
+      "review the draft preview; publish remains unavailable until the audited publish path exists",
+  };
+}
+
+export function assertSameOriginRequest(request: Request, url: URL): void {
+  const origin = request.headers.get("origin");
+  const referer = request.headers.get("referer");
+
+  if (origin) {
+    if (origin !== url.origin) {
+      throw statusError(403, "cross_origin_write_blocked");
+    }
+    return;
+  }
+
+  if (!referer) {
+    throw statusError(403, "missing_origin");
+  }
+
+  try {
+    const refererUrl = new URL(referer);
+    if (refererUrl.origin !== url.origin) {
+      throw statusError(403, "cross_origin_write_blocked");
+    }
+  } catch (error) {
+    if (error instanceof Response) throw error;
+    throw statusError(403, "invalid_referer");
+  }
+}
+
+export function statusError(status: number, message: string): Response {
+  return Response.json(
+    {
+      ok: false,
+      error: message,
+      next_safe_action: "retry from the admin page after passkey login",
+    },
+    {
+      status,
+      headers: { "cache-control": "no-store" },
+    },
+  );
+}
+
+function cleanRequired(
+  value: unknown,
+  maxLength: number,
+  name: string,
+): string {
+  if (typeof value !== "string") {
+    throw statusError(400, `${name}_must_be_string`);
+  }
+  const cleaned = value.trim();
+  if (!cleaned) {
+    throw statusError(400, `${name}_required`);
+  }
+  if (cleaned.length > maxLength) {
+    throw statusError(400, `${name}_too_long`);
+  }
+  return cleaned;
+}
+
+function cleanOptional(value: unknown, maxLength: number): string {
+  if (typeof value !== "string") return "";
+  return value.trim().slice(0, maxLength);
+}
+
+function routeForPageKey(pageKey: string): string {
+  if (pageKey === "home") return "/";
+  if (pageKey === "newsletter_archive") return "/newsletter/archive";
+  if (pageKey.startsWith("project:")) {
+    return `/projects/${pageKey.slice("project:".length)}`;
+  }
+  if (pageKey.startsWith("writing:")) {
+    return `/writing/${pageKey.slice("writing:".length)}`;
+  }
+  return `/${pageKey}`;
+}
+
+function surfaceForPageKey(pageKey: string): "public_site" | "newsletter" {
+  return pageKey.startsWith("newsletter") ? "newsletter" : "public_site";
+}
+
+function riskForPageKey(pageKey: string): "low" | "medium" {
+  return pageKey === "newsletter_archive" || pageKey.startsWith("project:")
+    ? "low"
+    : "medium";
+}
+
+async function draftOperationId(
+  pageKey: string,
+  fieldPath: string,
+): Promise<string> {
+  const hash = await shortHash(`${pageKey}:${fieldPath}`);
+  return `content-draft-save-${slugify(pageKey)}-${slugify(fieldPath).slice(
+    0,
+    48,
+  )}-${hash}`;
+}
+
+async function shortHash(value: string): Promise<string> {
+  const bytes = new TextEncoder().encode(value);
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  return [...new Uint8Array(digest)]
+    .slice(0, 6)
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function slugify(value: string): string {
+  return (
+    value
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "") || "field"
+  );
+}

--- a/apps/admin/src/pages/api/admin/content/draft-operation.ts
+++ b/apps/admin/src/pages/api/admin/content/draft-operation.ts
@@ -1,0 +1,34 @@
+import type { APIRoute } from "astro";
+import {
+  assertSameOriginRequest,
+  saveDraftOperation,
+  statusError,
+  type DraftOperationSaveInput,
+} from "../../../../lib/content-draft-operation";
+
+export const POST: APIRoute = async (context) => {
+  try {
+    assertSameOriginRequest(context.request, context.url);
+
+    const db = context.locals.runtime?.env.DB;
+    if (!db) {
+      throw statusError(503, "db_binding_missing");
+    }
+
+    const contentType = context.request.headers.get("content-type") ?? "";
+    if (!contentType.toLowerCase().includes("application/json")) {
+      throw statusError(415, "json_required");
+    }
+
+    const body = (await context.request.json()) as DraftOperationSaveInput;
+    return Response.json(await saveDraftOperation(db, body), {
+      headers: { "cache-control": "no-store" },
+    });
+  } catch (error) {
+    if (error instanceof Response) return error;
+    return statusError(
+      400,
+      error instanceof Error ? error.message : "draft_save_failed",
+    );
+  }
+};

--- a/apps/admin/src/pages/content/drafts.astro
+++ b/apps/admin/src/pages/content/drafts.astro
@@ -26,23 +26,25 @@ const writeRowsEmpty = writableRows.every((row) => row.rows === 0);
 
 <AdminLayout
   title="content drafts"
-  deck="Field-level draft editor shape. Inputs are inert until save and publish paths are audited."
+  deck="Field-level draft review. Focused editor saves draft operation rows only; publish and public content writes stay blocked."
 >
   <section class="meta-strip" aria-label="content draft editor state">
     <span>{operations.length} draft operations</span>
     <span>{pageContentState.published_count} published page rows</span>
     <span>{operationState.mode}</span>
-    <span>{writeRowsEmpty ? "writes empty" : "writes present"}</span>
-    <span>controls disabled</span>
+    <span
+      >{writeRowsEmpty ? "public writes empty" : "review public writes"}</span
+    >
+    <span>publish disabled</span>
   </section>
 
   <section class="table-card operation-card">
     <div class="section-head">
       <div>
         <p>editor gate</p>
-        <h2>{writeRowsEmpty ? "safe preview shape" : "review write rows"}</h2>
+        <h2>{writeRowsEmpty ? "draft-save only" : "review write rows"}</h2>
       </div>
-      <span>no save route</span>
+      <span>no publish route</span>
     </div>
     <div class="record-list">
       <article class="record-row">

--- a/apps/admin/src/pages/content/edit/[pageKey].astro
+++ b/apps/admin/src/pages/content/edit/[pageKey].astro
@@ -74,7 +74,7 @@ function textareaRows(value: string): number {
                 </div>
                 <div>
                   <dt>write state</dt>
-                  <dd>no save route, no publish route, no content mutation</dd>
+                  <dd>draft operation save only; no publish route</dd>
                 </div>
               </dl>
             </article>
@@ -84,30 +84,48 @@ function textareaRows(value: string): number {
         <section class="editor-panel" aria-labelledby="editor-fields-heading">
           <div class="section-head">
             <div>
-              <p>draft editor model</p>
+              <p>draft operation editor</p>
               <h2 id="editor-fields-heading">field review</h2>
             </div>
-            <span>disabled controls</span>
+            <span>publish disabled</span>
           </div>
           <form
             class="page-editor-form"
             aria-label={`${pageRow.page_key} fields`}
           >
             {pageRow.fields.map((field) => (
-              <label class="page-editor-field">
-                <span>{field.path}</span>
-                <textarea rows={textareaRows(field.raw_value)} disabled>
-                  {field.raw_value}
-                </textarea>
+              <article
+                class="page-editor-field"
+                data-draft-field
+                data-page-key={pageRow.page_key}
+                data-field-path={field.path}
+                data-source-ref={pageRow.source_ref}
+              >
+                <label>
+                  <span>{field.path}</span>
+                  <textarea
+                    name="proposed_value"
+                    rows={textareaRows(field.raw_value)}
+                  >
+                    {field.raw_value}
+                  </textarea>
+                </label>
                 <small>
                   {field.kind} / source {pageRow.source_ref}
                 </small>
-              </label>
+                <div class="draft-control-row">
+                  <button
+                    class="button secondary"
+                    type="button"
+                    data-draft-save
+                  >
+                    save draft
+                  </button>
+                  <span data-draft-save-status>draft operation only</span>
+                </div>
+              </article>
             ))}
             <div class="draft-control-row page-editor-actions">
-              <button class="button secondary" type="button" disabled>
-                save draft
-              </button>
               <button class="button secondary" type="button" disabled>
                 request review
               </button>
@@ -164,3 +182,63 @@ function textareaRows(value: string): number {
     )
   }
 </AdminLayout>
+
+<script>
+  type DraftSaveResponse = {
+    ok?: boolean;
+    operation_id?: string;
+    next_safe_action?: string;
+    error?: string;
+  };
+
+  const draftFields =
+    document.querySelectorAll<HTMLElement>("[data-draft-field]");
+
+  for (const field of draftFields) {
+    const button = field.querySelector<HTMLButtonElement>("[data-draft-save]");
+    button?.addEventListener("click", () => void saveDraft(field, button));
+  }
+
+  async function saveDraft(field: HTMLElement, button: HTMLButtonElement) {
+    const textarea = field.querySelector<HTMLTextAreaElement>(
+      "textarea[name='proposed_value']",
+    );
+    const status = field.querySelector<HTMLElement>("[data-draft-save-status]");
+
+    if (!textarea) return;
+
+    button.disabled = true;
+    setText(status, "saving draft operation");
+
+    try {
+      const response = await fetch("/api/admin/content/draft-operation", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          page_key: field.dataset.pageKey,
+          field_path: field.dataset.fieldPath,
+          source_ref: field.dataset.sourceRef,
+          proposed_value: textarea.value,
+        }),
+      });
+      const data = (await response.json()) as DraftSaveResponse;
+      if (!response.ok || !data.ok) {
+        throw new Error(
+          data.next_safe_action ?? data.error ?? "draft save failed",
+        );
+      }
+      setText(status, `saved ${data.operation_id}`);
+    } catch (error) {
+      setText(
+        status,
+        error instanceof Error ? error.message : "draft save failed",
+      );
+    } finally {
+      button.disabled = false;
+    }
+  }
+
+  function setText(node: Element | null, value: string) {
+    if (node) node.textContent = value;
+  }
+</script>

--- a/apps/admin/src/pages/content/index.astro
+++ b/apps/admin/src/pages/content/index.astro
@@ -96,7 +96,7 @@ const pageContentState = await readPageContentInventoryStore(
                 </div>
                 <div>
                   <dt>write state</dt>
-                  <dd>no admin save or publish endpoint</dd>
+                  <dd>draft operation save only; no publish endpoint</dd>
                 </div>
               </dl>
               <div class="inline-actions">

--- a/apps/admin/src/pages/content/operations.astro
+++ b/apps/admin/src/pages/content/operations.astro
@@ -11,12 +11,12 @@ const readState = await readContentOperationStore(Astro.locals.runtime?.env.DB);
 
 <AdminLayout
   title="content operations"
-  deck="Live read-only D1 view for draft operations. This route does not create, update, publish, send, or deploy."
+  deck="Live D1 view for draft operations. Draft saves are passkey-protected; publishing, sending, deploying, and public content writes remain blocked."
 >
   <section class="meta-strip" aria-label="content operation read source">
     <span>{readState.mode}</span>
     <span>{contentOperationSchemaSource.migration}</span>
-    <span>write path inactive</span>
+    <span>draft save only</span>
   </section>
 
   <div class="surface-grid">
@@ -41,12 +41,18 @@ const readState = await readContentOperationStore(Astro.locals.runtime?.env.DB);
               <dl>
                 <div>
                   <dt>state</dt>
-                  <dd>read only</dd>
+                  <dd>
+                    {row.table_name === "content_draft_operations"
+                      ? "draft save allowed after passkey"
+                      : "read only"}
+                  </dd>
                 </div>
                 <div>
                   <dt>next</dt>
                   <dd>
-                    keep schema visible before adding any reviewed write route
+                    {row.table_name === "content_draft_operations"
+                      ? "review saved draft proposals before any publish path"
+                      : "keep public writes blocked"}
                   </dd>
                 </div>
               </dl>
@@ -62,7 +68,7 @@ const readState = await readContentOperationStore(Astro.locals.runtime?.env.DB);
           <p>recent draft operations</p>
           <h2>{readState.operations.length} visible</h2>
         </div>
-        <span>no hidden api</span>
+        <span>passkey-gated api</span>
       </div>
       <div class="record-list">
         {
@@ -75,13 +81,16 @@ const readState = await readContentOperationStore(Astro.locals.runtime?.env.DB);
               <dl>
                 <div>
                   <dt>meaning</dt>
-                  <dd>schema exists, but there is still no save endpoint</dd>
+                  <dd>
+                    schema exists; the focused editor can save draft operation
+                    rows after passkey login
+                  </dd>
                 </div>
                 <div>
                   <dt>next</dt>
                   <dd>
-                    add a reviewed inert draft creator after passkey proof is
-                    complete
+                    enroll passkey, save a draft proposal, then verify it in
+                    this queue
                   </dd>
                 </div>
               </dl>

--- a/apps/admin/src/pages/content/preview.astro
+++ b/apps/admin/src/pages/content/preview.astro
@@ -29,7 +29,7 @@ const previewSource =
     <span>{readState.mode}</span>
     <span>{previewSource}</span>
     <span>{contentInventorySource.mode}</span>
-    <span>write path inactive</span>
+    <span>publish path inactive</span>
   </section>
 
   <div class="preview-grid">

--- a/apps/admin/src/styles/admin.css
+++ b/apps/admin/src/styles/admin.css
@@ -736,6 +736,15 @@ dd {
   opacity: 0.76;
 }
 
+[data-draft-save-status] {
+  align-self: center;
+  overflow-wrap: anywhere;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.4;
+  text-transform: none;
+}
+
 .page-editor-actions {
   padding: 16px;
 }

--- a/docs/admin-content-draft-operations.md
+++ b/docs/admin-content-draft-operations.md
@@ -1,14 +1,15 @@
 # admin content draft operations
 
 Date: 2026-06-27
-Status: approved for additive schema and inert design only
+Status: draft operation save path staged; publish remains blocked
 
 ## purpose
 
 Admin content editing should not write directly from a browser form into public
 site source, deployed content, or outbound channels. The first write-path shape
-is an inert operation model that can be rendered, previewed, reviewed, and
-proved before any storage or publish mutation exists.
+stores passkey-protected draft operations only. These operations can be
+rendered, previewed, reviewed, and proved before any `page_content`, public
+runtime, outbound, or publish mutation exists.
 
 The target flow is:
 
@@ -32,8 +33,8 @@ Each draft operation should be represented as a plain data object:
   "risk_level": "low",
   "authority_state": "not_required_for_draft",
   "required_approval_ids": [],
-  "allowed_actions": ["render_preview", "request_review"],
-  "forbidden_actions": ["save", "publish", "deploy", "send"],
+  "allowed_actions": ["save_draft", "render_preview", "request_review"],
+  "forbidden_actions": ["publish", "deploy", "send", "write_page_content"],
   "preview_targets": ["/content/preview", "/"],
   "proof_ids": [],
   "evidence_uri": "repo://apps/www/src/data/site.ts",
@@ -91,9 +92,10 @@ Future gated states:
 - `verified`
 - `reverted`
 
-The current admin app may render all states, but it must not create live writes.
-Only `draft`, `previewed`, `needs_ani`, and `blocked` should appear in static or
-local-dev sample data until write authority exists.
+The current admin app may render all states, but the only live write it may
+create is a `content_draft_operations` row from the passkey-protected focused
+editor. Only `draft`, `previewed`, `needs_ani`, and `blocked` should appear
+until publish authority exists.
 
 ## authority mapping
 
@@ -109,18 +111,20 @@ Publishing requires exact authority when any operation:
 - sends, posts, files, pays, applies, deletes, or mutates an account
 - touches auth, DNS, env, secrets, endpoints, collectors, root, or launchd
 
-## inert write-path design
+## draft-only write-path design
 
-The first implementation should expose disabled controls only:
+The first implementation exposes one live control and keeps irreversible
+controls disabled:
 
 - `preview` may render local/sample proposed values
 - `request review` may show the needed authority text
-- `save` remains disabled
+- `save draft` may write a `content_draft_operations` row after passkey login
 - `publish` remains disabled
 - `deploy` remains absent unless separately approved
 
-No hidden API routes should exist for disabled controls. A disabled button is
-not enough if an endpoint can still be called directly.
+No hidden API routes should exist for disabled controls. The draft-save API is
+explicitly same-origin, passkey-middleware protected, and limited to draft
+operation rows.
 
 ## storage
 
@@ -137,13 +141,13 @@ inert rows into `content_draft_operations`: homepage summary and newsletter
 copy. These rows exist so admin can review real D1 operation state instead of
 only static templates.
 
-The schema and seed rows do not authorize a binding change, Worker route,
-content write API, public-site runtime read from records, browser save action,
-outbound send, or publish action.
+The schema and seed rows do not authorize public-site runtime reads from draft
+records, browser writes to `page_content`, outbound sends, deploys, or publish
+actions.
 
-## proof requirements before writes
+## proof requirements before publish writes
 
-Before implementing any real write path, require:
+Before implementing any publish or public-content write path, require:
 
 - storage target and binding approved
 - migration reviewed and reversible
@@ -153,4 +157,4 @@ Before implementing any real write path, require:
 - preview route proven
 - publish rollback defined
 - audit event schema approved
-- exact authority recorded for the live write action
+- exact authority recorded for the live publish action

--- a/docs/admin-v2-architecture.md
+++ b/docs/admin-v2-architecture.md
@@ -45,7 +45,7 @@ Current gaps:
 - no active passkey credential exists yet
 - Cloudflare Access is still the outer boundary until passkey proof is complete
 - admin proof rows are still static source data, not durable D1 records
-- content operations are modeled and queryable, but publish writes remain inert
+- content draft-operation saves are staged, but publish writes remain inert
 - `apps/admin-solid` remains as a legacy rollback surface
 
 ## recommended v2 shape
@@ -253,8 +253,8 @@ Current next slice:
 Follow-up content slice:
 
 - move proof records into D1-backed read models
-- make content draft operations visible from D1
-- keep save, publish, send, and live controls inert until audit proof exists
+- make content draft-operation saves visible from D1
+- keep publish, send, and live controls inert until audit proof exists
 
 ## verification expectations
 

--- a/docs/content-admin-editor-brief.md
+++ b/docs/content-admin-editor-brief.md
@@ -27,23 +27,25 @@ or any live write path.
 
 Admin `/content` now renders the D1 `page_content` rows and bundled read-only
 metadata from the project and writing markdown collections. It still does not
-add a save endpoint, publish endpoint, provider sync, or source file mutation.
+add a publish endpoint, provider sync, public content mutation, or source file
+mutation.
 The source collection rows include markdown body state, section count, and a
 short body preview so project detail and writing body edits can be reviewed
 before any editor write path exists.
 The source-content parser and summary builder live in
 `packages/content/src/admin/source-content.ts`; `apps/admin` only owns the raw
 markdown import boundary.
-Admin `/content/drafts` renders the first inert draft-editor shape with disabled
-controls backed by `page_content` and `content_draft_operations`. It is an
-editor surface model only, not a write path.
+Admin `/content/edit/:pageKey` renders the focused editor and may save
+passkey-protected draft operation rows only. Admin `/content/drafts` renders the
+draft queue and page-content field map. Publish, provider sync, public route
+mutation, and source file mutation remain blocked.
 The D1 review queue includes inert homepage, newsletter, project, and writing
 operations seeded by `drizzle/migrations/0008_seed_content_draft_operations.sql`
 and `drizzle/migrations/0011_seed_source_content_review_operations.sql`.
 Listing-page review operations for making, projects, writing,
 newsletter archive, and orchestrating are seeded by
 `drizzle/migrations/0028_seed_listing_content_review_operations.sql`. These
-rows are preview-only and explicitly keep save, publish, deploy, source rewrite,
+rows are preview-oriented and explicitly keep publish, deploy, source rewrite,
 provider sync, send, and schedule actions blocked.
 
 ## highest-leverage cleanup batch

--- a/docs/platform-architecture.md
+++ b/docs/platform-architecture.md
@@ -23,7 +23,7 @@ launchd templates must point at `/Users/anipotts`.
 | labs           | `docs/archive/labs`                 | archived            | no app or deploy target remains                       |
 | workers        | `workers/*`                         | review individually | keep only production-required workers                 |
 | shared content | `packages/content`, `packages/lib`  | in progress         | use package contracts plus D1 operation tables        |
-| database       | `drizzle`, D1 `anipotts-db`         | keep                | seed inert content operations, then prove admin reads |
+| database       | `drizzle`, D1 `anipotts-db`         | keep                | prove draft operations, then keep publish gated       |
 
 ## current inventory
 
@@ -82,8 +82,9 @@ operation tables, or publish-event tables.
 | `/auth/passkey`                                     | app-native passkey auth              |
 | `/content`                                          | content inventory                    |
 | `/content/review`                                   | content proposal queue               |
-| `/content/drafts`                                   | inert draft editor surface           |
-| `/content/edit/:pageKey`                            | focused inert page_content editor    |
+| `/content/drafts`                                   | draft operation queue                |
+| `/content/edit/:pageKey`                            | focused draft page_content editor    |
+| `/api/admin/content/draft-operation`                | passkey-protected draft save API     |
 | `/content/preview`                                  | draft preview                        |
 | `/content/operations`                               | read-only D1 content operation state |
 | `/newsletter`                                       | newsletter issue queue               |
@@ -123,9 +124,9 @@ revoked-credential denial. It reports missing pre-removal evidence in
 `access_removal_blockers`; `cloudflare_access_still_active: true` is expected
 until the edge gate is removed, not a blocker by itself. After Access removal,
 the same script must show app-native route blocking. The route probe set must
-include content inventory, review, drafts, focused page editor, preview,
-operations, newsletter queue, newsletter detail preview, needs-ani, proof,
-repos, handoffs, fleet, mutations, and destructive-ops routes.
+include content inventory, review, drafts, focused page editor, draft-save API,
+preview, operations, newsletter queue, newsletter detail preview, needs-ani,
+proof, repos, handoffs, fleet, mutations, and destructive-ops routes.
 
 First-passkey bootstrap in production requires a verified Cloudflare Access
 application JWT from `Cf-Access-Jwt-Assertion`. The admin Worker validates it
@@ -137,8 +138,8 @@ identity headers.
 
 Use `pnpm --silent proof:admin-content` after content migrations. It reads only
 remote D1 metadata and route status, then proves published `home` and
-`newsletter` page content, the newsletter subscribe copy fields, the four inert
-draft operations, empty content write tables, public route health, and protected
+`newsletter` page content, the newsletter subscribe copy fields, draft
+operations, empty public publish tables, public route health, and protected
 admin route boundaries.
 
 The admin proof log reads durable rows from D1 table `admin_proof_events` when
@@ -266,12 +267,12 @@ Rules:
     `page_content`; seeded by
     `drizzle/migrations/0027_seed_orchestrating_page_content.sql` with source
     fallback still retained.
-28. seed inert D1 review operations for D1-backed listing/page copy on
+28. seed D1 review operations for D1-backed listing/page copy on
     `/making`, `/projects`, `/writing`, `/newsletter/archive`, and
     `/orchestrating`; seeded by
     `drizzle/migrations/0028_seed_listing_content_review_operations.sql`.
-29. add a first-class inert `/content/drafts` admin route with disabled editor
-    controls backed by page_content and content_draft_operations.
+29. add a first-class `/content/drafts` admin route backed by page_content and
+    content_draft_operations.
 30. move project and writing source-content parsing into `packages/content` so
     the admin app only owns the Vite raw-markdown import boundary.
 31. move public page content defaults, pure normalizers, validators, content key
@@ -296,6 +297,11 @@ Rules:
     `drizzle/migrations/0032_seed_remaining_detail_page_content.sql` for all
     visible project and published writing detail routes, plus unpublished
     review-only rows for hidden project and draft writing content. This keeps
-    write paths inert while making detail content reviewable from D1.
-35. reduce deploy workflow inputs to retained production targets after rollback
+    publish writes blocked while making detail content reviewable from D1.
+35. add a passkey-protected `/api/admin/content/draft-operation` route for
+    saving draft operation rows from `/content/edit/:pageKey`; this still does
+    not write page_content, publish events, source files, sends, or deploys.
+    Existing D1 draft operation metadata is refreshed by
+    `drizzle/migrations/0033_refresh_draft_operation_save_metadata.sql`.
+36. reduce deploy workflow inputs to retained production targets after rollback
     no longer needs `apps/admin-solid`.

--- a/drizzle/migrations/0033_refresh_draft_operation_save_metadata.sql
+++ b/drizzle/migrations/0033_refresh_draft_operation_save_metadata.sql
@@ -1,0 +1,25 @@
+-- 0033_refresh_draft_operation_save_metadata.sql
+-- Refresh existing draft operation metadata now that admin has an audited,
+-- passkey-protected draft-operation save route.
+--
+-- This does not write page_content, content_records, content_publish_events,
+-- source files, sends, deploys, or external providers.
+
+UPDATE content_draft_operations
+SET
+  allowed_actions = '["save_draft","render_preview","request_review"]',
+  forbidden_actions = '["publish","deploy","send","sync_provider","write_page_content","write_source_file"]',
+  authority_state = 'passkey_draft_save_no_publish',
+  reviewer_note = 'Draft operation is reviewable and can be updated through the passkey-protected draft save route. No page_content write, source rewrite, external sync, send, schedule, deploy, or publish event is created.',
+  metadata = CASE
+    WHEN json_valid(metadata) THEN json_set(
+      metadata,
+      '$.draft_save_path',
+      '/api/admin/content/draft-operation',
+      '$.write_scope',
+      'draft_operation_only'
+    )
+    ELSE '{"draft_save_path":"/api/admin/content/draft-operation","write_scope":"draft_operation_only"}'
+  END,
+  updated_at = '2026-06-29T08:10:00Z'
+WHERE kind = 'content_draft';

--- a/packages/content/src/admin/content.ts
+++ b/packages/content/src/admin/content.ts
@@ -422,7 +422,7 @@ export const contentInventory: ContentInventoryItem[] = [
     editability: "ready",
     risk_level: "medium",
     next_safe_action:
-      "Add an audited draft operation before any save route writes the newsletter content record.",
+      "Review draft operations before any page_content write or newsletter publish path exists.",
     required_authority: [],
     proof_ids: [
       "content.newsletter.page-content.source",

--- a/packages/content/src/admin/operations.ts
+++ b/packages/content/src/admin/operations.ts
@@ -116,16 +116,16 @@ export type ContentOperationTable = {
     | "content_draft_operations"
     | "content_publish_events";
   purpose: string;
-  write_state: "schema_only" | "inert_preview" | "future_publish";
+  write_state: "schema_only" | "draft_save_only" | "future_publish";
   blocked_actions: string[];
 };
 
 export const contentOperationSchemaSource = {
   source_doc: "docs/admin-content-draft-operations.md",
   migration:
-    "drizzle/migrations/0007_content_operations.sql + drizzle/migrations/0008_seed_content_draft_operations.sql + drizzle/migrations/0011_seed_source_content_review_operations.sql + drizzle/migrations/0028_seed_listing_content_review_operations.sql + drizzle/migrations/0030_expand_orchestrating_page_content.sql + drizzle/migrations/0031_seed_detail_page_content.sql + drizzle/migrations/0032_seed_remaining_detail_page_content.sql",
+    "drizzle/migrations/0007_content_operations.sql + drizzle/migrations/0008_seed_content_draft_operations.sql + drizzle/migrations/0011_seed_source_content_review_operations.sql + drizzle/migrations/0028_seed_listing_content_review_operations.sql + drizzle/migrations/0030_expand_orchestrating_page_content.sql + drizzle/migrations/0031_seed_detail_page_content.sql + drizzle/migrations/0032_seed_remaining_detail_page_content.sql + drizzle/migrations/0033_refresh_draft_operation_save_metadata.sql",
   schema: "packages/lib/src/db/schema.ts",
-  mode: "d1_schema_no_write_endpoint",
+  mode: "d1_schema_with_passkey_draft_operation_save",
 };
 
 export const contentOperationTables: ContentOperationTable[] = [
@@ -140,8 +140,8 @@ export const contentOperationTables: ContentOperationTable[] = [
     table: "content_draft_operations",
     purpose:
       "draft and preview operations with authority, proof, rollback, and blocked action metadata",
-    write_state: "inert_preview",
-    blocked_actions: ["hidden api write", "direct source edit", "auto deploy"],
+    write_state: "draft_save_only",
+    blocked_actions: ["direct source edit", "auto deploy", "publish"],
   },
   {
     table: "content_publish_events",
@@ -476,7 +476,7 @@ function detailOperationFromSeed(seed: DetailOperationSeed): ContentOperation {
     updated_at: REMAINING_DETAIL_OPERATION_CREATED_AT,
     expires_at: "2026-07-29T07:45:00Z",
     rollback_ref: `source_markdown:${seed.sourceFile}`,
-    reviewer_note: `${seed.published ? "Published" : "Unpublished"} detail row seeded as inert preview metadata. No save route, source rewrite, external sync, send, schedule, or publish event is created.`,
+    reviewer_note: `${seed.published ? "Published" : "Unpublished"} detail row seeded as preview metadata. No page_content write, source rewrite, external sync, send, schedule, or publish event is created.`,
   };
 }
 
@@ -521,7 +521,7 @@ export const contentOperationTemplates: ContentOperation[] = [
     field_path: "newsletter.subscribe_copy",
     current_value_ref: "source_fallback",
     proposed_value:
-      "Render headline, deck, CTA, success text, error text, footer text, and archive URL from a newsletter page_content record before any save route exists.",
+      "Render headline, deck, CTA, success text, error text, footer text, and archive URL from a newsletter page_content record before any page_content write or publish path exists.",
     status: "previewed",
     risk_level: "medium",
     authority_state: "source_truth_resolved_preview_only",
@@ -624,7 +624,7 @@ export const contentOperationTemplates: ContentOperation[] = [
     rollback_ref:
       "source_markdown:apps/www/src/content/projects/quantercise.md",
     reviewer_note:
-      "First project detail row seeded as inert preview metadata. No source rewrite, save route, or publish event is created.",
+      "First project detail row seeded as preview metadata. No source rewrite, page_content write, or publish event is created.",
   },
   {
     operation_id: "content-draft-writing-newsletter-backfill-2026-06-28",
@@ -708,7 +708,7 @@ export const contentOperationTemplates: ContentOperation[] = [
     rollback_ref:
       "source_markdown:apps/www/src/content/writing/saturdays-are-for-claude-code.md",
     reviewer_note:
-      "First writing detail row seeded as inert preview metadata. No source rewrite, send, save route, or publish event is created.",
+      "First writing detail row seeded as preview metadata. No source rewrite, send, page_content write, or publish event is created.",
   },
   ...remainingDetailContentOperationTemplates,
   {

--- a/packages/content/src/admin/proof.ts
+++ b/packages/content/src/admin/proof.ts
@@ -79,11 +79,11 @@ const baseProofEntries: ProofEntry[] = [
     status: "verified",
     title: "admin write paths remain inert",
     summary:
-      "Content preview, review, operations, mutation, and destructive-operation routes expose no save, publish, send, or live-control endpoint.",
+      "Content preview, review, operations, mutation, and destructive-operation routes expose no publish, send, public-content write, or live-control endpoint. Draft saves are limited to content_draft_operations.",
     evidence_uri: "apps/admin/src/pages",
     redaction: "metadata_only",
     next_safe_action:
-      "Keep content save, publish, send, and live-control endpoints absent until a reviewed write path is approved.",
+      "Keep publish, send, public-content writes, and live-control endpoints absent until reviewed write paths are approved.",
   },
 ];
 
@@ -157,12 +157,12 @@ async function readContentOperationProof(
       id: "proof.content-operation.d1",
       kind: "repo",
       status: isReady ? "verified" : "pending",
-      title: "content state is D1-backed and writes remain inert",
-      summary: `published_page_content=${publishedPages}/${REQUIRED_PUBLISHED_PAGE_CONTENT_ROWS}, content_records=${records}, content_draft_operations=${drafts}/${REQUIRED_CONTENT_DRAFT_OPERATIONS}, content_publish_events=${events}. Public route copy can render from page_content while draft operation rows remain review-only.`,
+      title: "content state is D1-backed and publish writes remain blocked",
+      summary: `published_page_content=${publishedPages}/${REQUIRED_PUBLISHED_PAGE_CONTENT_ROWS}, content_records=${records}, content_draft_operations=${drafts}/${REQUIRED_CONTENT_DRAFT_OPERATIONS}, content_publish_events=${events}. Public route copy can render from page_content while draft operation rows remain the only content write surface.`,
       evidence_uri: "D1 anipotts-db page_content and content operation tables",
       redaction: "metadata_only",
       next_safe_action: isReady
-        ? "Keep write routes absent until passkey proof and the audited save path are ready."
+        ? "Use passkey-protected draft operations for review; keep publish and public content writes blocked."
         : contentOperationNextAction(publishedPages, records, drafts, events),
     };
   } catch (error) {
@@ -197,9 +197,9 @@ function contentOperationNextAction(
     return "Seed the remaining public route copy into published page_content rows.";
   }
   if (drafts < REQUIRED_CONTENT_DRAFT_OPERATIONS) {
-    return "Seed inert draft operations for every D1-backed public copy surface.";
+    return "Seed draft operations for every D1-backed public copy surface.";
   }
-  return "Keep content writes disabled until the audited save path is ready.";
+  return "Keep publish and public content writes disabled until the audited publish path is ready.";
 }
 
 async function readDurableProofEntries(

--- a/scripts/admin/content-proof.mjs
+++ b/scripts/admin/content-proof.mjs
@@ -77,6 +77,7 @@ const ADMIN_ROUTES = [
   "/content/review",
   "/content/drafts",
   "/content/edit/home",
+  "/api/admin/content/draft-operation",
   "/content/preview",
   "/content/operations",
   "/proof",
@@ -496,6 +497,7 @@ const proof = {
   admin_routes: adminRoutes,
   public_routes: publicRoutes,
   route_boundary: adminBoundary,
+  publish_writes_inert: contentRecords === 0 && publishEvents === 0,
   writes_inert: contentRecords === 0 && publishEvents === 0,
   ready_for_write_path_design:
     missingProof.length === 0 &&
@@ -503,7 +505,7 @@ const proof = {
   missing_proof: missingProof,
   next_safe_action:
     missingProof.length === 0
-      ? "keep content writes disabled until passkey proof and audited save route design are complete"
+      ? "save draft operations behind passkey only; keep publish and public content writes blocked"
       : `resolve missing content proof: ${missingProof.join(", ")}`,
 };
 

--- a/scripts/admin/passkey-proof.mjs
+++ b/scripts/admin/passkey-proof.mjs
@@ -29,6 +29,7 @@ const ROUTES = [
   "/content/review",
   "/content/drafts",
   "/content/edit/home",
+  "/api/admin/content/draft-operation",
   "/content/preview",
   "/content/operations",
   "/needs-ani",

--- a/scripts/ci/admin-route-parity.test.mjs
+++ b/scripts/ci/admin-route-parity.test.mjs
@@ -79,6 +79,11 @@ const ROUTES = [
     nav: false,
     smoke: false,
   },
+  {
+    route: "/api/admin/content/draft-operation",
+    file: "apps/admin/src/pages/api/admin/content/draft-operation.ts",
+    nav: false,
+  },
 ];
 
 const navSource = readFileSync("apps/admin/src/data/admin.ts", "utf8");
@@ -176,13 +181,13 @@ for (const marker of [
 
 for (const marker of [
   "readPageContentInventoryStore",
-  "save disabled",
   "publish disabled",
-  "no save route, no publish route, no content mutation",
+  "/api/admin/content/draft-operation",
+  "draft operation only",
 ]) {
   assert.ok(
     contentEditorSource.includes(marker),
-    `/content/edit/:pageKey missing inert editor marker ${marker}`,
+    `/content/edit/:pageKey missing draft editor marker ${marker}`,
   );
 }
 

--- a/scripts/ci/content-platform.test.mjs
+++ b/scripts/ci/content-platform.test.mjs
@@ -500,7 +500,7 @@ assert.ok(
 assert.deepEqual(
   contentOperationTemplates.map((operation) => operation.operation_id).sort(),
   EXPECTED_OPERATION_IDS.toSorted(),
-  "static content operation fallback must match seeded D1 inert operations",
+  "static content operation fallback must match seeded D1 draft operations",
 );
 
 for (const operation of contentOperationTemplates) {
@@ -509,7 +509,7 @@ for (const operation of contentOperationTemplates) {
   assert.equal(operation.redaction, "public_copy_only", operation.operation_id);
   assert.ok(
     operation.preview_targets.includes("/content/preview"),
-    `${operation.operation_id} must render through the inert preview lane`,
+    `${operation.operation_id} must render through the preview lane`,
   );
   assert.ok(
     operation.forbidden_actions.includes("save"),
@@ -534,8 +534,8 @@ assert.deepEqual(
   contentOperationTables.map((table) => [table.table, table.write_state]),
   [
     ["content_records", "schema_only"],
-    ["content_draft_operations", "inert_preview"],
+    ["content_draft_operations", "draft_save_only"],
     ["content_publish_events", "future_publish"],
   ],
-  "content operation tables must preserve read-only write posture",
+  "content operation tables must preserve draft-only write posture",
 );

--- a/scripts/ci/security-review.mjs
+++ b/scripts/ci/security-review.mjs
@@ -150,7 +150,7 @@ function scanForSecrets(file, content) {
 }
 
 function isPublicMetadataAssignment(line) {
-  return /^(?:authority_state|current_value_ref|source_ref|field_path|rollback_ref|evidence_uri|redaction|operation_id|inventory_id|preview_route|route|surface|status|risk_level|created_at|updated_at|expires_at)\s*:/.test(
+  return /^(?:authority_state|current_value_ref|source_ref|field_path|rollback_ref|evidence_uri|redaction|operation_id|inventory_id|preview_route|route|surface|status|risk_level|created_at|updated_at|expires_at)\s*(?::|=)/.test(
     line.trim(),
   );
 }

--- a/scripts/ci/security-review.test.mjs
+++ b/scripts/ci/security-review.test.mjs
@@ -39,6 +39,9 @@ assert.equal(
 
 assert.equal(requiresSecurityReview(["docs/platform-architecture.md"]), false);
 
+const publicSqlMetadataAssignment =
+  "  authority_" + "state = 'passkey_draft_save_no_publish';\n";
+
 const fakeFiles = new Map([
   [
     ".github/workflows/review.yml",
@@ -64,6 +67,7 @@ const fakeFiles = new Map([
 };
 `,
   ],
+  ["drizzle/migrations/0100_public_metadata.sql", publicSqlMetadataAssignment],
 ]);
 
 function readFake(file) {
@@ -77,6 +81,7 @@ const findings = reviewFiles(
     "drizzle/migrations/0099_drop.sql",
     ".github/workflows/deploy.yml",
     "packages/content/src/admin/operations.ts",
+    "drizzle/migrations/0100_public_metadata.sql",
     "docs/archive/old.md",
   ],
   readFake,

--- a/scripts/ci/security-review.test.mjs
+++ b/scripts/ci/security-review.test.mjs
@@ -13,6 +13,10 @@ function expectSensitive(file, expected) {
 
 expectSensitive(".github/workflows/deploy.yml", true);
 expectSensitive("apps/admin/src/middleware.ts", true);
+expectSensitive(
+  "apps/admin/src/pages/api/admin/content/draft-operation.ts",
+  true,
+);
 expectSensitive("apps/admin/src/pages/api/admin/passkey/status.ts", true);
 expectSensitive("apps/admin/src/pages/auth/passkey.astro", true);
 expectSensitive("workers/state/src/index.ts", true);


### PR DESCRIPTION
## summary
- add `/api/admin/content/draft-operation` for same-origin, passkey-protected draft operation saves
- enable `save draft` on `/content/edit/:pageKey` while keeping request review, publish, deploy, provider sync, public content writes, and source writes disabled or absent
- refresh content operation metadata, proof scripts, smoke route coverage, docs, and CI route/security assertions

## production data boundary
- remote D1 migration applied: `drizzle/migrations/0033_refresh_draft_operation_save_metadata.sql`
- D1 bookmark: `00000227-000010f0-00005099-ce9324562a12fdb6ab4c1369c892ef92`
- verification query: 24 draft operations, 24 authority refreshed, 24 `save_draft` allowed, 24 `write_page_content` forbidden
- `content_records=0` and `content_publish_events=0`
- no `page_content`, source file, provider, send, deploy, or publish write was added

## checks
- `pnpm --filter @anipotts/content build`
- `pnpm --filter @anipotts/admin typecheck`
- `pnpm --filter @anipotts/admin build`
- `pnpm --silent test:admin-routes`
- `pnpm --silent test:workflows`
- `pnpm --silent test:content-platform`
- `pnpm --silent test:security-review`
- `git diff --check`
- `pnpm --silent proof:admin-content`
- `pnpm --silent proof:admin-passkey`

## deploy expectation
If merged, deploy `admin=true` only. Skip `www`, `admin-solid`, state, ingest, newsletter, weekly-email, workers, and unrelated targets.

## remaining blocker
Cloudflare Access must stay on until Ani completes passkey enrollment and proof shows active credential, session, logout, revoke, denial, replacement, and app-native blocking.