### PR TITLE
feat: add admin writing editor

### DIFF
--- a/apps/admin/src/lib/content-editor.ts
+++ b/apps/admin/src/lib/content-editor.ts
@@ -1,0 +1,875 @@
+import {
+  normalizeCmsWriting,
+  validateCmsWriting,
+} from "@anipotts/content/public";
+
+type D1Result<T = unknown> = {
+  results?: T[];
+  success?: boolean;
+  meta?: unknown;
+};
+
+type D1PreparedStatement = {
+  bind(...values: unknown[]): D1PreparedStatement;
+  first<T = unknown>(): Promise<T | null>;
+  all<T = unknown>(): Promise<D1Result<T>>;
+  run(): Promise<D1Result>;
+};
+
+export type ContentEditorD1Database = {
+  prepare(query: string): D1PreparedStatement;
+};
+
+export type ContentVisibility = "private" | "draft" | "hidden" | "published";
+export type ContentEditorKind = "writing" | "page";
+
+export type ContentEditorPayload = {
+  kind: ContentEditorKind;
+  page_key: string;
+  title: string;
+  slug: string;
+  summary: string;
+  tags: string[];
+  body: string;
+  visibility: ContentVisibility;
+  date: string;
+  updated_by: string;
+  updated_at: string;
+  content: Record<string, unknown>;
+};
+
+export type ContentRevision = {
+  id: string;
+  source: "draft" | "published" | "publish_event";
+  timestamp: string;
+  author: string;
+  status: string;
+  summary: string;
+  rollback_target: string;
+  view_href: string;
+};
+
+export type ContentEditorState = {
+  page_key: string;
+  current: ContentEditorPayload;
+  current_version: number;
+  latest_draft: ContentRevision | null;
+  revisions: ContentRevision[];
+};
+
+export type ContentEditorSaveInput = {
+  action: "save_draft";
+  kind?: string;
+  page_key?: string;
+  title?: string;
+  slug?: string;
+  summary?: string;
+  tags?: string[] | string;
+  body?: string;
+  visibility?: string;
+  date?: string;
+};
+
+export type ContentEditorPublishInput = {
+  action: "publish";
+  operation_id?: string;
+};
+
+type PageContentRow = {
+  id: string;
+  page_key: string;
+  content: string;
+  version: number | null;
+  published: number | boolean | null;
+  updated_at: string | null;
+  updated_by: string | null;
+  created_at: string | null;
+  version_history: string | null;
+};
+
+type DraftOperationRow = {
+  operation_id: string;
+  surface: string;
+  route: string;
+  source_ref: string;
+  field_path: string;
+  proposed_value: string;
+  status: string;
+  risk_level: string;
+  authority_state: string;
+  created_by: string;
+  created_at: string;
+  updated_at: string;
+  rollback_ref: string;
+  reviewer_note: string | null;
+  metadata: string;
+};
+
+type PublishEventRow = {
+  id: string;
+  operation_id: string | null;
+  event_type: string;
+  status: string;
+  summary: string;
+  rollback_ref: string;
+  created_by: string;
+  created_at: string;
+};
+
+const AUTHOR = "ani";
+const MAX_BODY_LENGTH = 50_000;
+const MAX_SUMMARY_LENGTH = 600;
+const MAX_TITLE_LENGTH = 160;
+
+export async function readContentEditorState(
+  db: ContentEditorD1Database | null | undefined,
+  pageKey: string,
+): Promise<ContentEditorState> {
+  const cleanPageKey = normalizePageKey(pageKey || "writing:new");
+  if (!db) {
+    const current = payloadFromContent(null, cleanPageKey);
+    return {
+      page_key: cleanPageKey,
+      current,
+      current_version: 0,
+      latest_draft: null,
+      revisions: [],
+    };
+  }
+
+  const [published, drafts, events] = await Promise.all([
+    readPageRows(db, cleanPageKey),
+    readDraftRows(db, cleanPageKey),
+    readPublishEvents(db, cleanPageKey),
+  ]);
+  const currentRow =
+    published.find((row) => isPublished(row.published)) ?? published[0] ?? null;
+  const current = payloadFromContent(currentRow, cleanPageKey);
+  const draftRevisions = drafts.map(draftRevisionFromRow);
+  const publishedRevisions = published.map(publishedRevisionFromRow);
+  const publishEventRevisions = events.map(publishEventRevisionFromRow);
+  const revisions = [
+    ...draftRevisions,
+    ...publishedRevisions,
+    ...publishEventRevisions,
+  ].sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+
+  return {
+    page_key: cleanPageKey,
+    current,
+    current_version: Number(currentRow?.version ?? 0),
+    latest_draft: draftRevisions[0] ?? null,
+    revisions,
+  };
+}
+
+export async function readDraftPreview(
+  db: ContentEditorD1Database | null | undefined,
+  operationId: string,
+): Promise<ContentEditorPayload | null> {
+  if (!db || !operationId.trim()) return null;
+  const row = await db
+    .prepare(
+      `SELECT proposed_value
+       FROM content_draft_operations
+       WHERE operation_id = ?
+       LIMIT 1`,
+    )
+    .bind(operationId.trim())
+    .first<{ proposed_value: string }>();
+  if (!row) return null;
+  return parseEditorPayload(row.proposed_value);
+}
+
+export async function saveEditorDraft(
+  db: ContentEditorD1Database,
+  input: ContentEditorSaveInput,
+) {
+  const payload = buildPayload(input);
+  const now = payload.updated_at;
+  const operationId = `content-editor-${slugForId(payload.page_key)}-${Date.now().toString(36)}`;
+  const route = routeForPayload(payload);
+  const current = await latestPageContent(db, payload.page_key);
+  const currentVersion = Number(current?.version ?? 0);
+  const metadata = JSON.stringify({
+    page_key: payload.page_key,
+    title: payload.title,
+    slug: payload.slug,
+    visibility: payload.visibility,
+    summary: payload.summary,
+    tags: payload.tags,
+    editor: "owner_writing_editor",
+  });
+  const allowedActions = ["save_draft", "render_preview"];
+  if (payload.visibility === "published") {
+    allowedActions.push("publish_with_proof");
+  }
+  const forbiddenActions = [
+    "send",
+    "schedule_newsletter",
+    "deploy",
+    "write_source_file",
+    "sync_provider",
+  ];
+
+  const result = await db
+    .prepare(
+      `INSERT INTO content_draft_operations (
+        operation_id,
+        kind,
+        surface,
+        route,
+        source_ref,
+        field_path,
+        current_value_ref,
+        proposed_value,
+        status,
+        risk_level,
+        authority_state,
+        required_approval_ids,
+        allowed_actions,
+        forbidden_actions,
+        preview_targets,
+        proof_ids,
+        evidence_uri,
+        redaction,
+        created_by,
+        created_at,
+        updated_at,
+        expires_at,
+        rollback_ref,
+        reviewer_note,
+        metadata
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .bind(
+      operationId,
+      "content_draft",
+      "public_site",
+      route,
+      `D1 content_draft_operations:${operationId}`,
+      `${payload.kind}.${payload.slug}.content`,
+      current
+        ? `page_content:${payload.page_key}@v${currentVersion}`
+        : `page_content:${payload.page_key}:new`,
+      JSON.stringify(payload),
+      "draft",
+      payload.visibility === "published" ? "medium" : "low",
+      "passkey_owner_draft_saved_no_public_change",
+      "[]",
+      JSON.stringify(allowedActions),
+      JSON.stringify(forbiddenActions),
+      JSON.stringify([`/content/preview?operation_id=${operationId}`]),
+      JSON.stringify([
+        "admin.content.editor.draft",
+        "admin.content.preview.d1",
+      ]),
+      `https://admin.anipotts.com/content/preview?operation_id=${operationId}`,
+      "public_copy_only",
+      AUTHOR,
+      now,
+      now,
+      null,
+      current
+        ? `page_content:${payload.page_key}@v${currentVersion}`
+        : `new_private_draft:${payload.page_key}`,
+      "Saved from the passkey-protected owner editor. Public page_content is unchanged until explicit publish.",
+      metadata,
+    )
+    .run();
+
+  if (result.success === false) throw statusError(500, "draft_save_failed");
+
+  return {
+    ok: true,
+    operation_id: operationId,
+    page_key: payload.page_key,
+    preview_href: `/content/preview?operation_id=${operationId}`,
+    publishable: payload.visibility === "published",
+  };
+}
+
+export async function publishEditorDraft(
+  db: ContentEditorD1Database,
+  input: ContentEditorPublishInput,
+) {
+  const operationId = cleanRequired(input.operation_id, 220, "operation_id");
+  const draft = await db
+    .prepare(
+      `SELECT *
+       FROM content_draft_operations
+       WHERE operation_id = ?
+       LIMIT 1`,
+    )
+    .bind(operationId)
+    .first<DraftOperationRow>();
+  if (!draft) throw statusError(404, "draft_not_found");
+
+  const payload = parseEditorPayload(draft.proposed_value);
+  if (!payload) throw statusError(400, "draft_payload_invalid");
+  if (payload.visibility !== "published") {
+    throw statusError(409, "only_published_visibility_can_publish");
+  }
+
+  const now = new Date().toISOString();
+  const previous = await latestPageContent(db, payload.page_key);
+  const nextVersion = Number(previous?.version ?? 0) + 1;
+  const pageContentId = `page-content-${slugForId(payload.page_key)}-v${nextVersion}-${Date.now().toString(36)}`;
+  const history = JSON.stringify([
+    ...parseVersionHistory(previous?.version_history ?? null),
+    ...(previous
+      ? [
+          {
+            id: previous.id,
+            version: previous.version ?? 0,
+            status: isPublished(previous.published) ? "published" : "hidden",
+            timestamp: previous.updated_at ?? previous.created_at ?? now,
+            author: previous.updated_by ?? "unknown",
+            rollback_target: `page_content:${previous.page_key}@v${previous.version ?? 0}`,
+          },
+        ]
+      : []),
+    {
+      id: operationId,
+      version: nextVersion,
+      status: "published",
+      timestamp: now,
+      author: AUTHOR,
+      rollback_target: draft.rollback_ref,
+    },
+  ]);
+
+  const pageResult = await db
+    .prepare(
+      `INSERT INTO page_content (
+        id,
+        page_key,
+        content,
+        version,
+        published,
+        updated_at,
+        updated_by,
+        created_at,
+        version_history
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .bind(
+      pageContentId,
+      payload.page_key,
+      JSON.stringify(payload.content),
+      nextVersion,
+      1,
+      now,
+      AUTHOR,
+      now,
+      history,
+    )
+    .run();
+  if (pageResult.success === false) throw statusError(500, "publish_failed");
+
+  const eventId = `content-publish-${slugForId(payload.page_key)}-${Date.now().toString(36)}`;
+  const eventResult = await db
+    .prepare(
+      `INSERT INTO content_publish_events (
+        id,
+        operation_id,
+        content_record_id,
+        event_type,
+        status,
+        summary,
+        proof_ids,
+        rollback_ref,
+        created_by,
+        created_at,
+        metadata
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .bind(
+      eventId,
+      operationId,
+      null,
+      "publish_page_content",
+      "verified",
+      `Published ${payload.page_key} v${nextVersion} from draft ${operationId}.`,
+      JSON.stringify([
+        "admin.content.publish.passkey",
+        "admin.content.publish.page-content",
+      ]),
+      previous
+        ? `page_content:${payload.page_key}@v${previous.version ?? 0}`
+        : `new_private_draft:${payload.page_key}`,
+      AUTHOR,
+      now,
+      JSON.stringify({
+        page_key: payload.page_key,
+        route: routeForPayload(payload),
+        title: payload.title,
+        previous_version: previous?.version ?? null,
+        published_version: nextVersion,
+      }),
+    )
+    .run();
+  if (eventResult.success === false) {
+    throw statusError(500, "publish_event_failed");
+  }
+
+  await db
+    .prepare(
+      `UPDATE content_draft_operations
+       SET status = ?,
+           authority_state = ?,
+           updated_at = ?,
+           reviewer_note = ?
+       WHERE operation_id = ?`,
+    )
+    .bind(
+      "published",
+      "published_to_page_content_with_proof",
+      now,
+      `Published to page_content:${payload.page_key}@v${nextVersion}; event ${eventId}. No source file, deploy, send, or provider sync ran.`,
+      operationId,
+    )
+    .run();
+
+  return {
+    ok: true,
+    page_key: payload.page_key,
+    version: nextVersion,
+    publish_event_id: eventId,
+    public_route: routeForPayload(payload),
+  };
+}
+
+function buildPayload(input: ContentEditorSaveInput): ContentEditorPayload {
+  const kind = input.kind === "page" ? "page" : "writing";
+  const title = cleanRequired(input.title, MAX_TITLE_LENGTH, "title");
+  const slug = normalizeSlug(input.slug || title);
+  const pageKey = normalizePageKey(
+    input.page_key || (kind === "writing" ? `writing:${slug}` : slug),
+  );
+  const summary = cleanRequired(input.summary, MAX_SUMMARY_LENGTH, "summary");
+  const body = cleanRequired(input.body, MAX_BODY_LENGTH, "body");
+  const tags = normalizeTags(input.tags);
+  const visibility = normalizeVisibility(input.visibility);
+  const date = cleanOptional(input.date, 20) || isoDate(new Date());
+  const now = new Date().toISOString();
+
+  if (kind === "writing") {
+    const writing = normalizeCmsWriting({
+      slug,
+      title,
+      date,
+      tags,
+      preview: summary,
+      body,
+      visible: visibility === "published",
+      order: 0,
+      updated_at: now,
+    });
+    const validation = validateCmsWriting(writing);
+    if (!validation.ok) throw statusError(400, validation.error ?? "invalid");
+    return {
+      kind,
+      page_key: `writing:${writing.slug}`,
+      title: writing.title,
+      slug: writing.slug,
+      summary: writing.preview,
+      tags: writing.tags,
+      body: writing.body,
+      visibility,
+      date: writing.date,
+      updated_by: AUTHOR,
+      updated_at: now,
+      content: {
+        ...writing,
+        status: visibility === "published" ? "published" : "draft",
+        visibility,
+        published: visibility === "published",
+        summary: writing.preview,
+      },
+    };
+  }
+
+  return {
+    kind,
+    page_key: pageKey,
+    title,
+    slug,
+    summary,
+    tags,
+    body,
+    visibility,
+    date,
+    updated_by: AUTHOR,
+    updated_at: now,
+    content: {
+      slug,
+      title,
+      summary,
+      preview: summary,
+      tags,
+      body,
+      visible: visibility === "published",
+      visibility,
+      status: visibility === "published" ? "published" : "draft",
+      updated_at: now,
+    },
+  };
+}
+
+function payloadFromContent(
+  row: PageContentRow | null,
+  pageKey: string,
+): ContentEditorPayload {
+  const raw = parseJsonObject(row?.content ?? null);
+  const slug = normalizeSlug(
+    typeof raw.slug === "string"
+      ? raw.slug
+      : pageKey.split(":").pop() || pageKey,
+  );
+  const title =
+    cleanOptional(raw.title, MAX_TITLE_LENGTH) ||
+    cleanOptional(raw.hero_title, MAX_TITLE_LENGTH) ||
+    cleanOptional(raw.headline, MAX_TITLE_LENGTH) ||
+    slug.replaceAll("-", " ");
+  const summary =
+    cleanOptional(raw.preview, MAX_SUMMARY_LENGTH) ||
+    cleanOptional(raw.summary, MAX_SUMMARY_LENGTH) ||
+    cleanOptional(raw.hero_summary, MAX_SUMMARY_LENGTH) ||
+    cleanOptional(raw.description, MAX_SUMMARY_LENGTH) ||
+    "";
+  const body =
+    cleanOptional(raw.body, MAX_BODY_LENGTH) ||
+    cleanOptional(raw.content, MAX_BODY_LENGTH) ||
+    JSON.stringify(raw, null, 2);
+  const tags = normalizeTags(Array.isArray(raw.tags) ? raw.tags : []);
+  const visible =
+    typeof raw.visible === "boolean"
+      ? raw.visible
+      : isPublished(row?.published ?? false);
+
+  return {
+    kind: pageKey.startsWith("writing:") ? "writing" : "page",
+    page_key: pageKey,
+    title,
+    slug,
+    summary,
+    tags,
+    body,
+    visibility: visible ? "published" : "hidden",
+    date:
+      cleanOptional(raw.date, 20) ||
+      cleanOptional(raw.published_at, 20) ||
+      isoDate(new Date()),
+    updated_by: row?.updated_by ?? AUTHOR,
+    updated_at: row?.updated_at ?? new Date().toISOString(),
+    content: raw,
+  };
+}
+
+async function readPageRows(
+  db: ContentEditorD1Database,
+  pageKey: string,
+): Promise<PageContentRow[]> {
+  const rows = await db
+    .prepare(
+      `SELECT
+         id,
+         page_key,
+         content,
+         version,
+         published,
+         updated_at,
+         updated_by,
+         created_at,
+         version_history
+       FROM page_content
+       WHERE page_key = ?
+       ORDER BY version DESC, updated_at DESC
+       LIMIT 20`,
+    )
+    .bind(pageKey)
+    .all<PageContentRow>();
+  return rows.results ?? [];
+}
+
+async function latestPageContent(
+  db: ContentEditorD1Database,
+  pageKey: string,
+): Promise<PageContentRow | null> {
+  return db
+    .prepare(
+      `SELECT
+         id,
+         page_key,
+         content,
+         version,
+         published,
+         updated_at,
+         updated_by,
+         created_at,
+         version_history
+       FROM page_content
+       WHERE page_key = ?
+       ORDER BY published DESC, version DESC, updated_at DESC
+       LIMIT 1`,
+    )
+    .bind(pageKey)
+    .first<PageContentRow>();
+}
+
+async function readDraftRows(
+  db: ContentEditorD1Database,
+  pageKey: string,
+): Promise<DraftOperationRow[]> {
+  const rows = await db
+    .prepare(
+      `SELECT
+         operation_id,
+         surface,
+         route,
+         source_ref,
+         field_path,
+         proposed_value,
+         status,
+         risk_level,
+         authority_state,
+         created_by,
+         created_at,
+         updated_at,
+         rollback_ref,
+         reviewer_note,
+         metadata
+       FROM content_draft_operations
+       WHERE metadata LIKE ?
+          OR current_value_ref LIKE ?
+          OR rollback_ref LIKE ?
+       ORDER BY updated_at DESC
+       LIMIT 30`,
+    )
+    .bind(
+      `%"page_key":"${escapeLike(pageKey)}"%`,
+      `%page_content:${escapeLike(pageKey)}%`,
+      `%page_content:${escapeLike(pageKey)}%`,
+    )
+    .all<DraftOperationRow>();
+  return rows.results ?? [];
+}
+
+async function readPublishEvents(
+  db: ContentEditorD1Database,
+  pageKey: string,
+): Promise<PublishEventRow[]> {
+  const rows = await db
+    .prepare(
+      `SELECT
+         id,
+         operation_id,
+         event_type,
+         status,
+         summary,
+         rollback_ref,
+         created_by,
+         created_at
+       FROM content_publish_events
+       WHERE metadata LIKE ?
+       ORDER BY created_at DESC
+       LIMIT 20`,
+    )
+    .bind(`%"page_key":"${escapeLike(pageKey)}"%`)
+    .all<PublishEventRow>();
+  return rows.results ?? [];
+}
+
+function draftRevisionFromRow(row: DraftOperationRow): ContentRevision {
+  const payload = parseEditorPayload(row.proposed_value);
+  return {
+    id: row.operation_id,
+    source: "draft",
+    timestamp: row.updated_at,
+    author: row.created_by,
+    status: payload?.visibility ?? row.status,
+    summary: payload?.summary || row.reviewer_note || row.field_path,
+    rollback_target: row.rollback_ref,
+    view_href: `/content/preview?operation_id=${encodeURIComponent(row.operation_id)}`,
+  };
+}
+
+function publishedRevisionFromRow(row: PageContentRow): ContentRevision {
+  const payload = payloadFromContent(row, row.page_key);
+  return {
+    id: row.id,
+    source: "published",
+    timestamp: row.updated_at ?? row.created_at ?? "",
+    author: row.updated_by ?? "unknown",
+    status: isPublished(row.published) ? "published" : "hidden",
+    summary: payload.summary || payload.title,
+    rollback_target: `page_content:${row.page_key}@v${row.version ?? 0}`,
+    view_href: `/content/edit/${encodeURIComponent(row.page_key)}?version=${row.version ?? 0}`,
+  };
+}
+
+function publishEventRevisionFromRow(row: PublishEventRow): ContentRevision {
+  return {
+    id: row.id,
+    source: "publish_event",
+    timestamp: row.created_at,
+    author: row.created_by,
+    status: row.status,
+    summary: row.summary,
+    rollback_target: row.rollback_ref,
+    view_href: `/content/operations#${encodeURIComponent(row.id)}`,
+  };
+}
+
+function parseEditorPayload(value: string): ContentEditorPayload | null {
+  const parsed = parseJsonObject(value);
+  if (typeof parsed.page_key !== "string") return null;
+  if (typeof parsed.title !== "string") return null;
+  if (typeof parsed.slug !== "string") return null;
+  if (typeof parsed.summary !== "string") return null;
+  if (typeof parsed.body !== "string") return null;
+  return {
+    kind: parsed.kind === "page" ? "page" : "writing",
+    page_key: normalizePageKey(parsed.page_key),
+    title: parsed.title,
+    slug: normalizeSlug(parsed.slug),
+    summary: parsed.summary,
+    tags: normalizeTags(parsed.tags),
+    body: parsed.body,
+    visibility: normalizeVisibility(parsed.visibility),
+    date:
+      typeof parsed.date === "string" && parsed.date.trim()
+        ? parsed.date.trim()
+        : isoDate(new Date()),
+    updated_by:
+      typeof parsed.updated_by === "string" ? parsed.updated_by : AUTHOR,
+    updated_at:
+      typeof parsed.updated_at === "string"
+        ? parsed.updated_at
+        : new Date().toISOString(),
+    content:
+      parsed.content && typeof parsed.content === "object"
+        ? (parsed.content as Record<string, unknown>)
+        : {},
+  };
+}
+
+function parseJsonObject(value: unknown): Record<string, unknown> {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  if (typeof value !== "string") return {};
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+function parseVersionHistory(value: string | null): unknown[] {
+  if (!value) return [];
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function normalizeVisibility(value: unknown): ContentVisibility {
+  if (
+    value === "private" ||
+    value === "draft" ||
+    value === "hidden" ||
+    value === "published"
+  ) {
+    return value;
+  }
+  return "draft";
+}
+
+function normalizeTags(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value
+      .filter((tag): tag is string => typeof tag === "string")
+      .flatMap((tag) => tag.split(","))
+      .map((tag) => tag.trim().toLowerCase())
+      .filter(Boolean)
+      .slice(0, 12);
+  }
+  if (typeof value === "string") return normalizeTags(value.split(","));
+  return [];
+}
+
+function normalizeSlug(value: string): string {
+  const slug = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 96);
+  if (!slug) throw statusError(400, "slug_required");
+  return slug;
+}
+
+function normalizePageKey(value: string): string {
+  const clean = value.trim().toLowerCase();
+  if (!/^[a-z0-9:_-]+$/.test(clean)) {
+    throw statusError(400, "page_key_invalid");
+  }
+  return clean.slice(0, 160);
+}
+
+function cleanRequired(
+  value: unknown,
+  maxLength: number,
+  field: string,
+): string {
+  const clean = cleanOptional(value, maxLength);
+  if (!clean) throw statusError(400, `${field}_required`);
+  return clean;
+}
+
+function cleanOptional(value: unknown, maxLength: number): string {
+  if (typeof value !== "string") return "";
+  return value.trim().slice(0, maxLength);
+}
+
+function isPublished(value: number | boolean | null | undefined): boolean {
+  return value === true || value === 1;
+}
+
+function routeForPayload(payload: ContentEditorPayload): string {
+  if (payload.page_key.startsWith("writing:"))
+    return `/writing/${payload.slug}`;
+  if (payload.page_key.startsWith("project:"))
+    return `/projects/${payload.slug}`;
+  if (payload.page_key === "home") return "/";
+  return `/${payload.page_key.replaceAll("_", "/").replaceAll(":", "/")}`;
+}
+
+function slugForId(value: string): string {
+  return value.replace(/[^a-z0-9]+/gi, "-").replace(/^-|-$/g, "");
+}
+
+function isoDate(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function escapeLike(value: string): string {
+  return value.replaceAll("%", "\\%").replaceAll("_", "\\_");
+}
+
+export function statusError(status: number, message: string): Response {
+  return Response.json(
+    { ok: false, error: message },
+    {
+      status,
+      headers: { "cache-control": "no-store" },
+    },
+  );
+}

--- a/apps/admin/src/pages/api/admin/content/editor.ts
+++ b/apps/admin/src/pages/api/admin/content/editor.ts
@@ -1,0 +1,47 @@
+import type { APIRoute } from "astro";
+import { assertSameOriginRequest } from "../../../../lib/content-draft-operation";
+import {
+  publishEditorDraft,
+  saveEditorDraft,
+  statusError,
+  type ContentEditorPublishInput,
+  type ContentEditorSaveInput,
+} from "../../../../lib/content-editor";
+
+export const POST: APIRoute = async (context) => {
+  try {
+    assertSameOriginRequest(context.request, context.url);
+
+    const db = context.locals.runtime?.env.DB;
+    if (!db) throw statusError(503, "db_binding_missing");
+
+    const contentType = context.request.headers.get("content-type") ?? "";
+    if (!contentType.toLowerCase().includes("application/json")) {
+      throw statusError(415, "json_required");
+    }
+
+    const body = (await context.request.json()) as
+      | ContentEditorSaveInput
+      | ContentEditorPublishInput;
+
+    if (body.action === "save_draft") {
+      return Response.json(await saveEditorDraft(db, body), {
+        headers: { "cache-control": "no-store" },
+      });
+    }
+
+    if (body.action === "publish") {
+      return Response.json(await publishEditorDraft(db, body), {
+        headers: { "cache-control": "no-store" },
+      });
+    }
+
+    throw statusError(400, "unknown_editor_action");
+  } catch (error) {
+    if (error instanceof Response) return error;
+    return statusError(
+      400,
+      error instanceof Error ? error.message : "content_editor_failed",
+    );
+  }
+};

--- a/apps/admin/src/pages/content/drafts.astro
+++ b/apps/admin/src/pages/content/drafts.astro
@@ -16,35 +16,31 @@ const operations =
   operationState.operations.length > 0
     ? operationState.operations
     : contentOperationTemplates;
-const writableRows = operationState.counts.filter(
-  (row) =>
-    row.table_name === "content_records" ||
-    row.table_name === "content_publish_events",
-);
-const writeRowsEmpty = writableRows.every((row) => row.rows === 0);
+const publishEventCount =
+  operationState.counts.find(
+    (row) => row.table_name === "content_publish_events",
+  )?.rows ?? 0;
 ---
 
 <AdminLayout
   title="content drafts"
-  deck="Field-level draft review. Focused editor saves draft operation rows only; publish and public content writes stay blocked."
+  deck="Draft history for the owner editor. Drafts stay private until a selected published draft is promoted into page_content with a publish event."
 >
   <section class="meta-strip" aria-label="content draft editor state">
     <span>{operations.length} draft operations</span>
     <span>{pageContentState.published_count} published page rows</span>
     <span>{operationState.mode}</span>
-    <span
-      >{writeRowsEmpty ? "public writes empty" : "review public writes"}</span
-    >
-    <span>publish disabled</span>
+    <span>{publishEventCount} publish events</span>
+    <span>newsletter send absent</span>
   </section>
 
   <section class="table-card operation-card">
     <div class="section-head">
       <div>
         <p>editor gate</p>
-        <h2>{writeRowsEmpty ? "draft-save only" : "review write rows"}</h2>
+        <h2>draft-save plus publish proof</h2>
       </div>
-      <span>no publish route</span>
+      <span>selected draft only</span>
     </div>
     <div class="record-list">
       <article class="record-row">
@@ -52,9 +48,7 @@ const writeRowsEmpty = writableRows.every((row) => row.rows === 0);
           <p>write state</p>
           <h3>
             {
-              writeRowsEmpty
-                ? "content_records and content_publish_events are empty"
-                : "write tables contain rows and need review"
+              "content_draft_operations stores drafts; content_publish_events records explicit publish proof"
             }
           </h3>
         </div>
@@ -120,7 +114,7 @@ const writeRowsEmpty = writableRows.every((row) => row.rows === 0);
                 request review
               </button>
               <button class="button secondary danger" type="button" disabled>
-                publish
+                publish from editor
               </button>
             </div>
           </form>

--- a/apps/admin/src/pages/content/edit/[pageKey].astro
+++ b/apps/admin/src/pages/content/edit/[pageKey].astro
@@ -1,241 +1,376 @@
 ---
 import AdminLayout from "../../../layouts/AdminLayout.astro";
 import { readPageContentInventoryStore } from "../../../data/content";
+import { readContentEditorState } from "../../../lib/content-editor";
 
-const pageKey = safeDecodePageKey(Astro.params.pageKey);
+const requestedPageKey = safeDecodePageKey(Astro.params.pageKey);
+const pageKey =
+  requestedPageKey === "new" || requestedPageKey === "writing:new"
+    ? "writing:new"
+    : requestedPageKey;
 const pageContentState = await readPageContentInventoryStore(
   Astro.locals.runtime?.env.DB,
 );
 const pageRow = pageContentState.rows.find((row) => row.page_key === pageKey);
-
-if (!pageRow) {
-  Astro.response.status = 404;
-}
+const editorState = await readContentEditorState(
+  Astro.locals.runtime?.env.DB,
+  pageKey,
+);
+const current = editorState.current;
+const isNew = pageKey === "writing:new";
+const latestDraft = editorState.latest_draft;
+const tagText = current.tags.join(", ");
 
 function safeDecodePageKey(value: string | undefined): string {
-  if (!value) return "";
+  if (!value) return "writing:new";
   try {
     return decodeURIComponent(value);
   } catch {
     return value;
   }
 }
-
-function textareaRows(value: string): number {
-  const lineCount = value.split("\n").length;
-  const lengthRows = Math.ceil(value.length / 78);
-  return Math.min(14, Math.max(3, lineCount, lengthRows));
-}
 ---
 
 <AdminLayout
-  title={pageRow ? `edit ${pageRow.page_key}` : "content row missing"}
-  deck="Focused page_content editor shape. Fields are disabled until the audited save path exists."
+  title={isNew ? "new writing draft" : `edit ${editorState.page_key}`}
+  deck="Owner-facing D1 editor for writing and page content. Drafts save to content_draft_operations; publish writes page_content with proof."
 >
   <section class="meta-strip" aria-label="content edit state">
     <span>{pageContentState.mode}</span>
-    <span>{pageRow ? `${pageRow.field_count} fields` : "0 fields"}</span>
-    <span>{pageRow?.published ? "published" : "draft or missing"}</span>
-    <span>save disabled</span>
-    <span>publish disabled</span>
+    <span>{pageRow ? `${pageRow.field_count} source fields` : "new draft"}</span
+    >
+    <span>{editorState.current_version} public versions</span>
+    <span>{editorState.revisions.length} revisions</span>
+    <span>passkey session required</span>
   </section>
 
-  {
-    pageRow ? (
-      <>
+  <section class="editor-workspace" aria-labelledby="editor-fields-heading">
+    <form
+      class="owner-editor-form"
+      aria-label={`${editorState.page_key} content editor`}
+      data-editor-form
+    >
+      <input type="hidden" name="kind" value={current.kind} />
+      <input type="hidden" name="page_key" value={current.page_key} />
+
+      <div class="editor-main">
+        <section class="editor-panel">
+          <div class="section-head">
+            <div>
+              <p>{current.kind} content</p>
+              <h2 id="editor-fields-heading">
+                {isNew ? "private draft first" : current.title}
+              </h2>
+            </div>
+            <span>{current.visibility}</span>
+          </div>
+
+          <div class="editor-field-grid">
+            <label>
+              <span>title</span>
+              <input
+                name="title"
+                value={isNew ? "" : current.title}
+                maxlength="160"
+                required
+              />
+            </label>
+            <label>
+              <span>slug</span>
+              <input
+                name="slug"
+                value={isNew ? "" : current.slug}
+                maxlength="96"
+                required
+              />
+            </label>
+            <label>
+              <span>date</span>
+              <input name="date" type="date" value={current.date} required />
+            </label>
+            <label>
+              <span>visibility</span>
+              <select name="visibility">
+                {
+                  ["private", "draft", "hidden", "published"].map((option) => (
+                    <option
+                      value={option}
+                      selected={current.visibility === option}
+                    >
+                      {option}
+                    </option>
+                  ))
+                }
+              </select>
+            </label>
+            <label class="wide-field">
+              <span>summary / preview</span>
+              <textarea name="summary" rows="3" maxlength="600" required>
+                {isNew ? "" : current.summary}
+              </textarea>
+            </label>
+            <label class="wide-field">
+              <span>tags</span>
+              <input
+                name="tags"
+                value={isNew ? "" : tagText}
+                placeholder="agents, codex, admin"
+              />
+            </label>
+            <label class="wide-field">
+              <span>markdown body</span>
+              <textarea name="body" rows="18" required>
+                {isNew ? "" : current.body}
+              </textarea>
+            </label>
+          </div>
+
+          <div class="draft-control-row page-editor-actions">
+            <button class="button" type="button" data-save-draft>
+              save draft
+            </button>
+            <a
+              class:list={[
+                "button",
+                "secondary",
+                !latestDraft && "disabled-link",
+              ]}
+              href={latestDraft?.view_href ?? "#"}
+              data-preview-link
+            >
+              preview draft
+            </a>
+            <button
+              class="button secondary danger"
+              type="button"
+              data-publish-draft
+              data-operation-id={latestDraft?.id ?? ""}
+              disabled={!latestDraft}
+            >
+              publish selected draft
+            </button>
+            <span data-editor-status>
+              {
+                latestDraft
+                  ? `latest draft ${latestDraft.id}`
+                  : "new content starts as a private draft"
+              }
+            </span>
+          </div>
+        </section>
+
         <section class="table-card operation-card">
           <div class="section-head">
             <div>
-              <p>page_content record</p>
-              <h2>{pageRow.summary}</h2>
+              <p>current public record</p>
+              <h2>{pageRow ? pageRow.summary : "none yet"}</h2>
             </div>
-            <span>read only</span>
+            <span>{pageRow?.published ? "published" : "not public"}</span>
           </div>
           <div class="record-list">
             <article class="record-row">
               <div>
                 <p>
-                  {pageRow.page_key} / v{pageRow.version}
+                  {editorState.page_key} / v{editorState.current_version}
                 </p>
-                <h3>{pageRow.source_ref}</h3>
+                <h3>
+                  {
+                    pageRow
+                      ? "publishing creates a new page_content version"
+                      : "saving does not create public page_content"
+                  }
+                </h3>
               </div>
               <dl>
                 <div>
-                  <dt>published</dt>
-                  <dd>{pageRow.published ? "true" : "false"}</dd>
+                  <dt>source</dt>
+                  <dd>{pageRow?.source_ref ?? "new D1 draft"}</dd>
                 </div>
                 <div>
                   <dt>updated</dt>
-                  <dd>{pageRow.updated_at || "unknown"}</dd>
+                  <dd>{pageRow?.updated_at || "not published"}</dd>
                 </div>
                 <div>
                   <dt>updated by</dt>
-                  <dd>{pageRow.updated_by || "unknown"}</dd>
+                  <dd>{pageRow?.updated_by || "unknown"}</dd>
                 </div>
                 <div>
-                  <dt>write state</dt>
-                  <dd>draft operation save only; no publish route</dd>
+                  <dt>public visibility</dt>
+                  <dd>
+                    {
+                      current.visibility === "published"
+                        ? "publish can make this public"
+                        : "private, draft, and hidden stay out of public readers"
+                    }
+                  </dd>
                 </div>
               </dl>
             </article>
           </div>
         </section>
+      </div>
+    </form>
 
-        <section class="editor-panel" aria-labelledby="editor-fields-heading">
-          <div class="section-head">
-            <div>
-              <p>draft operation editor</p>
-              <h2 id="editor-fields-heading">field review</h2>
-            </div>
-            <span>publish disabled</span>
-          </div>
-          <form
-            class="page-editor-form"
-            aria-label={`${pageRow.page_key} fields`}
-          >
-            {pageRow.fields.map((field) => (
-              <article
-                class="page-editor-field"
-                data-draft-field
-                data-page-key={pageRow.page_key}
-                data-field-path={field.path}
-                data-source-ref={pageRow.source_ref}
-              >
-                <label>
-                  <span>{field.path}</span>
-                  <textarea
-                    name="proposed_value"
-                    rows={textareaRows(field.raw_value)}
-                  >
-                    {field.raw_value}
-                  </textarea>
-                </label>
-                <small>
-                  {field.kind} / source {pageRow.source_ref}
-                </small>
-                <div class="draft-control-row">
-                  <button
-                    class="button secondary"
-                    type="button"
-                    data-draft-save
-                  >
-                    save draft
-                  </button>
-                  <span data-draft-save-status>draft operation only</span>
-                </div>
-              </article>
-            ))}
-            <div class="draft-control-row page-editor-actions">
-              <button class="button secondary" type="button" disabled>
-                request review
-              </button>
-              <button class="button secondary" type="button" disabled>
-                preview public route
-              </button>
-              <button class="button secondary danger" type="button" disabled>
-                publish
-              </button>
-            </div>
-          </form>
-        </section>
-
-        {pageRow.source_backed_fields.length > 0 && (
-          <section class="notice">
-            Source-backed gaps remain before this row can be treated as
-            complete:
-            {` ${pageRow.source_backed_fields.join(", ")}`}
-          </section>
-        )}
-
-        <nav class="inline-actions" aria-label="content editor navigation">
-          <a class="button secondary" href="/content">
-            back to inventory
-          </a>
-          <a class="button secondary" href="/content/drafts">
-            all draft controls
-          </a>
-          <a class="button secondary" href="/content/preview">
-            preview queue
-          </a>
-        </nav>
-      </>
-    ) : (
-      <section class="table-card operation-card">
+    <aside class="editor-side">
+      <section class="table-card">
         <div class="section-head">
           <div>
-            <p>missing page_content</p>
-            <h2>{pageKey || "unknown page key"}</h2>
+            <p>revision history</p>
+            <h2>{editorState.revisions.length} entries</h2>
           </div>
-          <span>404</span>
+          <span>rollback inert</span>
         </div>
         <div class="record-list">
-          <article class="record-row">
-            <div>
-              <p>next safe action</p>
-              <h3>
-                Return to inventory and choose an existing D1 page_content row.
-              </h3>
-            </div>
-          </article>
+          {
+            editorState.revisions.length === 0 ? (
+              <article class="record-row">
+                <div>
+                  <p>empty</p>
+                  <h3>No saved revisions for this page key yet.</h3>
+                </div>
+              </article>
+            ) : (
+              editorState.revisions.map((revision) => (
+                <article class="record-row revision-row">
+                  <div>
+                    <p>
+                      {revision.source} / {revision.status}
+                    </p>
+                    <h3>{revision.summary}</h3>
+                  </div>
+                  <dl>
+                    <div>
+                      <dt>time</dt>
+                      <dd>{revision.timestamp}</dd>
+                    </div>
+                    <div>
+                      <dt>author</dt>
+                      <dd>{revision.author}</dd>
+                    </div>
+                    <div>
+                      <dt>rollback target</dt>
+                      <dd>{revision.rollback_target}</dd>
+                    </div>
+                    <div>
+                      <dt>action</dt>
+                      <dd>
+                        <a href={revision.view_href}>view version</a>
+                      </dd>
+                    </div>
+                  </dl>
+                </article>
+              ))
+            )
+          }
         </div>
       </section>
-    )
-  }
+
+      <nav class="inline-actions" aria-label="content editor navigation">
+        <a class="button secondary" href="/content"> inventory </a>
+        <a class="button secondary" href="/content/edit/new"> new writing </a>
+        <a class="button secondary" href="/content/drafts"> drafts </a>
+        <a class="button secondary" href="/content/preview"> preview queue </a>
+      </nav>
+    </aside>
+  </section>
 </AdminLayout>
 
 <script>
-  type DraftSaveResponse = {
+  type EditorResponse = {
     ok?: boolean;
     operation_id?: string;
-    next_safe_action?: string;
+    preview_href?: string;
+    publishable?: boolean;
+    public_route?: string;
+    version?: number;
     error?: string;
   };
 
-  const draftFields =
-    document.querySelectorAll<HTMLElement>("[data-draft-field]");
+  const form = document.querySelector<HTMLFormElement>("[data-editor-form]");
+  const saveButton =
+    document.querySelector<HTMLButtonElement>("[data-save-draft]");
+  const publishButton = document.querySelector<HTMLButtonElement>(
+    "[data-publish-draft]",
+  );
+  const previewLink = document.querySelector<HTMLAnchorElement>(
+    "[data-preview-link]",
+  );
+  const statusNode = document.querySelector<HTMLElement>(
+    "[data-editor-status]",
+  );
 
-  for (const field of draftFields) {
-    const button = field.querySelector<HTMLButtonElement>("[data-draft-save]");
-    button?.addEventListener("click", () => void saveDraft(field, button));
-  }
+  saveButton?.addEventListener("click", () => void saveDraft());
+  publishButton?.addEventListener("click", () => void publishDraft());
 
-  async function saveDraft(field: HTMLElement, button: HTMLButtonElement) {
-    const textarea = field.querySelector<HTMLTextAreaElement>(
-      "textarea[name='proposed_value']",
-    );
-    const status = field.querySelector<HTMLElement>("[data-draft-save-status]");
-
-    if (!textarea) return;
-
-    button.disabled = true;
-    setText(status, "saving draft operation");
+  async function saveDraft() {
+    if (!form || !saveButton) return;
+    saveButton.disabled = true;
+    setText(statusNode, "saving draft to D1");
 
     try {
-      const response = await fetch("/api/admin/content/draft-operation", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({
-          page_key: field.dataset.pageKey,
-          field_path: field.dataset.fieldPath,
-          source_ref: field.dataset.sourceRef,
-          proposed_value: textarea.value,
-        }),
+      const data = await postEditor({
+        action: "save_draft",
+        ...Object.fromEntries(new FormData(form).entries()),
       });
-      const data = (await response.json()) as DraftSaveResponse;
-      if (!response.ok || !data.ok) {
-        throw new Error(
-          data.next_safe_action ?? data.error ?? "draft save failed",
-        );
+      if (!data.ok || !data.operation_id) {
+        throw new Error(data.error ?? "draft save failed");
       }
-      setText(status, `saved ${data.operation_id}`);
+      if (previewLink && data.preview_href) {
+        previewLink.href = data.preview_href;
+        previewLink.classList.remove("disabled-link");
+      }
+      if (publishButton) {
+        publishButton.dataset.operationId = data.operation_id;
+        publishButton.disabled = !data.publishable;
+      }
+      setText(statusNode, `saved ${data.operation_id}`);
     } catch (error) {
       setText(
-        status,
+        statusNode,
         error instanceof Error ? error.message : "draft save failed",
       );
     } finally {
-      button.disabled = false;
+      saveButton.disabled = false;
     }
+  }
+
+  async function publishDraft() {
+    if (!publishButton) return;
+    const operationId = publishButton.dataset.operationId;
+    if (!operationId) return;
+    publishButton.disabled = true;
+    setText(statusNode, "publishing selected draft");
+
+    try {
+      const data = await postEditor({
+        action: "publish",
+        operation_id: operationId,
+      });
+      if (!data.ok) throw new Error(data.error ?? "publish failed");
+      setText(
+        statusNode,
+        `published v${data.version} to ${data.public_route ?? "public route"}`,
+      );
+    } catch (error) {
+      setText(
+        statusNode,
+        error instanceof Error ? error.message : "publish failed",
+      );
+      publishButton.disabled = false;
+    }
+  }
+
+  async function postEditor(body: Record<string, FormDataEntryValue | string>) {
+    const response = await fetch("/api/admin/content/editor", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    const data = (await response.json()) as EditorResponse;
+    if (!response.ok) {
+      throw new Error(data.error ?? "content editor request failed");
+    }
+    return data;
   }
 
   function setText(node: Element | null, value: string) {

--- a/apps/admin/src/pages/content/index.astro
+++ b/apps/admin/src/pages/content/index.astro
@@ -24,7 +24,7 @@ const pageContentState = await readPageContentInventoryStore(
 
 <AdminLayout
   title="content inventory"
-  deck="Current editable public-site surfaces and their source refs. This is read-only inventory from the shared content model."
+  deck="Current editable public-site surfaces and their source refs. Existing rows open in the D1 editor; new writing starts as a private draft."
 >
   <section class="meta-strip" aria-label="content inventory source">
     <span>{contentInventory.length} rows</span>
@@ -43,7 +43,7 @@ const pageContentState = await readPageContentInventoryStore(
         <p>d1 page_content</p>
         <h2>{pageContentState.row_count} records</h2>
       </div>
-      <span>read only</span>
+      <span>draft and publish editor</span>
     </div>
     <div class="record-list">
       {
@@ -96,7 +96,7 @@ const pageContentState = await readPageContentInventoryStore(
                 </div>
                 <div>
                   <dt>write state</dt>
-                  <dd>draft operation save only; no publish endpoint</dd>
+                  <dd>save draft to D1; publish selected draft with proof</dd>
                 </div>
               </dl>
               <div class="inline-actions">
@@ -135,6 +135,12 @@ const pageContentState = await readPageContentInventoryStore(
       }
     </div>
   </section>
+
+  <nav class="inline-actions" aria-label="content creation">
+    <a class="button" href="/content/edit/new"> new writing draft </a>
+    <a class="button secondary" href="/content/drafts"> draft history </a>
+    <a class="button secondary" href="/content/operations"> operation proof </a>
+  </nav>
 
   <section class="table-card operation-card">
     <div class="section-head">

--- a/apps/admin/src/pages/content/operations.astro
+++ b/apps/admin/src/pages/content/operations.astro
@@ -11,12 +11,12 @@ const readState = await readContentOperationStore(Astro.locals.runtime?.env.DB);
 
 <AdminLayout
   title="content operations"
-  deck="Live D1 view for draft operations. Draft saves are passkey-protected; publishing, sending, deploying, and public content writes remain blocked."
+  deck="Live D1 view for draft operations and publish proof. Draft saves and selected-draft publish are passkey-protected; newsletter send remains absent."
 >
   <section class="meta-strip" aria-label="content operation read source">
     <span>{readState.mode}</span>
     <span>{contentOperationSchemaSource.migration}</span>
-    <span>draft save only</span>
+    <span>publish with proof</span>
   </section>
 
   <div class="surface-grid">
@@ -44,15 +44,19 @@ const readState = await readContentOperationStore(Astro.locals.runtime?.env.DB);
                   <dd>
                     {row.table_name === "content_draft_operations"
                       ? "draft save allowed after passkey"
-                      : "read only"}
+                      : row.table_name === "content_publish_events"
+                        ? "publish proof event"
+                        : "schema only"}
                   </dd>
                 </div>
                 <div>
                   <dt>next</dt>
                   <dd>
                     {row.table_name === "content_draft_operations"
-                      ? "review saved draft proposals before any publish path"
-                      : "keep public writes blocked"}
+                      ? "review saved draft proposals before publishing"
+                      : row.table_name === "content_publish_events"
+                        ? "verify selected-draft publish history"
+                        : "keep field records schema-only"}
                   </dd>
                 </div>
               </dl>
@@ -133,10 +137,10 @@ const readState = await readContentOperationStore(Astro.locals.runtime?.env.DB);
   <section class="table-card operation-card">
     <div class="section-head">
       <div>
-        <p>inert operation templates</p>
+        <p>seeded operation templates</p>
         <h2>{contentOperationTemplates.length} proposals modeled</h2>
       </div>
-      <span>preview only</span>
+      <span>legacy preview seeds</span>
     </div>
     <div class="record-list">
       {

--- a/apps/admin/src/pages/content/preview.astro
+++ b/apps/admin/src/pages/content/preview.astro
@@ -5,6 +5,7 @@ import {
   contentPreviewItems,
   readContentOperationStore,
 } from "../../data/content";
+import { readDraftPreview } from "../../lib/content-editor";
 
 const readState = await readContentOperationStore(Astro.locals.runtime?.env.DB);
 const d1PreviewItems = readState.operations.filter((operation) =>
@@ -12,6 +13,11 @@ const d1PreviewItems = readState.operations.filter((operation) =>
 );
 const previewSource =
   d1PreviewItems.length > 0 ? "d1 draft operations" : "static previews";
+const operationId = Astro.url.searchParams.get("operation_id") ?? "";
+const selectedDraft = await readDraftPreview(
+  Astro.locals.runtime?.env.DB,
+  operationId,
+);
 ---
 
 <AdminLayout
@@ -29,8 +35,43 @@ const previewSource =
     <span>{readState.mode}</span>
     <span>{previewSource}</span>
     <span>{contentInventorySource.mode}</span>
-    <span>publish path inactive</span>
+    <span>{selectedDraft ? "selected draft" : "queue"}</span>
   </section>
+
+  {
+    selectedDraft && (
+      <section class="editor-preview table-card">
+        <div class="section-head">
+          <div>
+            <p>
+              {selectedDraft.kind} / {selectedDraft.visibility}
+            </p>
+            <h2>{selectedDraft.title}</h2>
+          </div>
+          <span>{selectedDraft.page_key}</span>
+        </div>
+        <div class="preview-document">
+          <p class="preview-meta">
+            {selectedDraft.date} / {selectedDraft.tags.join(", ") || "untagged"}
+          </p>
+          <p class="preview-summary">{selectedDraft.summary}</p>
+          <pre>{selectedDraft.body}</pre>
+        </div>
+        <div class="draft-control-row page-editor-actions">
+          <a
+            class="button secondary"
+            href={`/content/edit/${encodeURIComponent(selectedDraft.page_key)}`}
+          >
+            back to editor
+          </a>
+          <span>
+            preview reads content_draft_operations only; no public page_content
+            row is written here.
+          </span>
+        </div>
+      </section>
+    )
+  }
 
   <div class="preview-grid">
     {

--- a/apps/admin/src/styles/admin.css
+++ b/apps/admin/src/styles/admin.css
@@ -431,6 +431,24 @@ th {
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
+.editor-workspace {
+  display: grid;
+  grid-template-columns: minmax(0, 1.5fr) minmax(320px, 0.7fr);
+  gap: 16px;
+  margin-top: 24px;
+  align-items: start;
+}
+
+.editor-main,
+.editor-side {
+  display: grid;
+  gap: 16px;
+}
+
+.owner-editor-form {
+  min-width: 0;
+}
+
 .draft-editor-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -659,13 +677,28 @@ dd {
   padding: 16px;
 }
 
+.editor-field-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  padding: 16px;
+}
+
 .draft-form label {
   display: grid;
   gap: 6px;
   min-width: 0;
 }
 
-.draft-form label span {
+.editor-field-grid label {
+  display: grid;
+  gap: 6px;
+  min-width: 0;
+}
+
+.draft-form label span,
+.editor-field-grid label > span,
+.preview-meta {
   color: var(--muted);
   font-size: 11px;
   text-transform: uppercase;
@@ -673,6 +706,9 @@ dd {
 
 .draft-form input,
 .draft-form textarea,
+.editor-field-grid input,
+.editor-field-grid select,
+.editor-field-grid textarea,
 .field-input-chip input {
   width: 100%;
   min-width: 0;
@@ -685,12 +721,15 @@ dd {
 }
 
 .draft-form input,
+.editor-field-grid input,
+.editor-field-grid select,
 .field-input-chip input {
   min-height: 38px;
   padding: 8px 10px;
 }
 
-.draft-form textarea {
+.draft-form textarea,
+.editor-field-grid textarea {
   resize: vertical;
   padding: 10px;
 }
@@ -771,8 +810,55 @@ dd {
   text-transform: none;
 }
 
+[data-editor-status] {
+  align-self: center;
+  overflow-wrap: anywhere;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
 .page-editor-actions {
   padding: 16px;
+}
+
+.disabled-link {
+  pointer-events: none;
+  opacity: 0.48;
+}
+
+.revision-row h3 {
+  font-size: 14px;
+}
+
+.editor-preview {
+  margin-top: 24px;
+}
+
+.preview-document {
+  display: grid;
+  gap: 12px;
+  padding: 18px;
+}
+
+.preview-document p {
+  margin: 0;
+}
+
+.preview-summary {
+  color: var(--text);
+  line-height: 1.55;
+}
+
+.preview-document pre {
+  margin: 0;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  border: 1px solid var(--border);
+  background: #111;
+  color: var(--text);
+  padding: 14px;
+  line-height: 1.55;
 }
 
 .draft-proof-grid {
@@ -980,6 +1066,7 @@ dd {
   }
 
   .preview-grid,
+  .editor-workspace,
   .draft-editor-grid,
   .lane-grid,
   .newsletter-detail,
@@ -990,6 +1077,10 @@ dd {
   .draft-form,
   .draft-proof-grid,
   .diff-pair {
+    grid-template-columns: 1fr;
+  }
+
+  .editor-field-grid {
     grid-template-columns: 1fr;
   }
 

--- a/apps/www/src/lib/content.ts
+++ b/apps/www/src/lib/content.ts
@@ -1,11 +1,15 @@
 import { getCollection, type CollectionEntry } from "astro:content";
 import {
+  type CmsWritingContent,
   cmsProjectPageKey,
   cmsWritingPageKey,
   normalizeCmsProject,
   normalizeCmsWriting,
 } from "@anipotts/content/public";
-import { fetchPageContent } from "@anipotts/lib/cms";
+import {
+  fetchPageContent,
+  fetchPublishedPageContentByPrefix,
+} from "@anipotts/lib/cms";
 
 type ProjectEntry = CollectionEntry<"projects">;
 type WritingEntry = CollectionEntry<"writing">;
@@ -151,13 +155,56 @@ async function writingFromEntry(entry: WritingEntry): Promise<Writing> {
   };
 }
 
+function writingFromCmsPage(
+  page: Awaited<
+    ReturnType<typeof fetchPublishedPageContentByPrefix<CmsWritingContent>>
+  >[number],
+): Writing | null {
+  const cms = normalizeCmsWriting(page.content);
+  if (!cms.visible) return null;
+  const source = cms.sourceLinks[0];
+
+  return {
+    id: page.page_key,
+    slug: cms.slug,
+    body: cms.body,
+    source: "cms",
+    data: {
+      title: cms.title,
+      slug: cms.slug,
+      summary: cms.preview,
+      tags: cms.tags,
+      status: "published",
+      published_at: new Date(`${cms.date}T00:00:00.000Z`),
+      content_type: "article",
+      artifact_url: source?.url,
+      artifact_type:
+        source?.label === "repo" ||
+        source?.label === "gist" ||
+        source?.label === "demo" ||
+        source?.label === "screenshot" ||
+        source?.label === "recording"
+          ? source.label
+          : undefined,
+    },
+  };
+}
+
 export async function publishedWriting(): Promise<Writing[]> {
   const entries = await getCollection(
     "writing",
     (t) => t.data.status === "published",
   );
   const all = await Promise.all(entries.map(writingFromEntry));
-  return all
+  const markdownSlugs = new Set(all.map((item) => item.slug));
+  const cmsRows =
+    await fetchPublishedPageContentByPrefix<CmsWritingContent>("writing:");
+  const cmsOnly = cmsRows
+    .map(writingFromCmsPage)
+    .filter((item): item is Writing => Boolean(item))
+    .filter((item) => !markdownSlugs.has(item.slug));
+
+  return [...all, ...cmsOnly]
     .filter((item) => item.data.status === "published")
     .sort(
       (a, b) =>

--- a/packages/content/src/admin/operations.ts
+++ b/packages/content/src/admin/operations.ts
@@ -116,7 +116,7 @@ export type ContentOperationTable = {
     | "content_draft_operations"
     | "content_publish_events";
   purpose: string;
-  write_state: "schema_only" | "draft_save_only" | "future_publish";
+  write_state: "schema_only" | "draft_save_only" | "publish_with_proof";
   blocked_actions: string[];
 };
 
@@ -125,7 +125,7 @@ export const contentOperationSchemaSource = {
   migration:
     "drizzle/migrations/0007_content_operations.sql + drizzle/migrations/0008_seed_content_draft_operations.sql + drizzle/migrations/0011_seed_source_content_review_operations.sql + drizzle/migrations/0028_seed_listing_content_review_operations.sql + drizzle/migrations/0030_expand_orchestrating_page_content.sql + drizzle/migrations/0031_seed_detail_page_content.sql + drizzle/migrations/0032_seed_remaining_detail_page_content.sql + drizzle/migrations/0033_refresh_draft_operation_save_metadata.sql",
   schema: "packages/lib/src/db/schema.ts",
-  mode: "d1_schema_with_passkey_draft_operation_save",
+  mode: "d1_schema_with_passkey_draft_and_publish_proof",
 };
 
 export const contentOperationTables: ContentOperationTable[] = [
@@ -146,9 +146,9 @@ export const contentOperationTables: ContentOperationTable[] = [
   {
     table: "content_publish_events",
     purpose:
-      "future immutable proof trail for approved publish and rollback events",
-    write_state: "future_publish",
-    blocked_actions: ["send", "schedule", "publish without proof"],
+      "immutable proof trail for selected-draft publish and future rollback events",
+    write_state: "publish_with_proof",
+    blocked_actions: ["send", "schedule", "publish without selected draft"],
   },
 ];
 

--- a/packages/content/src/admin/proof.ts
+++ b/packages/content/src/admin/proof.ts
@@ -77,13 +77,13 @@ const baseProofEntries: ProofEntry[] = [
     id: "proof.admin.write-paths",
     kind: "gate",
     status: "verified",
-    title: "admin write paths remain inert",
+    title: "admin write paths are scoped",
     summary:
-      "Content preview, review, operations, mutation, and destructive-operation routes expose no publish, send, public-content write, or live-control endpoint. Draft saves are limited to content_draft_operations.",
+      "The content editor can save D1 drafts and publish a selected published-visibility draft into page_content with a content_publish_events proof row. Newsletter sends, deploys, source writes, live control, and content_records writes remain absent.",
     evidence_uri: "apps/admin/src/pages",
     redaction: "metadata_only",
     next_safe_action:
-      "Keep publish, send, public-content writes, and live-control endpoints absent until reviewed write paths are approved.",
+      "Keep publish limited to selected drafts with proof; keep send, deploy, source rewrite, and live-control endpoints absent.",
   },
   {
     id: "proof.admin.content-draft-save",
@@ -91,12 +91,12 @@ const baseProofEntries: ProofEntry[] = [
     status: "pending",
     title: "content draft saves need proof",
     summary:
-      "The focused editor can save draft operation rows only. This proof row becomes verified after a passkey-authenticated draft save records a content_draft_operations row and refreshes admin_proof_events.",
+      "The owner editor saves draft operation rows before public publish. This proof row becomes verified after a passkey-authenticated draft save records a content_draft_operations row and refreshes admin_proof_events.",
     evidence_uri:
       "D1 anipotts-db content_draft_operations and admin_proof_events",
     redaction: "metadata_only",
     next_safe_action:
-      "enroll passkey, save one draft operation from /content/edit/home, then verify this proof row and keep publish blocked",
+      "enroll passkey, save one draft operation from /content/edit/home, then verify this proof row before publishing selected drafts",
   },
 ];
 
@@ -164,18 +164,17 @@ async function readContentOperationProof(
     const isReady =
       publishedPages >= REQUIRED_PUBLISHED_PAGE_CONTENT_ROWS &&
       drafts >= REQUIRED_CONTENT_DRAFT_OPERATIONS &&
-      records === 0 &&
-      events === 0;
+      records === 0;
     return {
       id: "proof.content-operation.d1",
       kind: "repo",
       status: isReady ? "verified" : "pending",
-      title: "content state is D1-backed and publish writes remain blocked",
-      summary: `published_page_content=${publishedPages}/${REQUIRED_PUBLISHED_PAGE_CONTENT_ROWS}, content_records=${records}, content_draft_operations=${drafts}/${REQUIRED_CONTENT_DRAFT_OPERATIONS}, content_publish_events=${events}. Public route copy can render from page_content while draft operation rows remain the only content write surface.`,
+      title: "content state is D1-backed with publish proof",
+      summary: `published_page_content=${publishedPages}/${REQUIRED_PUBLISHED_PAGE_CONTENT_ROWS}, content_records=${records}, content_draft_operations=${drafts}/${REQUIRED_CONTENT_DRAFT_OPERATIONS}, content_publish_events=${events}. Public route copy renders from published page_content; draft rows stay private until selected-draft publish records a proof event.`,
       evidence_uri: "D1 anipotts-db page_content and content operation tables",
       redaction: "metadata_only",
       next_safe_action: isReady
-        ? "Use passkey-protected draft operations for review; keep publish and public content writes blocked."
+        ? "Use passkey-protected drafts and publish only selected published-visibility drafts with proof."
         : contentOperationNextAction(publishedPages, records, drafts, events),
     };
   } catch (error) {
@@ -198,13 +197,10 @@ function contentOperationNextAction(
   publishedPages: number,
   records: number,
   drafts: number,
-  events: number,
+  _events: number,
 ): string {
   if (records > 0) {
     return "Review content_records before enabling any public runtime read from draft records.";
-  }
-  if (events > 0) {
-    return "Review publish events before enabling more content writes.";
   }
   if (publishedPages < REQUIRED_PUBLISHED_PAGE_CONTENT_ROWS) {
     return "Seed the remaining public route copy into published page_content rows.";
@@ -212,7 +208,7 @@ function contentOperationNextAction(
   if (drafts < REQUIRED_CONTENT_DRAFT_OPERATIONS) {
     return "Seed draft operations for every D1-backed public copy surface.";
   }
-  return "Keep publish and public content writes disabled until the audited publish path is ready.";
+  return "Use selected-draft publish only; keep source rewrites, deploys, sends, and content_records writes disabled.";
 }
 
 async function readDurableProofEntries(

--- a/packages/content/src/public/index.ts
+++ b/packages/content/src/public/index.ts
@@ -33,6 +33,7 @@ export {
 } from "./homepage.js";
 
 export type {
+  CmsWritingContent,
   HomepageMention,
   HomepageRichSummarySegment,
   HomepageRichSummarySentence,

--- a/packages/lib/src/cms/index.ts
+++ b/packages/lib/src/cms/index.ts
@@ -29,7 +29,7 @@ export {
   normalizeHomepageContent,
   validateHomepageContent,
 } from "./homepage";
-export { fetchPageContent } from "./page";
+export { fetchPageContent, fetchPublishedPageContentByPrefix } from "./page";
 export { fetchProjects } from "./projects";
 export {
   fetchAllSiteSettings,

--- a/packages/lib/src/cms/page.ts
+++ b/packages/lib/src/cms/page.ts
@@ -1,5 +1,5 @@
 import type { PageContent } from "@anipotts/types";
-import { and, desc, eq } from "drizzle-orm";
+import { and, desc, eq, like } from "drizzle-orm";
 import { getDrizzle, parseJson } from "../db";
 import * as s from "../db/schema";
 import { logger } from "../logger";
@@ -42,4 +42,48 @@ export async function fetchPageContent<T = unknown>(
   }
 
   return null;
+}
+
+export async function fetchPublishedPageContentByPrefix<T = unknown>(
+  pageKeyPrefix: string,
+): Promise<PageContent<T>[]> {
+  const db = getDrizzle();
+  if (!db) return [];
+
+  try {
+    const rows = await db
+      .select()
+      .from(s.pageContent)
+      .where(
+        and(
+          like(s.pageContent.page_key, `${pageKeyPrefix}%`),
+          eq(s.pageContent.published, true),
+        ),
+      )
+      .orderBy(desc(s.pageContent.version));
+    const latestByKey = new Map<string, PageContent<T>>();
+
+    for (const row of rows) {
+      if (latestByKey.has(row.page_key)) continue;
+      latestByKey.set(row.page_key, {
+        id: row.id,
+        page_key: row.page_key,
+        content: parseJson<T>(row.content) as T,
+        version: row.version ?? 1,
+        published: row.published ?? false,
+        updated_at: row.updated_at ?? "",
+        updated_by: row.updated_by ?? null,
+        created_at: row.created_at ?? "",
+      });
+    }
+
+    return [...latestByKey.values()];
+  } catch (err) {
+    logger.error(
+      "cms",
+      `D1 fetchPublishedPageContentByPrefix("${pageKeyPrefix}") failed`,
+      { error: String(err) },
+    );
+    return [];
+  }
 }

--- a/scripts/admin/content-proof.mjs
+++ b/scripts/admin/content-proof.mjs
@@ -78,6 +78,7 @@ const ADMIN_ROUTES = [
   "/content/drafts",
   "/content/edit/home",
   "/api/admin/content/draft-operation",
+  "/api/admin/content/editor",
   "/content/preview",
   "/content/operations",
   "/proof",
@@ -429,7 +430,6 @@ const missingProof = [
   ...staleOperationSources.map(
     (operationId) => `stale_content_operation_source:${operationId}`,
   ),
-  ...(publishEvents === 0 ? [] : ["content_publish_events_should_be_empty"]),
   ...(contentRecords === 0 ? [] : ["content_records_should_be_empty"]),
   ...publicRouteFailures.map((route) => `public_route:${route.path}`),
   ...(adminBoundary === "cloudflare_access" ||
@@ -523,15 +523,15 @@ const proof = {
   admin_routes: adminRoutes,
   public_routes: publicRoutes,
   route_boundary: adminBoundary,
-  publish_writes_inert: contentRecords === 0 && publishEvents === 0,
-  writes_inert: contentRecords === 0 && publishEvents === 0,
+  publish_writes_proof_backed: publishEvents >= 0,
+  field_record_writes_inert: contentRecords === 0,
   ready_for_write_path_design:
     missingProof.length === 0 &&
     (contentCounts.content_draft_operations ?? 0) >= REQUIRED_OPERATIONS.length,
   missing_proof: missingProof,
   next_safe_action:
     missingProof.length === 0
-      ? "save draft operations behind passkey only; keep publish and public content writes blocked"
+      ? "save drafts behind passkey; publish only selected published-visibility drafts with content_publish_events proof"
       : `resolve missing content proof: ${missingProof.join(", ")}`,
 };
 

--- a/scripts/ci/admin-route-inventory.mjs
+++ b/scripts/ci/admin-route-inventory.mjs
@@ -80,6 +80,12 @@ export const ADMIN_ROUTES = [
     file: "apps/admin/src/pages/api/admin/content/draft-operation.ts",
     nav: false,
   },
+  {
+    route: "/api/admin/content/editor",
+    file: "apps/admin/src/pages/api/admin/content/editor.ts",
+    nav: false,
+    smoke: false,
+  },
 ];
 
 export const PUBLIC_UNSMOKED_ROUTE_FILES = [

--- a/scripts/ci/admin-route-parity.test.mjs
+++ b/scripts/ci/admin-route-parity.test.mjs
@@ -137,9 +137,10 @@ for (const marker of [
 
 for (const marker of [
   "readPageContentInventoryStore",
-  "publish disabled",
-  "/api/admin/content/draft-operation",
-  "draft operation only",
+  "/api/admin/content/editor",
+  "publish selected draft",
+  "content_draft_operations",
+  "new content starts as a private draft",
 ]) {
   assert.ok(
     contentEditorSource.includes(marker),

--- a/scripts/ci/content-platform.test.mjs
+++ b/scripts/ci/content-platform.test.mjs
@@ -544,7 +544,7 @@ assert.deepEqual(
   [
     ["content_records", "schema_only"],
     ["content_draft_operations", "draft_save_only"],
-    ["content_publish_events", "future_publish"],
+    ["content_publish_events", "publish_with_proof"],
   ],
-  "content operation tables must preserve draft-only write posture",
+  "content operation tables must preserve selected-draft publish posture",
 );


### PR DESCRIPTION
## summary
- add a passkey-protected admin content editor API for full D1 draft payloads and selected-draft publish
- replace `/content/edit/:pageKey` with a real owner editor for title, slug/page key, summary, tags, markdown body, visibility, metadata, preview links, publish action, and revision history
- update preview, drafts, operations, proof, and route inventory for publish-with-proof instead of preview-only posture
- let public writing read published D1-only writing rows while private, draft, and hidden drafts stay invisible

## d1 / migration proof
- no migration required; this uses existing `page_content`, `content_draft_operations`, and `content_publish_events`
- save draft writes to `content_draft_operations`
- preview reads the selected draft from `content_draft_operations`
- publish inserts a new published `page_content` version and records `content_publish_events`
- rollback remains designed/inert through revision `rollback_target` metadata and view links

## verification
- `pnpm turbo typecheck --filter=@anipotts/admin...`
- `pnpm turbo build --filter=@anipotts/admin...`
- `pnpm test:ci-invariants`
- `pnpm turbo typecheck --filter=@anipotts/www...`
- `pnpm turbo build --filter=@anipotts/www...`
- `pnpm --silent proof:admin-content`
- `git diff --check`
- `pnpm exec prettier --check <touched files>`
- in-memory D1 behavior smoke against `apps/admin/src/lib/content-editor.ts`: saved private, published, and hidden drafts; previewed a draft; blocked private publish; published selected public draft to one `page_content` row; recorded one publish event; showed revision history; confirmed hidden/private drafts did not create public rows

## deploy target proof
`node scripts/ci/compute-deploy-targets.mjs /tmp/admin-editor-files.txt`:

```text
www=true
admin=true
admin_solid=false
ingest=false
newsletter=false
state=false
weekly_email=false
```

## gaps
- no newsletter send path
- no source-file writes
- no deploy trigger from publish
- rollback action is visible as metadata/view history only; it does not revert rows yet
