### PR TITLE
fix(www): limit jetbrains mono to latin

### DIFF
--- a/apps/www/src/styles/global.css
+++ b/apps/www/src/styles/global.css
@@ -1,7 +1,19 @@
 @import "@anipotts/styles/tokens-www.css";
 @import "@fontsource-variable/instrument-sans";
 @import "@fontsource/urbanist/latin-900.css";
-@import "@fontsource-variable/jetbrains-mono";
+
+@font-face {
+  font-family: "JetBrains Mono Variable";
+  font-style: normal;
+  font-display: swap;
+  font-weight: 100 800;
+  src: url("@fontsource-variable/jetbrains-mono/files/jetbrains-mono-latin-wght-normal.woff2")
+    format("woff2-variations");
+  unicode-range:
+    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
+    U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212,
+    U+2215, U+FEFF, U+FFFD;
+}
 
 :root {
   --display: "Urbanist", var(--sans);


### PR DESCRIPTION
## what changed

- replace the full JetBrains Mono variable-font import with its exported Latin variable WOFF2
- keep `font-src 'self'` and `script-src` unchanged

## diagnosis

The production build imported every JetBrains Mono subset. Vite inlined the small, unused Cyrillic Extended face as a `data:font` URL, which the strict public CSP correctly blocked. The Cloudflare Insights beacon is a separate conditional edge injection and remains intentionally disallowed by application CSP.

## impact

Technical labels and article code retain JetBrains Mono for Latin text. The production CSS no longer emits the blocked data-font resource. Page layout, content, routes, CMS behavior, and Cloudflare configuration are unchanged.

## verification

- `pnpm turbo typecheck --filter=@anipotts/www...`
- `pnpm turbo build --filter=@anipotts/www...`
- `pnpm exec prettier --check apps/www/src/styles/global.css`
- `git diff --check`
- static security and literal-secret scans
- built CSS has zero `data:font` URLs and emits the hashed Latin WOFF2
- browser QA at 1440 and 390 in light and dark, with theme persistence, no overflow, computed JetBrains Mono, and zero console errors

No Cloudflare setting, deployment, CMS data, or D1 state was changed.