### PR TITLE
feat(admin): simplify operator shell

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -13,6 +13,10 @@
   },
   "dependencies": {
     "@anipotts/content": "workspace:*",
+    "@anipotts/styles": "workspace:*",
+    "@fontsource-variable/instrument-sans": "^5.2.8",
+    "@fontsource-variable/jetbrains-mono": "^5.2.5",
+    "@fontsource/geist-sans": "^5.2.5",
     "@astrojs/cloudflare": "^12.6.0",
     "@simplewebauthn/browser": "13.3.0",
     "@simplewebauthn/server": "13.3.2",

--- a/apps/admin/src/data/admin.ts
+++ b/apps/admin/src/data/admin.ts
@@ -1,7 +1,9 @@
 export type NavItem = {
   href: string;
   label: string;
-  status: "live-source" | "migrating" | "gated";
+  status: string;
+  group: "primary" | "content" | "advanced";
+  description: string;
 };
 
 export type DashboardCard = {
@@ -9,6 +11,8 @@ export type DashboardCard = {
   status: string;
   risk: "low" | "medium" | "high";
   next: string;
+  href: string;
+  action: string;
 };
 
 export type QueueRow = {
@@ -28,65 +32,162 @@ export type DeployRow = {
 };
 
 export const navItems: NavItem[] = [
-  { href: "/", label: "overview", status: "live-source" },
-  { href: "/content", label: "content", status: "live-source" },
-  { href: "/content/review", label: "review", status: "live-source" },
-  { href: "/content/drafts", label: "drafts", status: "live-source" },
-  { href: "/content/preview", label: "preview", status: "live-source" },
-  { href: "/content/operations", label: "operations", status: "live-source" },
-  { href: "/newsletter", label: "newsletter", status: "live-source" },
-  { href: "/needs-ani", label: "needs ani", status: "live-source" },
-  { href: "/proof", label: "proof", status: "live-source" },
-  { href: "/deploys", label: "deploys", status: "live-source" },
-  { href: "/repos", label: "repos", status: "migrating" },
-  { href: "/handoffs", label: "handoffs", status: "migrating" },
-  { href: "/fleet", label: "fleet", status: "migrating" },
-  { href: "/mutations", label: "mutations", status: "gated" },
-  { href: "/ops/destructive", label: "destructive ops", status: "gated" },
+  {
+    href: "/",
+    label: "overview",
+    status: "source",
+    group: "primary",
+    description: "what is safe to do next",
+  },
+  {
+    href: "/fleet",
+    label: "fleet",
+    status: "runtime",
+    group: "primary",
+    description: "machines, repo state, current work",
+  },
+  {
+    href: "/content",
+    label: "content",
+    status: "D1",
+    group: "primary",
+    description: "public-site content inventory",
+  },
+  {
+    href: "/content/drafts",
+    label: "writing editor",
+    status: "drafts",
+    group: "primary",
+    description: "draft operations and editable rows",
+  },
+  {
+    href: "/proof",
+    label: "proof/auth",
+    status: "passkeys",
+    group: "primary",
+    description: "auth, proof, and blocked checks",
+  },
+  {
+    href: "/deploys",
+    label: "deploys",
+    status: "scoped",
+    group: "primary",
+    description: "target map and deploy proof",
+  },
+  {
+    href: "/content/review",
+    label: "review queue",
+    status: "content",
+    group: "content",
+    description: "proposed copy and review state",
+  },
+  {
+    href: "/content/preview",
+    label: "preview",
+    status: "content",
+    group: "content",
+    description: "draft preview surfaces",
+  },
+  {
+    href: "/content/operations",
+    label: "operations",
+    status: "content",
+    group: "content",
+    description: "draft operation metadata",
+  },
+  {
+    href: "/newsletter",
+    label: "newsletter",
+    status: "retained",
+    group: "content",
+    description: "issue preview without sends",
+  },
+  {
+    href: "/needs-ani",
+    label: "needs ani",
+    status: "queue",
+    group: "content",
+    description: "typed approval and decision queue",
+  },
+  {
+    href: "/repos",
+    label: "repos",
+    status: "details",
+    group: "advanced",
+    description: "dirty state and branch drift",
+  },
+  {
+    href: "/handoffs",
+    label: "handoffs",
+    status: "details",
+    group: "advanced",
+    description: "handoff freshness and absorption",
+  },
+  {
+    href: "/mutations",
+    label: "mutations",
+    status: "gated",
+    group: "advanced",
+    description: "proposed, approved, running, verified",
+  },
+  {
+    href: "/ops/destructive",
+    label: "destructive ops",
+    status: "gated",
+    group: "advanced",
+    description: "delete, dns, auth, deploy, secrets",
+  },
 ];
 
 export const overviewCards: DashboardCard[] = [
   {
-    title: "admin Astro cutover",
-    status: "canonical route cut over",
-    risk: "low",
-    next: "prove passkey behavior, then remove the legacy Solid rollback",
-  },
-  {
-    title: "passkey auth",
-    status: "edge protected",
+    title: "passkey proof",
+    status: "two credentials registered, one active session",
     risk: "high",
-    next: "register first biometric passkey before Access removal",
+    next: "record revoked-credential and denied-auth proof before Access removal",
+    href: "/auth/passkey",
+    action: "open auth proof",
   },
   {
-    title: "content platform",
-    status: "D1-backed review state",
+    title: "writing editor",
+    status:
+      "draft operation editor is live; full publish flow moved to a worktree",
     risk: "medium",
-    next: "enroll passkey and save one draft operation before publish design",
+    next: "build D1 save, preview, publish, visibility, and revision history",
+    href: "/content/drafts",
+    action: "review editor",
   },
   {
-    title: "proof log",
-    status: "durable D1 proof",
+    title: "content inventory",
+    status: "D1 page_content rows are visible with source fallback",
     risk: "low",
-    next: "keep deploy target proof current after each admin or public deploy",
+    next: "keep public content readable while editor writes are proven separately",
+    href: "/content",
+    action: "open content",
   },
   {
-    title: "deploy scopes",
-    status: "read-only target map",
+    title: "fleet status",
+    status: "runtime and repo state are readable from the operator dashboard",
     risk: "low",
-    next: "use /deploys to confirm skipped targets after each scoped deploy",
+    next: "make machine drift, stale work, and current owner clearer",
+    href: "/fleet",
+    action: "open fleet",
   },
   {
-    title: "newsletter drafts",
-    status: "D1 page content plus static issue preview",
+    title: "deploy proof",
+    status: "admin and public deploy targets are separated",
+    risk: "low",
+    next: "after each merge, prove only the intended target ran",
+    href: "/deploys",
+    action: "check deploys",
+  },
+  {
+    title: "advanced ops",
+    status: "handoffs, mutations, and destructive ops are demoted",
     risk: "medium",
-    next: "review issue structure in admin before any D1 write or send path",
-  },
-  {
-    title: "legacy cleanup",
-    status: "blocked by passkey proof",
-    risk: "low",
-    next: "archive or remove admin-solid after passkey proof",
+    next: "keep visible for audit without making them the first screen",
+    href: "/mutations",
+    action: "open gates",
   },
 ];
 
@@ -249,6 +350,14 @@ export const mutationRows: QueueRow[] = [
 ];
 
 export function routeTitle(pathname: string): string {
-  const match = navItems.find((item) => item.href === pathname);
+  if (pathname.startsWith("/content/edit/")) return "writing editor";
+
+  const match =
+    navItems.find((item) => item.href === pathname) ??
+    [...navItems]
+      .sort((a, b) => b.href.length - a.href.length)
+      .find(
+        (item) => item.href !== "/" && pathname.startsWith(`${item.href}/`),
+      );
   return match?.label ?? "admin";
 }

--- a/apps/admin/src/layouts/AdminLayout.astro
+++ b/apps/admin/src/layouts/AdminLayout.astro
@@ -8,6 +8,23 @@ type Props = {
 };
 
 const { title = routeTitle(Astro.url.pathname), deck = "" } = Astro.props;
+const currentPath = Astro.url.pathname.replace(/\/$/, "") || "/";
+const primaryNav = navItems.filter((item) => item.group === "primary");
+const secondaryNav = [
+  {
+    label: "content queues",
+    items: navItems.filter((item) => item.group === "content"),
+  },
+  {
+    label: "advanced",
+    items: navItems.filter((item) => item.group === "advanced"),
+  },
+];
+
+function isActive(href: string): boolean {
+  if (href === "/") return currentPath === "/";
+  return currentPath === href || currentPath.startsWith(`${href}/`);
+}
 ---
 
 <!doctype html>
@@ -15,8 +32,40 @@ const { title = routeTitle(Astro.url.pathname), deck = "" } = Astro.props;
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#101010" />
+    <meta
+      name="theme-color"
+      media="(prefers-color-scheme: light)"
+      content="#fbfaf7"
+    />
+    <meta
+      name="theme-color"
+      media="(prefers-color-scheme: dark)"
+      content="#11111b"
+    />
     <title>{title} | anipotts admin</title>
+    <script is:inline>
+      (() => {
+        const stored = localStorage.getItem("theme");
+        const theme =
+          stored === "dark" || stored === "light"
+            ? stored
+            : matchMedia("(prefers-color-scheme: dark)").matches
+              ? "dark"
+              : "light";
+        document.documentElement.dataset.theme = theme;
+
+        const requestedFont = new URLSearchParams(location.search).get("font");
+        const storedFont = localStorage.getItem("font");
+        const font =
+          requestedFont === "geist" || requestedFont === "instrument"
+            ? requestedFont
+            : storedFont === "geist" || storedFont === "instrument"
+              ? storedFont
+              : "instrument";
+        document.documentElement.dataset.font = font;
+        localStorage.setItem("font", font);
+      })();
+    </script>
   </head>
   <body>
     <div class="shell">
@@ -25,25 +74,53 @@ const { title = routeTitle(Astro.url.pathname), deck = "" } = Astro.props;
           <span class="brand-mark">a</span>
           <span>
             <strong>anipotts admin</strong>
-            <small>Astro canonical</small>
+            <small>operator console</small>
           </span>
         </a>
-        <nav>
+        <nav class="nav-stack">
+          <section class="nav-section" aria-label="primary admin routes">
+            <p class="nav-section-title">primary</p>
+            <div class="nav-section-links">
+              {
+                primaryNav.map((item) => (
+                  <a
+                    class:list={["nav-link", isActive(item.href) && "active"]}
+                    href={item.href}
+                  >
+                    <span>{item.label}</span>
+                    <small>{item.description}</small>
+                  </a>
+                ))
+              }
+            </div>
+          </section>
           {
-            navItems.map((item) => (
-              <a
-                class:list={[
-                  "nav-link",
-                  Astro.url.pathname === item.href && "active",
-                ]}
-                href={item.href}
+            secondaryNav.map((section) => (
+              <details
+                class="nav-section nav-details"
+                open={section.items.some((item) => isActive(item.href))}
               >
-                <span>{item.label}</span>
-                <small>{item.status}</small>
-              </a>
+                <summary>{section.label}</summary>
+                <div class="nav-section-links">
+                  {section.items.map((item) => (
+                    <a
+                      class:list={["nav-link", isActive(item.href) && "active"]}
+                      href={item.href}
+                    >
+                      <span>{item.label}</span>
+                      <small>{item.description}</small>
+                    </a>
+                  ))}
+                </div>
+              </details>
             ))
           }
         </nav>
+        <div class="sidebar-proof">
+          <span>auth state</span>
+          <strong>passkey active, Access outer guard</strong>
+          <small>remove Access only after revoked and denied auth proof.</small>
+        </div>
       </aside>
       <main>
         <header class="page-header">

--- a/apps/admin/src/pages/index.astro
+++ b/apps/admin/src/pages/index.astro
@@ -1,13 +1,74 @@
 ---
 import AdminLayout from "../layouts/AdminLayout.astro";
-import { overviewCards } from "../data/admin";
+import { navItems, overviewCards } from "../data/admin";
+
+const primaryLinks = navItems.filter(
+  (item) => item.group === "primary" && item.href !== "/",
+);
+
+const proofRows = [
+  {
+    label: "passkeys",
+    value: "2 credentials",
+    detail: "1 active session, revoke/denial proof still missing",
+  },
+  {
+    label: "content",
+    value: "D1 backed",
+    detail: "inventory, review queue, draft operation editor",
+  },
+  {
+    label: "threads",
+    value: "2 worktrees",
+    detail: "orchestrating redesign and real writing editor",
+  },
+  {
+    label: "guard",
+    value: "Access on",
+    detail: "remove only after app-native passkey proof is ready",
+  },
+];
 ---
 
 <AdminLayout
   title="operator overview"
-  deck="Canonical Astro admin shell. Cloudflare Access remains only until app-native passkey proof is complete."
+  deck="Small surface first. Primary routes answer what is safe next; advanced queues stay available without dominating the screen."
 >
-  <section class="grid" aria-label="operator overview cards">
+  <section class="overview-hero" aria-labelledby="safe-next-heading">
+    <p class="section-label">what is safe next</p>
+    <h2 id="safe-next-heading">
+      finish passkey revoke proof, keep content writes scoped, and let the
+      editor worktree own publishing.
+    </h2>
+    <p>
+      This admin surface is now organized like a docs console: fleet, content,
+      writing, proof, and deploys are first. Handoffs, raw repos, mutations, and
+      destructive operations stay one level down.
+    </p>
+    <div class="hero-actions" aria-label="primary admin routes">
+      {
+        primaryLinks.map((item) => (
+          <a class="button secondary" href={item.href}>
+            {item.label}
+          </a>
+        ))
+      }
+    </div>
+  </section>
+
+  <section class="quick-grid" aria-label="current operator state">
+    {
+      proofRows.map((row) => (
+        <article class="quick-card">
+          <p>{row.label}</p>
+          <h2>{row.value}</h2>
+          <span>{row.detail}</span>
+        </article>
+      ))
+    }
+  </section>
+
+  <section class="surface-grid" aria-label="operator overview cards">
     {
       overviewCards.map((card) => (
         <article class="panel">
@@ -15,13 +76,16 @@ import { overviewCards } from "../data/admin";
           <h2>{card.title}</h2>
           <p>{card.status}</p>
           <p>{card.next}</p>
+          <a class="panel-link" href={card.href}>
+            {card.action}
+          </a>
         </article>
       ))
     }
   </section>
   <div class="notice">
-    This app now owns admin.anipotts.com. It is intentionally protected by the
-    app-native passkey session middleware, with Cloudflare Access kept as the
-    outer guard until passkey proof is complete.
+    Cloudflare Access stays in front of admin.anipotts.com until app-native
+    passkey proof reports ready. This page does not register passkeys, revoke
+    credentials, publish content, dispatch deploys, or write public-site data.
   </div>
 </AdminLayout>

--- a/apps/admin/src/styles/admin.css
+++ b/apps/admin/src/styles/admin.css
@@ -1,21 +1,38 @@
+@import "@anipotts/styles/tokens-www.css";
+@import "@fontsource-variable/instrument-sans";
+@import "@fontsource/geist-sans";
+@import "@fontsource-variable/jetbrains-mono";
+
 :root {
+  color-scheme: light;
+  --panel: var(--surface);
+  --panel-strong: #ebe8e0;
+  --text: var(--ink);
+  --muted: var(--ink-muted);
+  --risk: #b45309;
+  --danger-border: #c2410c;
+  --danger-text: #9a3412;
+  --inverse-ink: #fbfaf7;
+  --field-surface: #f7f5ef;
+  --warn-border: #d6a950;
+  --warn-surface: #fbf4dd;
+}
+
+html {
+  background: var(--bg);
+  color-scheme: light;
+}
+
+html[data-theme="dark"] {
   color-scheme: dark;
-  --bg: #101010;
-  --panel: #171717;
-  --panel-strong: #202020;
-  --border: #303030;
-  --text: #f4f1ea;
-  --muted: #a7a096;
-  --accent: #d7ff63;
-  --risk: #ffb86b;
-  font-family:
-    Inter,
-    ui-sans-serif,
-    system-ui,
-    -apple-system,
-    BlinkMacSystemFont,
-    "Segoe UI",
-    sans-serif;
+  --panel-strong: #252538;
+  --risk: #f9e2af;
+  --danger-border: #f38ba8;
+  --danger-text: #f38ba8;
+  --inverse-ink: #11111b;
+  --field-surface: #181825;
+  --warn-border: #f9e2af;
+  --warn-surface: #1f1d2a;
 }
 
 * {
@@ -26,6 +43,12 @@ body {
   margin: 0;
   background: var(--bg);
   color: var(--text);
+  font-family: var(--sans);
+  font-size: var(--p-body);
+  line-height: var(--lh-body);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
 }
 
 a {
@@ -35,7 +58,7 @@ a {
 
 .shell {
   display: grid;
-  grid-template-columns: 280px minmax(0, 1fr);
+  grid-template-columns: 292px minmax(0, 1fr);
   min-height: 100vh;
 }
 
@@ -46,7 +69,7 @@ a {
   top: 0;
   align-self: start;
   min-height: 100vh;
-  background: #0d0d0d;
+  background: var(--bg);
 }
 
 .brand {
@@ -64,7 +87,7 @@ a {
   height: 36px;
   border: 1px solid var(--border);
   background: var(--accent);
-  color: #101010;
+  color: var(--inverse-ink);
   font-weight: 800;
 }
 
@@ -83,10 +106,49 @@ td {
   color: var(--muted);
 }
 
+.brand strong,
+.nav-link span,
+.page-header h1,
+.panel h2,
+.quick-card h2 {
+  font-weight: 500;
+}
+
+.nav-stack,
+.nav-section-links {
+  display: grid;
+  gap: 6px;
+}
+
+.nav-stack {
+  gap: 18px;
+}
+
+.nav-section,
+.nav-details {
+  display: grid;
+  gap: 8px;
+}
+
+.nav-section-title,
+.nav-details summary {
+  margin: 0;
+  color: var(--muted);
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+.nav-details summary {
+  cursor: pointer;
+}
+
 .nav-link {
   display: grid;
-  gap: 3px;
-  padding: 12px;
+  gap: 4px;
+  padding: 10px 12px;
   border: 1px solid transparent;
   font-size: 14px;
 }
@@ -97,8 +159,39 @@ td {
   background: var(--panel);
 }
 
+.nav-link small {
+  line-height: 1.35;
+}
+
+.sidebar-proof {
+  display: grid;
+  gap: 4px;
+  margin-top: 28px;
+  border: 1px solid var(--border);
+  background: var(--panel);
+  padding: 12px;
+}
+
+.sidebar-proof span {
+  color: var(--muted);
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.sidebar-proof strong {
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.sidebar-proof small {
+  color: var(--muted);
+  line-height: 1.4;
+}
+
 main {
-  padding: 28px;
+  padding: clamp(20px, 4vw, 44px);
 }
 
 .page-header {
@@ -112,8 +205,8 @@ main {
 
 .page-header h1 {
   margin: 0;
-  font-size: clamp(32px, 5vw, 64px);
-  line-height: 0.95;
+  font-size: var(--p-h1);
+  line-height: var(--lh-tight);
   letter-spacing: 0;
 }
 
@@ -130,6 +223,88 @@ main {
   text-align: right;
   line-height: 1.5;
   text-transform: none;
+}
+
+.overview-hero {
+  display: grid;
+  gap: 18px;
+  max-width: 880px;
+  padding: clamp(22px, 5vw, 46px) 0 6px;
+}
+
+.overview-hero .section-label,
+.section-label {
+  margin: 0;
+  color: var(--muted);
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.overview-hero h2 {
+  max-width: 820px;
+  margin: 0;
+  font-size: var(--p-hero);
+  font-weight: 500;
+  line-height: 1;
+  letter-spacing: 0;
+}
+
+.overview-hero p {
+  max-width: var(--measure);
+  margin: 0;
+  color: var(--muted);
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.quick-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+  margin: 28px 0;
+}
+
+.quick-card {
+  display: grid;
+  gap: 8px;
+  border: 1px solid var(--border);
+  background: var(--panel);
+  padding: 16px;
+}
+
+.quick-card p,
+.quick-card h2,
+.quick-card span {
+  margin: 0;
+}
+
+.quick-card p {
+  color: var(--muted);
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.quick-card h2 {
+  font-size: var(--p-h3);
+  letter-spacing: 0;
+}
+
+.quick-card span {
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.surface-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
 .grid {
@@ -154,6 +329,12 @@ main {
 
 .panel p {
   line-height: 1.55;
+}
+
+.panel-link {
+  color: var(--accent);
+  font-size: 13px;
+  font-weight: 650;
 }
 
 .risk-low {
@@ -213,7 +394,7 @@ th {
 .button {
   border: 1px solid var(--border);
   background: var(--accent);
-  color: #101010;
+  color: var(--inverse-ink);
   padding: 10px 12px;
   font: inherit;
   font-size: 14px;
@@ -226,8 +407,8 @@ th {
 }
 
 .button.danger {
-  border-color: #8f4b3f;
-  color: #f2b8ad;
+  border-color: var(--danger-border);
+  color: var(--danger-text);
 }
 
 .inert-button {
@@ -415,7 +596,7 @@ th {
 .runbook-step.complete .step-index,
 .proof-item.complete .proof-dot {
   background: var(--accent);
-  color: #101010;
+  color: var(--inverse-ink);
 }
 
 .proof-item code {
@@ -540,7 +721,7 @@ dd {
   gap: 4px;
   min-width: 0;
   border: 1px solid var(--border);
-  background: #141414;
+  background: var(--field-surface);
   padding: 10px;
 }
 
@@ -577,8 +758,8 @@ dd {
   display: grid;
   gap: 6px;
   margin-top: 10px;
-  border: 1px solid #4a3b28;
-  background: #181510;
+  border: 1px solid var(--warn-border);
+  background: var(--warn-surface);
   padding: 10px;
 }
 
@@ -587,7 +768,7 @@ dd {
   gap: 6px;
   margin-top: 12px;
   border: 1px solid var(--border);
-  background: #111;
+  background: var(--field-surface);
   padding: 12px;
 }
 
@@ -645,7 +826,7 @@ dd {
 .compact-row {
   display: grid;
   gap: 5px;
-  background: #141414;
+  background: var(--field-surface);
 }
 
 .proposal-row {
@@ -677,7 +858,7 @@ dd {
   width: 100%;
   min-width: 0;
   border: 1px solid var(--border);
-  background: #111;
+  background: var(--field-surface);
   color: var(--text);
   font: inherit;
   font-size: 13px;
@@ -748,7 +929,7 @@ dd {
   width: 100%;
   min-width: 0;
   border: 1px solid var(--border);
-  background: #111;
+  background: var(--field-surface);
   color: var(--text);
   padding: 10px;
   font: inherit;
@@ -792,7 +973,7 @@ dd {
 
 .diff-pair > div {
   border: 1px solid var(--border);
-  background: #141414;
+  background: var(--field-surface);
   padding: 12px;
 }
 
@@ -955,9 +1136,8 @@ dd {
     border-bottom: 1px solid var(--border);
   }
 
-  .sidebar nav {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+  .sidebar .nav-stack {
+    grid-template-columns: 1fr;
   }
 
   main {
@@ -975,7 +1155,9 @@ dd {
     margin-top: 12px;
   }
 
-  .grid {
+  .grid,
+  .quick-grid,
+  .surface-grid {
     grid-template-columns: 1fr;
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,9 +51,21 @@ importers:
       '@anipotts/content':
         specifier: workspace:*
         version: link:../../packages/content
+      '@anipotts/styles':
+        specifier: workspace:*
+        version: link:../../packages/styles
       '@astrojs/cloudflare':
         specifier: ^12.6.0
         version: 12.6.13(@types/node@22.19.19)(astro@5.18.2(@types/node@22.19.19)(aws4fetch@1.0.20)(db0@0.3.4(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260518.1)(@opentelemetry/api@1.9.0)))(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.59.0)(terser@5.47.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0))(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0)
+      '@fontsource-variable/instrument-sans':
+        specifier: ^5.2.8
+        version: 5.2.8
+      '@fontsource-variable/jetbrains-mono':
+        specifier: ^5.2.5
+        version: 5.2.8
+      '@fontsource/geist-sans':
+        specifier: ^5.2.5
+        version: 5.2.5
       '@simplewebauthn/browser':
         specifier: 13.3.0
         version: 13.3.0


### PR DESCRIPTION
## summary
- reorganizes Astro admin navigation around overview, fleet, content, writing editor, proof/auth, and deploys
- groups content queues and advanced ops under secondary sidebar sections
- aligns admin typography, theme bootstrapping, and colors with the public-site style tokens
- declares the admin app style/font package dependencies explicitly

## verification
- `pnpm exec prettier --check apps/admin/package.json apps/admin/src/data/admin.ts apps/admin/src/layouts/AdminLayout.astro apps/admin/src/pages/index.astro apps/admin/src/styles/admin.css`
- `git diff --check`
- `pnpm turbo typecheck --filter=@anipotts/admin...`
- `pnpm turbo build --filter=@anipotts/admin...`
- `pnpm test:ci-invariants`
- `node scripts/ci/compute-deploy-targets.mjs /tmp/anipotts-admin-shell-files.txt` returned `admin=true` and all other deploy targets false
- local dev smoke on `127.0.0.1:3001`: protected routes redirected to passkey gate, `/auth/passkey` returned 200

## live impact
none yet. expected deploy target after merge is `admin=true` only.

## passkey gate
`pnpm --silent proof:admin-passkey` still reports missing `passkey.credential.revoked` and `passkey.authentication.denied`, so Cloudflare Access removal remains blocked.
