### PR TITLE
fix: require batch-backed content publish

### DIFF
--- a/apps/admin/src/lib/content-editor.ts
+++ b/apps/admin/src/lib/content-editor.ts
@@ -490,13 +490,13 @@ export async function publishEditorDraft(
       ),
   ];
 
-  if (db.batch) {
-    const results = await db.batch(statements);
-    if (results.some((result) => result.success === false)) {
-      throw statusError(500, "publish_batch_failed");
-    }
-  } else {
-    await runSequentialPublish(statements);
+  if (!db.batch) {
+    throw statusError(503, "publish_batch_required");
+  }
+
+  const results = await db.batch(statements);
+  if (results.some((result) => result.success === false)) {
+    throw statusError(500, "publish_batch_failed");
   }
 
   return {
@@ -583,13 +583,6 @@ async function validatePayloadForPublish(
 function assertWritingSlugAllowed(slug: string) {
   if (RESERVED_WRITING_SLUGS.has(slug)) {
     throw statusError(409, "reserved_writing_slug");
-  }
-}
-
-async function runSequentialPublish(statements: D1PreparedStatement[]) {
-  for (const statement of statements) {
-    const result = await statement.run();
-    if (result.success === false) throw statusError(500, "publish_failed");
   }
 }
 

--- a/scripts/ci/content-platform.test.mjs
+++ b/scripts/ci/content-platform.test.mjs
@@ -237,6 +237,24 @@ assert.ok(
   "passkey replacement registration must reactivate a previously revoked credential",
 );
 
+const contentEditorSource = readFileSync(
+  "apps/admin/src/lib/content-editor.ts",
+  "utf8",
+);
+assert.ok(
+  contentEditorSource.includes("publish_batch_required"),
+  "content editor publish must fail closed when D1 batch semantics are unavailable",
+);
+assert.equal(
+  contentEditorSource.includes("runSequentialPublish"),
+  false,
+  "content editor publish must not fall back to sequential public writes",
+);
+assert.ok(
+  contentEditorSource.includes("content_publish_events"),
+  "content editor publish must keep explicit publish proof writes",
+);
+
 const disabledRuntime = disabledRuntimeOverlayResponse();
 assert.equal(disabledRuntime.mode, "disabled");
 assert.equal(disabledRuntime.available, false);


### PR DESCRIPTION
## summary
- fail closed when the admin content publish path cannot use D1 `batch`
- add a CI invariant that prevents the sequential publish fallback from returning
- keep `content_publish_events` proof as a required publish-path signal

## verification
- `pnpm test:content-platform`
- `pnpm turbo typecheck --filter=@anipotts/admin...`
- `pnpm turbo build --filter=@anipotts/admin...`
- `pnpm test:ci-invariants`
- `git diff --check`

## remaining
- prod browser editor smoke is still pending on app-native passkey approval. Cloudflare Access code path was cleared earlier, but `/auth/passkey` stayed on `starting passkey authentication` without a visible macOS prompt in this session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Publishing drafts now fails safely if the required database batch operation isn’t available.
  * Publish actions now stop immediately if any step in the batch fails, avoiding partial updates.
  * Removed a fallback path that could have led to inconsistent publish behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->