### PR TITLE
test admin route coverage fail closed

### DIFF
--- a/docs/platform-architecture.md
+++ b/docs/platform-architecture.md
@@ -67,7 +67,10 @@ covered while passkey proof and Access removal are completed, then remove
 `apps/admin-solid`:
 
 `pnpm test:admin-routes` enforces the route files, admin navigation, deploy
-smoke list, and manual smoke list for this parity set.
+smoke list, manual smoke list, passkey proof route set, and full admin page/API
+file classification for this parity set. New admin route files must be added to
+the protected route table or to an explicit public exception list before they
+can ship.
 
 `pnpm test:public-boundary` enforces the public app boundary for `apps/www`.
 The public app may render public CMS/D1 content, run newsletter subscribe
@@ -314,3 +317,6 @@ Rules:
     and skipped-target proof expectations.
 38. reduce deploy workflow inputs to retained production targets after rollback
     no longer needs `apps/admin-solid`.
+39. fail closed on new admin routes: `pnpm test:admin-routes` now requires every
+    `apps/admin/src/pages` route file to be classified and every protected smoke
+    route to appear in passkey proof before merge.

--- a/scripts/ci/admin-route-parity.test.mjs
+++ b/scripts/ci/admin-route-parity.test.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 
 import assert from "node:assert/strict";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 
 const ROUTES = [
   { route: "/", file: "apps/admin/src/pages/index.astro", nav: true },
@@ -87,8 +88,23 @@ const ROUTES = [
   },
 ];
 
+const PUBLIC_UNSMOKED_ROUTE_FILES = [
+  "apps/admin/src/pages/api/health.ts",
+  "apps/admin/src/pages/api/admin/passkey/login-options.ts",
+  "apps/admin/src/pages/api/admin/passkey/login-verify.ts",
+  "apps/admin/src/pages/api/admin/passkey/logout.ts",
+  "apps/admin/src/pages/api/admin/passkey/register-options.ts",
+  "apps/admin/src/pages/api/admin/passkey/register-verify.ts",
+  "apps/admin/src/pages/api/admin/passkey/revoke-current.ts",
+  "apps/admin/src/pages/api/admin/passkey/status.ts",
+];
+
 const navSource = readFileSync("apps/admin/src/data/admin.ts", "utf8");
 const middlewareSource = readFileSync("apps/admin/src/middleware.ts", "utf8");
+const passkeyProofSource = readFileSync(
+  "scripts/admin/passkey-proof.mjs",
+  "utf8",
+);
 const passkeySource = readFileSync(
   "apps/admin/src/pages/auth/passkey.astro",
   "utf8",
@@ -101,6 +117,9 @@ const deployWorkflow = readFileSync(".github/workflows/deploy.yml", "utf8");
 const smokeWorkflow = readFileSync(".github/workflows/smoke.yml", "utf8");
 const deploySmokeRoutes = extractShellForRoutes(deployWorkflow);
 const manualSmokeRoutes = extractShellForRoutes(smokeWorkflow);
+const passkeyProofRoutes = new Set(
+  extractStringList(passkeyProofSource, "ROUTES"),
+);
 const publicPaths = extractStringList(middlewareSource, "PUBLIC_PATHS");
 const publicPasskeyApiPaths = extractStringList(
   middlewareSource,
@@ -125,6 +144,22 @@ assert.deepEqual(publicPasskeyApiPaths, [
   "/api/admin/passkey/status",
 ]);
 assert.deepEqual(publicPrefixes, ["/_astro/", "/assets/"]);
+
+const classifiedFiles = new Set([
+  ...ROUTES.map((route) => route.file),
+  ...PUBLIC_UNSMOKED_ROUTE_FILES,
+]);
+
+for (const file of listAdminPageFiles()) {
+  assert.ok(
+    classifiedFiles.has(file),
+    `${file} must be classified in admin-route-parity before it can ship`,
+  );
+}
+
+for (const file of PUBLIC_UNSMOKED_ROUTE_FILES) {
+  assert.ok(existsSync(file), `public admin exception missing ${file}`);
+}
 
 for (const route of ROUTES) {
   assert.ok(existsSync(route.file), `${route.route} missing ${route.file}`);
@@ -162,6 +197,10 @@ for (const route of ROUTES) {
     assert.ok(
       manualSmokeRoutes.has(route.route),
       `${route.route} missing from smoke.yml admin route proof`,
+    );
+    assert.ok(
+      passkeyProofRoutes.has(route.route),
+      `${route.route} missing from passkey proof route set`,
     );
   }
 }
@@ -207,4 +246,14 @@ function extractStringList(source, name) {
     ) ?? source.match(new RegExp(`const ${name} = \\[([\\s\\S]*?)\\];`));
   assert.ok(match, `missing middleware list ${name}`);
   return [...match[1].matchAll(/"([^"]+)"/g)].map((item) => item[1]).sort();
+}
+
+function listAdminPageFiles(dir = "apps/admin/src/pages") {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) return listAdminPageFiles(path);
+    if (!entry.isFile()) return [];
+    if (!/\.(astro|ts)$/.test(entry.name)) return [];
+    return [path];
+  });
 }


### PR DESCRIPTION
## summary
- make admin route parity fail when a new apps/admin route file is not explicitly classified
- require protected smoke routes to also appear in passkey proof
- document the fail-closed route guard in the platform architecture

## verification
- pnpm --silent test:admin-routes
- pnpm --silent test:security-review
- node scripts/ci/security-review.mjs scripts/ci/admin-route-parity.test.mjs docs/platform-architecture.md
- pnpm exec prettier --check scripts/ci/admin-route-parity.test.mjs docs/platform-architecture.md
- git diff --check

## live impact
- no app deploy expected
- no Cloudflare Access, DNS, env, secret, D1, or write-path changes