### PR TITLE
add read-only admin deploy map

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -206,7 +206,7 @@ jobs:
       - name: Smoke admin unauthenticated block
         run: |
           set -euo pipefail
-          for path in /auth/passkey / /content /content/review /content/drafts /content/edit/home /api/admin/content/draft-operation /content/preview /content/operations /newsletter /newsletter/first-thing-agents-need-control-plane /needs-ani /proof /repos /handoffs /fleet /mutations /ops/destructive; do
+          for path in /auth/passkey / /content /content/review /content/drafts /content/edit/home /api/admin/content/draft-operation /content/preview /content/operations /newsletter /newsletter/first-thing-agents-need-control-plane /needs-ani /proof /deploys /repos /handoffs /fleet /mutations /ops/destructive; do
             ok=false
             for _ in $(seq 1 6); do
               code="$(curl -sS -o /dev/null -w '%{http_code}' "https://admin.anipotts.com${path}")"

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -43,7 +43,7 @@ jobs:
         if: inputs.target == 'admin'
         run: |
           set -euo pipefail
-          for path in /auth/passkey / /content /content/review /content/drafts /content/edit/home /api/admin/content/draft-operation /content/preview /content/operations /newsletter /newsletter/first-thing-agents-need-control-plane /needs-ani /proof /repos /handoffs /fleet /mutations /ops/destructive; do
+          for path in /auth/passkey / /content /content/review /content/drafts /content/edit/home /api/admin/content/draft-operation /content/preview /content/operations /newsletter /newsletter/first-thing-agents-need-control-plane /needs-ani /proof /deploys /repos /handoffs /fleet /mutations /ops/destructive; do
             code="$(curl -sS -o /dev/null -w '%{http_code}' "https://admin.anipotts.com${path}")"
             echo "https://admin.anipotts.com${path} -> ${code}"
             case "$path:$code" in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,7 @@ For `admin.anipotts.com`, use this order:
    `/api/admin/content/draft-operation`, `/content/preview`,
    `/content/operations`, `/newsletter`,
    `/newsletter/first-thing-agents-need-control-plane`, `/needs-ani`, and
-   `/proof`
+   `/proof`, `/deploys`
 6. remove Cloudflare Access only after proof passes
 7. verify app-native unauthenticated block and authenticated passkey access
 8. rollback by restoring the previous Access app or policy if proof fails

--- a/apps/admin/src/data/admin.ts
+++ b/apps/admin/src/data/admin.ts
@@ -18,6 +18,15 @@ export type QueueRow = {
   evidence: string;
 };
 
+export type DeployRow = {
+  target: string;
+  input: string;
+  scope: string;
+  status: "automatic safe lane" | "manual rollback" | "retained worker";
+  proof: string;
+  next: string;
+};
+
 export const navItems: NavItem[] = [
   { href: "/", label: "overview", status: "migrating" },
   { href: "/content", label: "content", status: "live-source" },
@@ -28,6 +37,7 @@ export const navItems: NavItem[] = [
   { href: "/newsletter", label: "newsletter", status: "live-source" },
   { href: "/needs-ani", label: "needs ani", status: "live-source" },
   { href: "/proof", label: "proof", status: "live-source" },
+  { href: "/deploys", label: "deploys", status: "live-source" },
   { href: "/repos", label: "repos", status: "migrating" },
   { href: "/handoffs", label: "handoffs", status: "migrating" },
   { href: "/fleet", label: "fleet", status: "migrating" },
@@ -56,9 +66,15 @@ export const overviewCards: DashboardCard[] = [
   },
   {
     title: "proof log",
-    status: "static route proof",
+    status: "durable D1 proof",
     risk: "low",
-    next: "move deploy and passkey proof into durable records",
+    next: "keep deploy target proof current after each admin or public deploy",
+  },
+  {
+    title: "deploy scopes",
+    status: "read-only target map",
+    risk: "low",
+    next: "use /deploys to confirm skipped targets after each scoped deploy",
   },
   {
     title: "newsletter drafts",
@@ -140,6 +156,65 @@ export const repoRows: QueueRow[] = [
     owner: "legacy-admin-solid.anipotts.com",
     status: "legacy rollback",
     evidence: "deploy run 28302990801",
+  },
+];
+
+export const deployRows: DeployRow[] = [
+  {
+    target: "public site",
+    input: "www=true",
+    scope: "apps/www and proven public consumers",
+    status: "automatic safe lane",
+    proof: "public routes return 200 after scoped deploy",
+    next: "keep public content/layout changes isolated from admin code",
+  },
+  {
+    target: "Astro admin",
+    input: "admin=true",
+    scope: "apps/admin and proven admin consumers",
+    status: "automatic safe lane",
+    proof: "admin routes return Cloudflare Access 302 until passkey removal",
+    next: "enroll passkey, then prove app-native blocking before Access removal",
+  },
+  {
+    target: "admin-solid rollback",
+    input: "admin_solid=true",
+    scope: "apps/admin-solid only",
+    status: "manual rollback",
+    proof: "Deploy admin-solid is skipped unless explicitly requested",
+    next: "archive or remove after passkey proof and Astro admin rollback window closes",
+  },
+  {
+    target: "state worker",
+    input: "state=true",
+    scope: "workers/state only",
+    status: "retained worker",
+    proof: "state deploy job is skipped unless the target is selected",
+    next: "keep write routes behind STATE_PUBLISH_KEY and route-level proof",
+  },
+  {
+    target: "ingest worker",
+    input: "ingest=true",
+    scope: "workers/ingest only",
+    status: "retained worker",
+    proof: "ingest deploy job is skipped unless the target is selected",
+    next: "do not expand receivers without source-specific proof",
+  },
+  {
+    target: "newsletter worker",
+    input: "newsletter=true",
+    scope: "workers/newsletter only",
+    status: "retained worker",
+    proof: "newsletter deploy job is skipped unless the target is selected",
+    next: "keep sends gated until newsletter publishing proof exists",
+  },
+  {
+    target: "weekly email worker",
+    input: "weekly_email=true",
+    scope: "workers/weekly-email only",
+    status: "retained worker",
+    proof: "weekly email deploy job is skipped unless the target is selected",
+    next: "fold or retire after newsletter/content system owns the summary path",
   },
 ];
 

--- a/apps/admin/src/pages/deploys.astro
+++ b/apps/admin/src/pages/deploys.astro
@@ -1,0 +1,98 @@
+---
+import AdminLayout from "../layouts/AdminLayout.astro";
+import { deployRows } from "../data/admin";
+
+const safeLaneCount = deployRows.filter(
+  (row) => row.status === "automatic safe lane",
+).length;
+const retainedWorkerCount = deployRows.filter(
+  (row) => row.status === "retained worker",
+).length;
+const rollbackCount = deployRows.filter(
+  (row) => row.status === "manual rollback",
+).length;
+---
+
+<AdminLayout
+  title="deploys"
+  deck="Read-only deployment target map. This route shows what may deploy, what must skip, and what remains rollback-only."
+>
+  <section class="meta-strip" aria-label="deploy target summary">
+    <span>{deployRows.length} deploy targets</span>
+    <span>{safeLaneCount} automatic safe lanes</span>
+    <span>{retainedWorkerCount} retained workers</span>
+    <span>{rollbackCount} manual rollback</span>
+    <span>no dispatch controls</span>
+  </section>
+
+  <section class="table-card" aria-labelledby="deploy-targets-heading">
+    <div class="section-head">
+      <div>
+        <p>deploy matrix</p>
+        <h2 id="deploy-targets-heading">scoped targets</h2>
+      </div>
+      <span>workflow_dispatch inputs only</span>
+    </div>
+    <div class="table-wrap">
+      <table>
+        <thead>
+          <tr>
+            <th>target</th>
+            <th>input</th>
+            <th>scope</th>
+            <th>status</th>
+            <th>proof</th>
+            <th>next</th>
+          </tr>
+        </thead>
+        <tbody>
+          {
+            deployRows.map((row) => (
+              <tr>
+                <td>{row.target}</td>
+                <td>{row.input}</td>
+                <td>{row.scope}</td>
+                <td>{row.status}</td>
+                <td>{row.proof}</td>
+                <td>{row.next}</td>
+              </tr>
+            ))
+          }
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <section class="grid" aria-label="deploy gates">
+    <article class="panel">
+      <p class="risk-low">safe</p>
+      <h2>docs-only</h2>
+      <p>merge after green checks</p>
+      <p>deploy nothing</p>
+    </article>
+    <article class="panel">
+      <p class="risk-low">safe</p>
+      <h2>public site</h2>
+      <p>deploy <code>www=true</code> only</p>
+      <p>prove public routes return 200</p>
+    </article>
+    <article class="panel">
+      <p class="risk-medium">gated</p>
+      <h2>admin</h2>
+      <p>deploy <code>admin=true</code> only</p>
+      <p>prove protected routes block unauthenticated access</p>
+    </article>
+    <article class="panel">
+      <p class="risk-high">blocked</p>
+      <h2>Access removal</h2>
+      <p>requires passkey proof first</p>
+      <p>rollback by restoring the previous Access app or policy</p>
+    </article>
+  </section>
+
+  <div class="notice">
+    This route is informational. It does not call GitHub Actions, Wrangler,
+    Cloudflare, D1 migrations, DNS, Access policies, workers, queues, or send
+    paths.
+  </div>
+</AdminLayout>

--- a/docs/admin-v2-architecture.md
+++ b/docs/admin-v2-architecture.md
@@ -27,7 +27,8 @@ Live baseline:
   `/api/admin/content/draft-operation`, `/content/preview`,
   `/content/operations`, `/newsletter`,
   `/newsletter/first-thing-agents-need-control-plane`, `/needs-ani`, `/proof`,
-  `/repos`, `/handoffs`, `/fleet`, `/mutations`, and `/ops/destructive`
+  `/deploys`, `/repos`, `/handoffs`, `/fleet`, `/mutations`, and
+  `/ops/destructive`
 
 Current strengths:
 
@@ -38,6 +39,7 @@ Current strengths:
 - `/repos` can render the local-dev Infra runtime repo overlay metadata through
   `/api/admin/runtime-feed`
 - `admin_proof_events` provides durable proof rows in D1
+- `/deploys` shows the scoped deploy target map without dispatch controls
 - deploy workflow can target only admin
 - unauthenticated users are blocked by Cloudflare Access before app content
   renders

--- a/docs/platform-architecture.md
+++ b/docs/platform-architecture.md
@@ -91,6 +91,7 @@ operation tables, or publish-event tables.
 | `/newsletter/first-thing-agents-need-control-plane` | newsletter issue detail preview      |
 | `/needs-ani`                                        | typed human decision queue           |
 | `/proof`                                            | deploy, auth, and route proof log    |
+| `/deploys`                                          | scoped deploy target map             |
 | `/repos`                                            | repo and worktree state              |
 | `/handoffs`                                         | handoff freshness                    |
 | `/fleet`                                            | machine and agent state              |
@@ -126,7 +127,7 @@ until the edge gate is removed, not a blocker by itself. After Access removal,
 the same script must show app-native route blocking. The route probe set must
 include content inventory, review, drafts, focused page editor, draft-save API,
 preview, operations, newsletter queue, newsletter detail preview, needs-ani,
-proof, repos, handoffs, fleet, mutations, and destructive-ops routes.
+proof, deploys, repos, handoffs, fleet, mutations, and destructive-ops routes.
 
 First-passkey bootstrap in production requires a verified Cloudflare Access
 application JWT from `Cf-Access-Jwt-Assertion`. The admin Worker validates it
@@ -308,5 +309,8 @@ Rules:
 36. add durable `admin_proof_events` coverage for the draft-save write path.
     `drizzle/migrations/0034_seed_content_draft_save_proof.sql` seeds the
     pending proof row, and successful draft saves update it with metadata only.
-37. reduce deploy workflow inputs to retained production targets after rollback
+37. add a read-only `/deploys` route so the admin sidebar exposes scoped
+    deploy targets, rollback-only admin-solid status, retained worker targets,
+    and skipped-target proof expectations.
+38. reduce deploy workflow inputs to retained production targets after rollback
     no longer needs `apps/admin-solid`.

--- a/scripts/admin/passkey-proof.mjs
+++ b/scripts/admin/passkey-proof.mjs
@@ -36,6 +36,7 @@ const ROUTES = [
   "/newsletter",
   "/newsletter/first-thing-agents-need-control-plane",
   "/proof",
+  "/deploys",
   "/repos",
   "/handoffs",
   "/fleet",

--- a/scripts/ci/admin-route-parity.test.mjs
+++ b/scripts/ci/admin-route-parity.test.mjs
@@ -56,6 +56,7 @@ const ROUTES = [
     nav: true,
   },
   { route: "/proof", file: "apps/admin/src/pages/proof.astro", nav: true },
+  { route: "/deploys", file: "apps/admin/src/pages/deploys.astro", nav: true },
   { route: "/repos", file: "apps/admin/src/pages/repos.astro", nav: true },
   {
     route: "/handoffs",

--- a/scripts/ci/public-app-boundary.test.mjs
+++ b/scripts/ci/public-app-boundary.test.mjs
@@ -22,6 +22,7 @@ const ALLOWED_API_ROUTES = [
 const FORBIDDEN_PAGE_SEGMENTS = new Set([
   "admin",
   "auth",
+  "deploys",
   "fleet",
   "handoffs",
   "mutations",


### PR DESCRIPTION
## summary
- add a read-only /deploys route to the Astro admin sidebar
- show scoped deploy inputs, rollback-only admin-solid status, retained worker targets, and skipped-target proof expectations
- extend admin smoke/proof/route-parity coverage for /deploys

## verification
- pnpm --filter @anipotts/admin typecheck
- pnpm --filter @anipotts/admin build
- pnpm --silent test:admin-routes
- pnpm --silent test:workflows
- pnpm --silent test:public-boundary
- pnpm --silent test:security-review
- node scripts/ci/security-review.mjs .github/workflows/deploy.yml .github/workflows/smoke.yml CLAUDE.md apps/admin/src/data/admin.ts apps/admin/src/pages/deploys.astro docs/admin-v2-architecture.md docs/platform-architecture.md scripts/admin/passkey-proof.mjs scripts/ci/admin-route-parity.test.mjs scripts/ci/public-app-boundary.test.mjs
- pnpm exec prettier --check .github/workflows/deploy.yml .github/workflows/smoke.yml CLAUDE.md apps/admin/src/data/admin.ts apps/admin/src/pages/deploys.astro docs/admin-v2-architecture.md docs/platform-architecture.md scripts/admin/passkey-proof.mjs scripts/ci/admin-route-parity.test.mjs scripts/ci/public-app-boundary.test.mjs
- git diff --check

## live impact
- no live impact until merged and deployed
- no dispatch controls, write paths, Cloudflare Access changes, DNS changes, env changes, or secret handling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new read-only **Deploys** page in the admin area.
  * The admin navigation now includes **Deploys**, showing a deploy target overview and status summary.

* **Documentation**
  * Updated admin and platform docs to reference the new **Deploys** route and related route checks.

* **Bug Fixes**
  * Expanded smoke and proof checks to include **/deploys**, improving route coverage and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->