### PR TITLE
feat(admin): add carousel review route

### DIFF
--- a/apps/admin/src/data/admin.ts
+++ b/apps/admin/src/data/admin.ts
@@ -61,6 +61,13 @@ export const navItems: NavItem[] = [
     description: "draft operations and editable rows",
   },
   {
+    href: "/content/carousels",
+    label: "carousels",
+    status: "media",
+    group: "primary",
+    description: "slides, crops, captions, exports",
+  },
+  {
     href: "/proof",
     label: "proof/auth",
     status: "passkeys",

--- a/apps/admin/src/data/carousels.ts
+++ b/apps/admin/src/data/carousels.ts
@@ -1,0 +1,167 @@
+export type CarouselCrop = {
+  platform: "instagram" | "tiktok";
+  surface: string;
+  aspect: "4:5" | "9:16" | "1:1";
+  size: string;
+  exportName: string;
+  state: "expected" | "ready" | "blocked";
+};
+
+export type CarouselSlide = {
+  number: number;
+  title: string;
+  role: string;
+  slideFile: string;
+  captionFile: string;
+  state: "expected" | "ready" | "blocked";
+};
+
+export type CarouselSet = {
+  id: string;
+  title: string;
+  status: "media source pending" | "review ready" | "blocked";
+  sourceRoot: string;
+  sourceThread: string;
+  audience: string;
+  concept: string;
+  nextSafeAction: string;
+  crops: CarouselCrop[];
+  slides: CarouselSlide[];
+  exportFiles: string[];
+  blockedActions: string[];
+};
+
+export const carouselBoundary = {
+  mode: "static admin manifest",
+  runtime: "admin route does not read local media files at runtime",
+  source:
+    "/Users/anipotts/Media/projects/carousel-backdrops/series/durable_agent_workflows/v2",
+  sourceStatus: "not bundled with admin runtime yet",
+  allowed:
+    "inspect sets, crop targets, slide/caption refs, and export readiness",
+  blocked:
+    "no social posting, scheduling, platform mutation, media deletion, or publish write",
+};
+
+export const carouselSets: CarouselSet[] = [
+  {
+    id: "durable-agent-workflows-v2",
+    title: "durable agent workflows v2",
+    status: "media source pending",
+    sourceRoot: carouselBoundary.source,
+    sourceThread: "media/carousels",
+    audience: "anipottsbuilds",
+    concept:
+      "operator-facing carousel about durable agent workflows and proof-backed control planes.",
+    nextSafeAction:
+      "sync a media manifest or thumbnail bundle from the media thread, then bind real preview assets to this route.",
+    crops: [
+      {
+        platform: "instagram",
+        surface: "feed carousel",
+        aspect: "4:5",
+        size: "1080x1350",
+        exportName: "ig-feed/*.png",
+        state: "expected",
+      },
+      {
+        platform: "instagram",
+        surface: "reel/story",
+        aspect: "9:16",
+        size: "1080x1920",
+        exportName: "ig-vertical/*.png",
+        state: "expected",
+      },
+      {
+        platform: "tiktok",
+        surface: "vertical post",
+        aspect: "9:16",
+        size: "1080x1920",
+        exportName: "tiktok/*.png",
+        state: "expected",
+      },
+      {
+        platform: "instagram",
+        surface: "profile-safe square",
+        aspect: "1:1",
+        size: "1080x1080",
+        exportName: "square/*.png",
+        state: "expected",
+      },
+    ],
+    slides: [
+      {
+        number: 1,
+        title: "control plane",
+        role: "open with the system promise and visual identity",
+        slideFile: "slides/01-control-plane.md",
+        captionFile: "captions/01-control-plane.md",
+        state: "expected",
+      },
+      {
+        number: 2,
+        title: "intent",
+        role: "show the owner request before any operation starts",
+        slideFile: "slides/02-intent.md",
+        captionFile: "captions/02-intent.md",
+        state: "expected",
+      },
+      {
+        number: 3,
+        title: "authority",
+        role: "make gates and allowed actions visible",
+        slideFile: "slides/03-authority.md",
+        captionFile: "captions/03-authority.md",
+        state: "expected",
+      },
+      {
+        number: 4,
+        title: "operation",
+        role: "show the work unit and owner thread",
+        slideFile: "slides/04-operation.md",
+        captionFile: "captions/04-operation.md",
+        state: "expected",
+      },
+      {
+        number: 5,
+        title: "proof",
+        role: "capture route, deploy, and artifact evidence",
+        slideFile: "slides/05-proof.md",
+        captionFile: "captions/05-proof.md",
+        state: "expected",
+      },
+      {
+        number: 6,
+        title: "state",
+        role: "close with what changed and what remains blocked",
+        slideFile: "slides/06-state.md",
+        captionFile: "captions/06-state.md",
+        state: "expected",
+      },
+    ],
+    exportFiles: [
+      "manifest.json",
+      "captions/post-caption.md",
+      "captions/alt-text.md",
+      "exports/ig-feed",
+      "exports/ig-vertical",
+      "exports/tiktok",
+    ],
+    blockedActions: [
+      "publish to instagram",
+      "publish to tiktok",
+      "schedule social post",
+      "mutate media source files",
+      "delete source exports",
+    ],
+  },
+];
+
+export const carouselSummary = {
+  sets: carouselSets.length,
+  crops: carouselSets.reduce((sum, set) => sum + set.crops.length, 0),
+  slides: carouselSets.reduce((sum, set) => sum + set.slides.length, 0),
+  blockedActions: Array.from(
+    new Set(carouselSets.flatMap((set) => set.blockedActions)),
+  ),
+};

--- a/apps/admin/src/pages/content/carousels.astro
+++ b/apps/admin/src/pages/content/carousels.astro
@@ -1,0 +1,176 @@
+---
+import AdminLayout from "../../layouts/AdminLayout.astro";
+import {
+  carouselBoundary,
+  carouselSets,
+  carouselSummary,
+} from "../../data/carousels";
+
+function cropClass(aspect: string): string {
+  return `crop-frame aspect-${aspect.replace(":", "-")}`;
+}
+---
+
+<AdminLayout
+  title="content carousels"
+  deck="Read-only carousel review for anipottsbuilds media sets. It tracks source paths, crop targets, slide files, captions, and export readiness without posting or scheduling."
+>
+  <section class="meta-strip" aria-label="carousel review source">
+    <span>{carouselSummary.sets} set</span>
+    <span>{carouselSummary.crops} crops</span>
+    <span>{carouselSummary.slides} slides</span>
+    <span>{carouselBoundary.mode}</span>
+    <span>{carouselBoundary.sourceStatus}</span>
+  </section>
+
+  <section class="table-card operation-card">
+    <div class="section-head">
+      <div>
+        <p>data boundary</p>
+        <h2>static manifest first</h2>
+      </div>
+      <span>read only</span>
+    </div>
+    <div class="lane-grid">
+      <div>
+        <h3>app boundary</h3>
+        <p class="muted">{carouselBoundary.allowed}</p>
+        <div class="body-preview">
+          <span>source root</span>
+          <p>{carouselBoundary.source}</p>
+        </div>
+      </div>
+      <div>
+        <h3>runtime boundary</h3>
+        <p class="muted">{carouselBoundary.runtime}</p>
+        <div class="body-preview">
+          <span>blocked</span>
+          <p>{carouselBoundary.blocked}</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <div class="carousel-set-grid">
+    {
+      carouselSets.map((set) => (
+        <article class="table-card">
+          <div class="section-head">
+            <div>
+              <p>
+                {set.audience} / {set.status}
+              </p>
+              <h2>{set.title}</h2>
+            </div>
+            <span>{set.id}</span>
+          </div>
+
+          <div class="carousel-brief">
+            <p>{set.concept}</p>
+            <dl>
+              <div>
+                <dt>source thread</dt>
+                <dd>{set.sourceThread}</dd>
+              </div>
+              <div>
+                <dt>source root</dt>
+                <dd>{set.sourceRoot}</dd>
+              </div>
+              <div>
+                <dt>next</dt>
+                <dd>{set.nextSafeAction}</dd>
+              </div>
+            </dl>
+          </div>
+
+          <section class="carousel-section" aria-label={`${set.title} crops`}>
+            <div class="section-head compact-section-head">
+              <div>
+                <p>crops</p>
+                <h3>platform targets</h3>
+              </div>
+              <span>{set.crops.length} expected</span>
+            </div>
+            <div class="crop-board">
+              {set.crops.map((crop) => (
+                <article class="crop-card">
+                  <div class={cropClass(crop.aspect)}>
+                    <span>{crop.aspect}</span>
+                  </div>
+                  <div>
+                    <p>
+                      {crop.platform} / {crop.surface}
+                    </p>
+                    <h3>{crop.size}</h3>
+                    <small>{crop.exportName}</small>
+                  </div>
+                </article>
+              ))}
+            </div>
+          </section>
+
+          <section class="carousel-section" aria-label={`${set.title} slides`}>
+            <div class="section-head compact-section-head">
+              <div>
+                <p>slides</p>
+                <h3>copy and caption refs</h3>
+              </div>
+              <span>{set.slides.length} expected</span>
+            </div>
+            <div class="record-list">
+              {set.slides.map((slide) => (
+                <article class="record-row">
+                  <div>
+                    <p>
+                      slide {slide.number} / {slide.state}
+                    </p>
+                    <h3>{slide.title}</h3>
+                  </div>
+                  <dl>
+                    <div>
+                      <dt>role</dt>
+                      <dd>{slide.role}</dd>
+                    </div>
+                    <div>
+                      <dt>slide file</dt>
+                      <dd>{slide.slideFile}</dd>
+                    </div>
+                    <div>
+                      <dt>caption file</dt>
+                      <dd>{slide.captionFile}</dd>
+                    </div>
+                  </dl>
+                </article>
+              ))}
+            </div>
+          </section>
+
+          <div class="newsletter-detail">
+            <section>
+              <h3>export files</h3>
+              <div class="record-list">
+                {set.exportFiles.map((file) => (
+                  <article class="compact-row">
+                    <strong>{file}</strong>
+                    <small>expected from media manifest sync</small>
+                  </article>
+                ))}
+              </div>
+            </section>
+            <section>
+              <h3>blocked live actions</h3>
+              <div class="record-list">
+                {set.blockedActions.map((action) => (
+                  <article class="compact-row">
+                    <strong>{action}</strong>
+                    <small>not part of this admin review route</small>
+                  </article>
+                ))}
+              </div>
+            </section>
+          </div>
+        </article>
+      ))
+    }
+  </div>
+</AdminLayout>

--- a/apps/admin/src/pages/content/index.astro
+++ b/apps/admin/src/pages/content/index.astro
@@ -139,6 +139,7 @@ const pageContentState = await readPageContentInventoryStore(
   <nav class="inline-actions" aria-label="content creation">
     <a class="button" href="/content/edit/new"> new writing draft </a>
     <a class="button secondary" href="/content/drafts"> draft history </a>
+    <a class="button secondary" href="/content/carousels"> carousel review </a>
     <a class="button secondary" href="/content/operations"> operation proof </a>
   </nav>
 

--- a/apps/admin/src/styles/admin.css
+++ b/apps/admin/src/styles/admin.css
@@ -856,6 +856,98 @@ dd {
   padding: 16px;
 }
 
+.carousel-set-grid {
+  display: grid;
+  gap: 18px;
+  margin-top: 24px;
+}
+
+.carousel-brief {
+  display: grid;
+  gap: 14px;
+  padding: 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.carousel-brief p {
+  max-width: var(--measure);
+  margin: 0;
+  color: var(--text);
+  line-height: 1.55;
+}
+
+.carousel-brief dl {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  margin: 0;
+}
+
+.carousel-section {
+  border-bottom: 1px solid var(--border);
+}
+
+.compact-section-head {
+  padding-block: 14px;
+}
+
+.crop-board {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+  padding: 16px;
+}
+
+.crop-card {
+  display: grid;
+  gap: 10px;
+  min-width: 0;
+}
+
+.crop-card p,
+.crop-card h3,
+.crop-card small {
+  margin: 0;
+}
+
+.crop-card p,
+.crop-card small {
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.crop-card h3 {
+  font-size: 16px;
+  font-weight: 500;
+}
+
+.crop-frame {
+  display: grid;
+  place-items: center;
+  width: 100%;
+  border: 1px solid var(--border);
+  background: var(--field-surface);
+}
+
+.crop-frame span {
+  color: var(--muted);
+  font-family: var(--mono);
+  font-size: 12px;
+}
+
+.aspect-4-5 {
+  aspect-ratio: 4 / 5;
+}
+
+.aspect-9-16 {
+  aspect-ratio: 9 / 16;
+}
+
+.aspect-1-1 {
+  aspect-ratio: 1 / 1;
+}
+
 .draft-form {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -1312,6 +1404,8 @@ dd {
   .lane-grid,
   .newsletter-detail,
   .newsletter-preview-layout,
+  .carousel-brief dl,
+  .crop-board,
   .record-row dl,
   .need-row dl,
   .proposal-row dl,

--- a/scripts/ci/admin-route-inventory.mjs
+++ b/scripts/ci/admin-route-inventory.mjs
@@ -21,6 +21,12 @@ export const ADMIN_ROUTES = [
     nav: true,
   },
   {
+    route: "/content/carousels",
+    file: "apps/admin/src/pages/content/carousels.astro",
+    nav: true,
+    smoke: false,
+  },
+  {
     route: "/content/edit/home",
     file: "apps/admin/src/pages/content/edit/[pageKey].astro",
     nav: false,


### PR DESCRIPTION
## summary
- add `/content/carousels` to the Astro admin app as a read-only owner review surface
- add a typed static carousel manifest boundary for the durable agent workflows v2 set
- link the route from the content dashboard and admin nav
- classify the route in admin route inventory without enabling live writes, posting, scheduling, or platform mutation

## data boundary
- source context: `/Users/anipotts/Media/projects/carousel-backdrops/series/durable_agent_workflows/v2`
- runtime boundary: admin does not read local media files at runtime
- first slice uses a static admin manifest shape for sets, crop targets, slide/caption refs, expected exports, and blocked live actions
- the exact source media path was not present on this host during implementation, so this PR does not claim bundled thumbnail/export proof

## verification
- `pnpm exec prettier --check apps/admin/src/data/admin.ts apps/admin/src/data/carousels.ts apps/admin/src/pages/content/carousels.astro apps/admin/src/pages/content/index.astro apps/admin/src/styles/admin.css scripts/ci/admin-route-inventory.mjs`
- `git diff --cached --check`
- `pnpm test:admin-routes`
- `pnpm test:ci-invariants`
- `pnpm turbo typecheck --filter=@anipotts/admin...`
- `pnpm turbo build --filter=@anipotts/admin...`
- local smoke: `/content/carousels` returns protected 302 locally, `/auth/passkey` returns 200
- deploy target impact from touched files: `admin=true`, all other targets false

## notes
- no deploy was run
- no DNS/auth/env/secret/endpoint changes
- no public publish
- no social posting or scheduling
- no source media deletion
- workflow smoke-list edits for this new route were intentionally not included because the current GitHub token cannot push `.github/workflows/*` changes without workflow permission
