### PR TITLE
show passkey proof command in admin

### DIFF
--- a/apps/admin/src/pages/auth/passkey.astro
+++ b/apps/admin/src/pages/auth/passkey.astro
@@ -89,6 +89,27 @@ function sanitizeAdminReturnPath(path: string | null): string {
     proven.
   </p>
 
+  <section
+    class="proof-command-board"
+    aria-labelledby="passkey-command-heading"
+  >
+    <div class="section-header">
+      <div>
+        <p>proof command</p>
+        <h2 id="passkey-command-heading">do not remove Access yet</h2>
+      </div>
+      <span>rerun after every browser step</span>
+    </div>
+    <div class="command-row">
+      <code>pnpm --silent proof:admin-passkey</code>
+      <p>
+        Access removal is allowed only when this reports an active credential,
+        an active session, required audit events, and
+        <code>ready_for_access_removal: true</code>.
+      </p>
+    </div>
+  </section>
+
   <section class="handoff-board" aria-labelledby="passkey-handoff-heading">
     <div class="section-header">
       <div>

--- a/apps/admin/src/styles/admin.css
+++ b/apps/admin/src/styles/admin.css
@@ -296,6 +296,7 @@ th {
 }
 
 .handoff-board,
+.proof-command-board,
 .runbook-board,
 .proof-checklist {
   margin-top: 24px;
@@ -304,10 +305,35 @@ th {
 }
 
 .handoff-board .section-header,
+.proof-command-board .section-header,
 .runbook-board .section-header,
 .proof-checklist .section-header {
   padding: 16px;
   border-bottom: 1px solid var(--border);
+}
+
+.command-row {
+  display: grid;
+  gap: 10px;
+  padding: 16px;
+}
+
+.command-row code {
+  border: 1px solid var(--border);
+  background: var(--panel-strong);
+  color: var(--ink);
+  padding: 10px 12px;
+  width: fit-content;
+}
+
+.command-row p {
+  margin: 0;
+  color: var(--muted);
+  max-width: 760px;
+}
+
+.command-row p code {
+  padding: 2px 5px;
 }
 
 .handoff-list,


### PR DESCRIPTION
## summary
- add an operator-facing proof command panel to `/auth/passkey`
- make the Access-removal threshold explicit in the live admin UI
- reuse the existing admin panel styles for the new cue

## verification
- `pnpm turbo typecheck --filter=@anipotts/admin...`
- `pnpm turbo build --filter=@anipotts/admin...`
- `pnpm test:ci-invariants`
- `git diff --check`
- `pnpm exec prettier --check apps/admin/src/pages/auth/passkey.astro apps/admin/src/styles/admin.css`
- `node scripts/ci/compute-deploy-targets.mjs /tmp/passkey-cue-files.txt` -> `admin=true`, all other targets false

## live impact
- admin-only UI cue on `/auth/passkey`
- expected deploy target: `admin=true` only
- no dns, cloudflare access policy, env, secret, d1 migration, worker, publish, send, or write-path change
- Access removal remains blocked until `pnpm --silent proof:admin-passkey` reports proof complete