### PR TITLE
align local validate with ci gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,6 +132,10 @@ pnpm turbo build --filter=@anipotts/admin-solid...
 pnpm validate
 ```
 
+`pnpm validate` mirrors the local PR gate: workspace/deploy/admin/public/path
+invariants, content platform invariants, workflow/security guards, formatting,
+and full build/lint/typecheck/test.
+
 For deploys, record:
 
 - PR number and merge SHA

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ pnpm dev:www      # just the astro site (astro defaults to http://localhost:4321
 ```bash
 pnpm build
 pnpm test
-pnpm validate     # build + lint + typecheck + test
+pnpm validate     # local PR gate: invariants + format + build/lint/typecheck/test
 ```
 
 ## Content model

--- a/package.json
+++ b/package.json
@@ -35,9 +35,10 @@
     "test:workspace": "node scripts/ci/workspace-inventory.test.mjs",
     "test:workflows": "node scripts/ci/workflow-inventory.test.mjs",
     "test:security-review": "node scripts/ci/security-review.test.mjs",
+    "test:ci-invariants": "pnpm test:workspace && pnpm test:deploy-targets && pnpm test:admin-routes && pnpm test:public-boundary && pnpm test:public-routes && pnpm test:path-hygiene && pnpm test:content-platform && pnpm test:workflows && pnpm test:security-review",
     "test:unit": "turbo test",
     "test": "pnpm test:unit",
-    "validate": "turbo build && turbo lint && turbo typecheck && turbo test",
+    "validate": "pnpm test:ci-invariants && pnpm format:check && pnpm build && pnpm lint && pnpm typecheck && pnpm test",
     "prepare": "husky"
   },
   "lint-staged": {


### PR DESCRIPTION
## summary
- add a `test:ci-invariants` root script for the repo guard suite
- make `pnpm validate` run invariants, formatting, build, lint, typecheck, and tests
- document the updated local PR gate in README and CLAUDE/AGENTS

## verification
- `git diff --check`
- `pnpm exec prettier --check package.json README.md CLAUDE.md`
- `pnpm test:ci-invariants`
- `pnpm validate`

## live impact
- none expected
- docs/package-script metadata only
- no deploy, dns, auth, env, secret, d1, worker, or write-path mutation