### PR TITLE
add proof-backed draft save tracking

### DIFF
--- a/apps/admin/src/lib/content-draft-operation.ts
+++ b/apps/admin/src/lib/content-draft-operation.ts
@@ -21,6 +21,7 @@ export type DraftOperationSaveResult = {
   next_safe_action: string;
 };
 
+const DRAFT_SAVE_PROOF_ID = "proof.admin.content-draft-save";
 const MAX_PAGE_KEY_LENGTH = 160;
 const MAX_FIELD_PATH_LENGTH = 320;
 const MAX_PROPOSED_VALUE_LENGTH = 20_000;
@@ -146,6 +147,14 @@ export async function saveDraftOperation(
     throw statusError(500, "draft_save_failed");
   }
 
+  await writeDraftSaveProof(db, {
+    operationId,
+    pageKey,
+    fieldPath,
+    route,
+    now,
+  });
+
   return {
     ok: true,
     operation_id: operationId,
@@ -153,6 +162,74 @@ export async function saveDraftOperation(
     next_safe_action:
       "review the draft preview; publish remains unavailable until the audited publish path exists",
   };
+}
+
+async function writeDraftSaveProof(
+  db: DraftOperationD1Database,
+  input: {
+    operationId: string;
+    pageKey: string;
+    fieldPath: string;
+    route: string;
+    now: string;
+  },
+): Promise<void> {
+  const metadata = JSON.stringify({
+    operation_id: input.operationId,
+    page_key: input.pageKey,
+    field_path: input.fieldPath,
+    route: input.route,
+    write_scope: "draft_operation_only",
+  });
+  const summary = `Latest draft save wrote ${input.operationId} for ${input.pageKey}.${input.fieldPath} to content_draft_operations only. No page_content, public route, publish event, send, deploy, or source file was changed.`;
+
+  const result = await db
+    .prepare(
+      `INSERT INTO admin_proof_events (
+        id,
+        kind,
+        status,
+        title,
+        summary,
+        evidence_uri,
+        redaction,
+        next_safe_action,
+        source_ref,
+        created_at,
+        updated_at,
+        metadata
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(id) DO UPDATE SET
+        kind = excluded.kind,
+        status = excluded.status,
+        title = excluded.title,
+        summary = excluded.summary,
+        evidence_uri = excluded.evidence_uri,
+        redaction = excluded.redaction,
+        next_safe_action = excluded.next_safe_action,
+        source_ref = excluded.source_ref,
+        updated_at = excluded.updated_at,
+        metadata = excluded.metadata`,
+    )
+    .bind(
+      DRAFT_SAVE_PROOF_ID,
+      "gate",
+      "verified",
+      "content draft saves are proof-backed",
+      summary,
+      "D1 anipotts-db content_draft_operations and admin_proof_events",
+      "metadata_only",
+      "review the saved draft operation from /content/drafts before any publish or public content write path exists",
+      "apps/admin/src/lib/content-draft-operation.ts",
+      input.now,
+      input.now,
+      metadata,
+    )
+    .run();
+
+  if (result.success === false) {
+    throw statusError(500, "draft_save_proof_failed");
+  }
 }
 
 export function assertSameOriginRequest(request: Request, url: URL): void {

--- a/apps/admin/src/pages/proof.astro
+++ b/apps/admin/src/pages/proof.astro
@@ -13,7 +13,7 @@ const proofCounts = countProofEntries(proofEntries);
 
 <AdminLayout
   title="proof log"
-  deck="Read-only proof records for deploys, route probes, auth gates, and repo state. This page does not write audit records yet."
+  deck="Proof records for deploys, route probes, auth gates, repo state, and draft-only content writes. This page is read-only."
 >
   <section class="meta-strip" aria-label="proof log source">
     <span>{proofCounts.total} proof rows</span>
@@ -74,7 +74,8 @@ const proofCounts = countProofEntries(proofEntries);
   </div>
 
   <div class="notice">
-    This route reads D1 metadata for content-operation and passkey proof without
-    creating proof rows, updating sessions, or writing audit records.
+    This route reads D1 metadata for content-operation and passkey proof. The
+    focused editor may update draft-save proof metadata, but this page does not
+    create rows, update sessions, publish content, or trigger deploys.
   </div>
 </AdminLayout>

--- a/docs/admin-content-draft-operations.md
+++ b/docs/admin-content-draft-operations.md
@@ -124,7 +124,9 @@ controls disabled:
 
 No hidden API routes should exist for disabled controls. The draft-save API is
 explicitly same-origin, passkey-middleware protected, and limited to draft
-operation rows.
+operation rows. A successful draft save may also refresh the metadata-only
+`proof.admin.content-draft-save` row in `admin_proof_events`; it must not store
+the proposed copy in the proof row.
 
 ## storage
 
@@ -144,6 +146,10 @@ only static templates.
 The schema and seed rows do not authorize public-site runtime reads from draft
 records, browser writes to `page_content`, outbound sends, deploys, or publish
 actions.
+
+`drizzle/migrations/0034_seed_content_draft_save_proof.sql` seeds the pending
+draft-save proof row. The proof row is verified only after a passkey-authenticated
+draft save updates both `content_draft_operations` and `admin_proof_events`.
 
 ## proof requirements before publish writes
 

--- a/docs/admin-v2-architecture.md
+++ b/docs/admin-v2-architecture.md
@@ -23,7 +23,9 @@ Live baseline:
 - protection: Cloudflare Access plus staged app-native passkey middleware
 - deployed state: Astro admin operator and content shell
 - latest protected route set: `/`, `/content`, `/content/review`,
-  `/content/preview`, `/content/operations`, `/newsletter`,
+  `/content/drafts`, `/content/edit/home`,
+  `/api/admin/content/draft-operation`, `/content/preview`,
+  `/content/operations`, `/newsletter`,
   `/newsletter/first-thing-agents-need-control-plane`, `/needs-ani`, `/proof`,
   `/repos`, `/handoffs`, `/fleet`, `/mutations`, and `/ops/destructive`
 
@@ -35,6 +37,7 @@ Current strengths:
   routes
 - `/repos` can render the local-dev Infra runtime repo overlay metadata through
   `/api/admin/runtime-feed`
+- `admin_proof_events` provides durable proof rows in D1
 - deploy workflow can target only admin
 - unauthenticated users are blocked by Cloudflare Access before app content
   renders
@@ -44,8 +47,8 @@ Current gaps:
 
 - no active passkey credential exists yet
 - Cloudflare Access is still the outer boundary until passkey proof is complete
-- admin proof rows are still static source data, not durable D1 records
-- content draft-operation saves are staged, but publish writes remain inert
+- first draft-save proof is still pending passkey-authenticated save proof
+- content draft-operation saves are staged, but publish writes remain blocked
 - `apps/admin-solid` remains as a legacy rollback surface
 
 ## recommended v2 shape
@@ -253,7 +256,7 @@ Current next slice:
 Follow-up content slice:
 
 - move proof records into D1-backed read models
-- make content draft-operation saves visible from D1
+- make content draft-operation saves and proof rows visible from D1
 - keep publish, send, and live controls inert until audit proof exists
 
 ## verification expectations

--- a/docs/content-admin-editor-brief.md
+++ b/docs/content-admin-editor-brief.md
@@ -36,9 +36,11 @@ The source-content parser and summary builder live in
 `packages/content/src/admin/source-content.ts`; `apps/admin` only owns the raw
 markdown import boundary.
 Admin `/content/edit/:pageKey` renders the focused editor and may save
-passkey-protected draft operation rows only. Admin `/content/drafts` renders the
-draft queue and page-content field map. Publish, provider sync, public route
-mutation, and source file mutation remain blocked.
+passkey-protected draft operation rows only. Successful draft saves also refresh
+metadata-only proof in `admin_proof_events` without storing proposed copy in the
+proof row. Admin `/content/drafts` renders the draft queue and page-content
+field map. Publish, provider sync, public route mutation, and source file
+mutation remain blocked.
 The D1 review queue includes inert homepage, newsletter, project, and writing
 operations seeded by `drizzle/migrations/0008_seed_content_draft_operations.sql`
 and `drizzle/migrations/0011_seed_source_content_review_operations.sql`.

--- a/docs/platform-architecture.md
+++ b/docs/platform-architecture.md
@@ -145,8 +145,10 @@ admin route boundaries.
 The admin proof log reads durable rows from D1 table `admin_proof_events` when
 available, then appends live D1 metadata for content operations and passkey
 proof. The table is seeded by
-`drizzle/migrations/0012_admin_proof_events.sql`. There is still no admin proof
-write API.
+`drizzle/migrations/0012_admin_proof_events.sql`. The focused draft-save route
+may update `proof.admin.content-draft-save` with metadata-only proof after a
+passkey-authenticated `content_draft_operations` write; there is still no
+publish, send, deploy, or public-content proof write path.
 
 ## ci/cd target
 
@@ -303,5 +305,8 @@ Rules:
     not write page_content, publish events, source files, sends, or deploys.
     Existing D1 draft operation metadata is refreshed by
     `drizzle/migrations/0033_refresh_draft_operation_save_metadata.sql`.
-36. reduce deploy workflow inputs to retained production targets after rollback
+36. add durable `admin_proof_events` coverage for the draft-save write path.
+    `drizzle/migrations/0034_seed_content_draft_save_proof.sql` seeds the
+    pending proof row, and successful draft saves update it with metadata only.
+37. reduce deploy workflow inputs to retained production targets after rollback
     no longer needs `apps/admin-solid`.

--- a/drizzle/migrations/0034_seed_content_draft_save_proof.sql
+++ b/drizzle/migrations/0034_seed_content_draft_save_proof.sql
@@ -1,0 +1,67 @@
+-- 0034_seed_content_draft_save_proof.sql
+-- Add the durable proof row for the admin draft-save write path.
+--
+-- This records the proof gate for content_draft_operations saves. It does not
+-- write page_content, content_records, content_publish_events, source files,
+-- sends, deploys, or external providers.
+--
+-- Rollback:
+--   DELETE FROM admin_proof_events
+--   WHERE id = 'proof.admin.content-draft-save';
+
+INSERT INTO admin_proof_events (
+  id,
+  kind,
+  status,
+  title,
+  summary,
+  evidence_uri,
+  redaction,
+  next_safe_action,
+  source_ref,
+  created_at,
+  updated_at,
+  metadata
+) VALUES (
+  'proof.admin.content-draft-save',
+  'gate',
+  'pending',
+  'content draft saves need proof',
+  'The focused editor can save draft operation rows only. This proof row becomes verified after a passkey-authenticated draft save records a content_draft_operations row and refreshes admin_proof_events.',
+  'D1 anipotts-db content_draft_operations and admin_proof_events',
+  'metadata_only',
+  'enroll passkey, save one draft operation from /content/edit/home, then verify this proof row and keep publish blocked',
+  'apps/admin/src/lib/content-draft-operation.ts',
+  '2026-06-29T09:00:00Z',
+  '2026-06-29T09:00:00Z',
+  '{"seed":"drizzle/migrations/0034_seed_content_draft_save_proof.sql","write_scope":"draft_operation_only","status":"pending_first_save"}'
+)
+ON CONFLICT(id) DO UPDATE SET
+  kind = excluded.kind,
+  status = CASE
+    WHEN admin_proof_events.status = 'verified' THEN admin_proof_events.status
+    ELSE excluded.status
+  END,
+  title = CASE
+    WHEN admin_proof_events.status = 'verified' THEN admin_proof_events.title
+    ELSE excluded.title
+  END,
+  summary = CASE
+    WHEN admin_proof_events.status = 'verified' THEN admin_proof_events.summary
+    ELSE excluded.summary
+  END,
+  evidence_uri = excluded.evidence_uri,
+  redaction = excluded.redaction,
+  next_safe_action = CASE
+    WHEN admin_proof_events.status = 'verified' THEN admin_proof_events.next_safe_action
+    ELSE excluded.next_safe_action
+  END,
+  source_ref = excluded.source_ref,
+  updated_at = CASE
+    WHEN admin_proof_events.status = 'verified' THEN admin_proof_events.updated_at
+    ELSE excluded.updated_at
+  END,
+  metadata = CASE
+    WHEN admin_proof_events.status = 'verified' THEN admin_proof_events.metadata
+    ELSE excluded.metadata
+  END;

--- a/packages/content/src/admin/proof.ts
+++ b/packages/content/src/admin/proof.ts
@@ -32,7 +32,7 @@ export const proofSource = {
   mode: "read_only_d1_plus_runtime_metadata",
   generated_from:
     "admin_proof_events, route probes, PR state, and read-only D1 metadata",
-  live_writes: "disabled",
+  live_writes: "draft_save_proof_only",
 };
 
 const baseProofEntries: ProofEntry[] = [
@@ -84,6 +84,19 @@ const baseProofEntries: ProofEntry[] = [
     redaction: "metadata_only",
     next_safe_action:
       "Keep publish, send, public-content writes, and live-control endpoints absent until reviewed write paths are approved.",
+  },
+  {
+    id: "proof.admin.content-draft-save",
+    kind: "gate",
+    status: "pending",
+    title: "content draft saves need proof",
+    summary:
+      "The focused editor can save draft operation rows only. This proof row becomes verified after a passkey-authenticated draft save records a content_draft_operations row and refreshes admin_proof_events.",
+    evidence_uri:
+      "D1 anipotts-db content_draft_operations and admin_proof_events",
+    redaction: "metadata_only",
+    next_safe_action:
+      "enroll passkey, save one draft operation from /content/edit/home, then verify this proof row and keep publish blocked",
   },
 ];
 

--- a/scripts/admin/content-proof.mjs
+++ b/scripts/admin/content-proof.mjs
@@ -285,6 +285,17 @@ SELECT 'content_publish_events', COUNT(*) FROM content_publish_events;
 `).map((row) => [String(row.table_name), Number(row.count)]),
 );
 
+const [draftSaveProof] = runD1(`
+SELECT
+  id,
+  status,
+  summary,
+  updated_at,
+  metadata
+FROM admin_proof_events
+WHERE id = 'proof.admin.content-draft-save';
+`);
+
 const [adminRoutes, publicRoutes] = await Promise.all([
   Promise.all(ADMIN_ROUTES.map((path) => probeRoute(ADMIN_ORIGIN, path))),
   Promise.all(PUBLIC_ROUTES.map((path) => probeRoute(WWW_ORIGIN, path))),
@@ -494,6 +505,15 @@ const proof = {
     risk_level: String(row.risk_level),
     authority_state: String(row.authority_state),
   })),
+  draft_save_proof: draftSaveProof
+    ? {
+        id: String(draftSaveProof.id),
+        status: String(draftSaveProof.status),
+        summary: String(draftSaveProof.summary),
+        updated_at: String(draftSaveProof.updated_at),
+        metadata: parseJsonObject(draftSaveProof.metadata),
+      }
+    : null,
   admin_routes: adminRoutes,
   public_routes: publicRoutes,
   route_boundary: adminBoundary,
@@ -537,6 +557,18 @@ function runD1(command) {
     throw new Error(`D1 content proof query failed for ${D1_DATABASE}`);
   }
   return firstResult.results ?? [];
+}
+
+function parseJsonObject(value) {
+  if (typeof value !== "string") return {};
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? parsed
+      : {};
+  } catch {
+    return {};
+  }
 }
 
 async function probeRoute(origin, path) {

--- a/scripts/ci/content-platform.test.mjs
+++ b/scripts/ci/content-platform.test.mjs
@@ -474,18 +474,27 @@ assert.equal(
 );
 
 assert.equal(proofSource.mode, "read_only_d1_plus_runtime_metadata");
-assert.equal(proofSource.live_writes, "disabled");
+assert.equal(proofSource.live_writes, "draft_save_proof_only");
 
 const proofEntriesWithoutDb = await readProofEntries(undefined);
 assert.deepEqual(
   countProofEntries(proofEntriesWithoutDb),
   {
-    total: 6,
+    total: 7,
     verified: 4,
     blocked: 1,
-    pending: 1,
+    pending: 2,
   },
   "proof exports must preserve read-only fallback status without an app D1 binding",
+);
+assert.ok(
+  proofEntriesWithoutDb.some(
+    (entry) =>
+      entry.id === "proof.admin.content-draft-save" &&
+      entry.status === "pending" &&
+      entry.next_safe_action.includes("save one draft operation"),
+  ),
+  "proof fallback must expose the draft-save proof gate before first save",
 );
 assert.ok(
   proofEntriesWithoutDb.some(


### PR DESCRIPTION
## summary
- seed `proof.admin.content-draft-save` in `admin_proof_events`
- update `/api/admin/content/draft-operation` so successful draft saves refresh metadata-only proof after writing `content_draft_operations`
- expose `draft_save_proof` in `pnpm --silent proof:admin-content`
- update proof UI, docs, and content platform assertions

## production data boundary
- remote D1 migration applied: `drizzle/migrations/0034_seed_content_draft_save_proof.sql`
- D1 bookmark: `00000227-00001115-00005099-bbb046fc216044f1e173e132bd87bcc6`
- current proof row status: `pending`
- proof metadata write scope: `draft_operation_only`
- `content_records=0` and `content_publish_events=0`
- no `page_content`, source file, provider, send, deploy, or publish write was added

## checks
- sqlite3 migration smoke for `0012` plus `0034`
- `pnpm --filter @anipotts/content build`
- `pnpm --filter @anipotts/admin typecheck`
- `pnpm --filter @anipotts/admin build`
- `pnpm --silent test:content-platform`
- `pnpm --silent test:security-review`
- `pnpm --silent test:admin-routes`
- `pnpm --silent test:workflows`
- `node scripts/ci/security-review.mjs` on changed files
- `git diff --check`
- `pnpm --silent proof:admin-content`
- `pnpm --silent proof:admin-passkey`

## deploy expectation
If merged, deploy `admin=true` only. Skip `www`, `admin-solid`, state, ingest, newsletter, weekly-email, workers, and unrelated targets.

## remaining blocker
Cloudflare Access removal still waits for biometric passkey enrollment and proof: active credential, active session, logout, revoke, denial, replacement, and app-native route blocking.