### PR TITLE
fix(admin): simplify overview console

### DIFF
--- a/apps/admin/src/layouts/AdminLayout.astro
+++ b/apps/admin/src/layouts/AdminLayout.astro
@@ -12,7 +12,7 @@ const currentPath = Astro.url.pathname.replace(/\/$/, "") || "/";
 const primaryNav = navItems.filter((item) => item.group === "primary");
 const secondaryNav = [
   {
-    label: "content queues",
+    label: "content",
     items: navItems.filter((item) => item.group === "content"),
   },
   {
@@ -74,7 +74,7 @@ function isActive(href: string): boolean {
           <span class="brand-mark">a</span>
           <span>
             <strong>anipotts admin</strong>
-            <small>operator console</small>
+            <small>admin</small>
           </span>
         </a>
         <nav class="nav-stack">
@@ -88,7 +88,6 @@ function isActive(href: string): boolean {
                     href={item.href}
                   >
                     <span>{item.label}</span>
-                    <small>{item.description}</small>
                   </a>
                 ))
               }
@@ -108,7 +107,6 @@ function isActive(href: string): boolean {
                       href={item.href}
                     >
                       <span>{item.label}</span>
-                      <small>{item.description}</small>
                     </a>
                   ))}
                 </div>
@@ -117,9 +115,8 @@ function isActive(href: string): boolean {
           }
         </nav>
         <div class="sidebar-proof">
-          <span>auth state</span>
-          <strong>passkey active, Access outer guard</strong>
-          <small>remove Access only after revoked and denied auth proof.</small>
+          <strong>passkey + Access</strong>
+          <small>Access stays until proof passes.</small>
         </div>
       </aside>
       <main>

--- a/apps/admin/src/pages/index.astro
+++ b/apps/admin/src/pages/index.astro
@@ -1,91 +1,77 @@
 ---
 import AdminLayout from "../layouts/AdminLayout.astro";
-import { navItems, overviewCards } from "../data/admin";
 
-const primaryLinks = navItems.filter(
-  (item) => item.group === "primary" && item.href !== "/",
-);
-
-const proofRows = [
+const primaryRoutes = [
   {
-    label: "passkeys",
-    value: "2 credentials",
-    detail: "1 active session, revoke/denial proof still missing",
+    href: "/fleet",
+    label: "fleet",
+    detail: "machines, repo state, current work",
   },
   {
+    href: "/content",
     label: "content",
-    value: "D1 backed",
-    detail: "inventory, review queue, draft operation editor",
+    detail: "public-site content inventory",
   },
   {
-    label: "threads",
-    value: "2 worktrees",
-    detail: "orchestrating redesign and real writing editor",
+    href: "/content/drafts",
+    label: "writing editor",
+    detail: "drafts and editable rows",
   },
   {
-    label: "guard",
-    value: "Access on",
-    detail: "remove only after app-native passkey proof is ready",
+    href: "/proof",
+    label: "proof/auth",
+    detail: "passkeys and blocked checks",
+  },
+  {
+    href: "/deploys",
+    label: "deploys",
+    detail: "target map and proof",
+  },
+];
+
+const quietRoutes = [
+  {
+    href: "/needs-ani",
+    label: "needs ani",
+  },
+  {
+    href: "/repos",
+    label: "repos",
+  },
+  {
+    href: "/handoffs",
+    label: "handoffs",
+  },
+  {
+    href: "/mutations",
+    label: "mutations",
   },
 ];
 ---
 
-<AdminLayout
-  title="operator overview"
-  deck="Small surface first. Primary routes answer what is safe next; advanced queues stay available without dominating the screen."
->
-  <section class="overview-hero" aria-labelledby="safe-next-heading">
-    <p class="section-label">what is safe next</p>
-    <h2 id="safe-next-heading">
-      finish passkey revoke proof, keep content writes scoped, and let the
-      editor worktree own publishing.
-    </h2>
-    <p>
-      This admin surface is now organized like a docs console: fleet, content,
-      writing, proof, and deploys are first. Handoffs, raw repos, mutations, and
-      destructive operations stay one level down.
-    </p>
-    <div class="hero-actions" aria-label="primary admin routes">
+<AdminLayout title="overview">
+  <section class="minimal-home" aria-labelledby="admin-next-heading">
+    <div class="next-panel">
+      <p>next</p>
+      <h2 id="admin-next-heading">
+        prove passkey revoke and denied login before removing Access.
+      </h2>
+      <span>writes off. publishing gated. social actions off.</span>
+    </div>
+
+    <nav class="route-list" aria-label="primary admin routes">
       {
-        primaryLinks.map((item) => (
-          <a class="button secondary" href={item.href}>
-            {item.label}
+        primaryRoutes.map((route) => (
+          <a class="route-row" href={route.href}>
+            <strong>{route.label}</strong>
+            <span>{route.detail}</span>
           </a>
         ))
       }
-    </div>
-  </section>
+    </nav>
 
-  <section class="quick-grid" aria-label="current operator state">
-    {
-      proofRows.map((row) => (
-        <article class="quick-card">
-          <p>{row.label}</p>
-          <h2>{row.value}</h2>
-          <span>{row.detail}</span>
-        </article>
-      ))
-    }
+    <nav class="quiet-links" aria-label="secondary admin routes">
+      {quietRoutes.map((route) => <a href={route.href}>{route.label}</a>)}
+    </nav>
   </section>
-
-  <section class="surface-grid" aria-label="operator overview cards">
-    {
-      overviewCards.map((card) => (
-        <article class="panel">
-          <p class={`risk-${card.risk}`}>{card.risk} risk</p>
-          <h2>{card.title}</h2>
-          <p>{card.status}</p>
-          <p>{card.next}</p>
-          <a class="panel-link" href={card.href}>
-            {card.action}
-          </a>
-        </article>
-      ))
-    }
-  </section>
-  <div class="notice">
-    Cloudflare Access stays in front of admin.anipotts.com until app-native
-    passkey proof reports ready. This page does not register passkeys, revoke
-    credentials, publish content, dispatch deploys, or write public-site data.
-  </div>
 </AdminLayout>

--- a/apps/admin/src/styles/admin.css
+++ b/apps/admin/src/styles/admin.css
@@ -58,7 +58,7 @@ a {
 
 .shell {
   display: grid;
-  grid-template-columns: 292px minmax(0, 1fr);
+  grid-template-columns: 240px minmax(0, 1fr);
   min-height: 100vh;
 }
 
@@ -77,7 +77,7 @@ a {
   grid-template-columns: 36px 1fr;
   gap: 12px;
   align-items: center;
-  margin-bottom: 24px;
+  margin-bottom: 22px;
 }
 
 .brand-mark {
@@ -99,7 +99,6 @@ a {
 }
 
 .brand small,
-.nav-link small,
 .page-header p,
 .panel p,
 td {
@@ -147,8 +146,7 @@ td {
 
 .nav-link {
   display: grid;
-  gap: 4px;
-  padding: 10px 12px;
+  padding: 8px 10px;
   border: 1px solid transparent;
   font-size: 14px;
 }
@@ -157,10 +155,6 @@ td {
 .nav-link:hover {
   border-color: var(--border);
   background: var(--panel);
-}
-
-.nav-link small {
-  line-height: 1.35;
 }
 
 .sidebar-proof {
@@ -178,6 +172,87 @@ td {
   font-size: 11px;
   letter-spacing: 0.12em;
   text-transform: uppercase;
+}
+
+.minimal-home {
+  display: grid;
+  gap: 18px;
+  max-width: 720px;
+  padding-top: 28px;
+}
+
+.next-panel {
+  display: grid;
+  gap: 8px;
+  padding-bottom: 18px;
+  border-bottom: 1px solid var(--border);
+}
+
+.next-panel p,
+.next-panel h2,
+.next-panel span {
+  margin: 0;
+}
+
+.next-panel p {
+  color: var(--muted);
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.next-panel h2 {
+  max-width: 640px;
+  font-size: clamp(30px, 4.5vw, 56px);
+  font-weight: 500;
+  line-height: 0.98;
+  letter-spacing: 0;
+}
+
+.next-panel span {
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.route-list {
+  display: grid;
+  border-top: 1px solid var(--border);
+}
+
+.route-row {
+  display: grid;
+  grid-template-columns: 170px minmax(0, 1fr);
+  gap: 18px;
+  align-items: baseline;
+  padding: 14px 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.route-row strong {
+  font-size: 18px;
+  font-weight: 500;
+}
+
+.route-row span {
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.route-row:hover strong,
+.quiet-links a:hover {
+  color: var(--accent);
+}
+
+.quiet-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+}
+
+.quiet-links a {
+  color: var(--muted);
+  font-size: 13px;
 }
 
 .sidebar-proof strong {


### PR DESCRIPTION
## summary
- strip verbose operator-dashboard scaffold copy from the admin homepage
- reduce sidebar nav to route labels only
- keep the overview as one current gate, five primary routes, and quiet secondary links

## verification
- `pnpm exec prettier --check apps/admin/src/layouts/AdminLayout.astro apps/admin/src/pages/index.astro apps/admin/src/styles/admin.css`
- `pnpm test:admin-routes`
- `pnpm test:ci-invariants`
- `pnpm turbo typecheck --filter=@anipotts/admin...`
- `pnpm turbo build --filter=@anipotts/admin...`
- `git diff --check`
- deploy target impact: `admin=true`, all other targets false

## live plan
- merge after required checks pass
- deploy `admin=true` only
- no DNS/auth/env/secret/content write/public publish/social action changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the admin home experience with a simpler landing layout and clearer route groups for primary and secondary navigation.
  * Revised sidebar branding and status messaging for a more concise, current display.

* **Style**
  * Refined spacing and navigation styling across the admin interface.
  * Reduced visual clutter by showing link labels only and removing extra descriptive text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->