### PR TITLE
fix(www): hide collapsed mobile nav from focus

### DIFF
--- a/apps/www/src/components/Nav.astro
+++ b/apps/www/src/components/Nav.astro
@@ -208,17 +208,21 @@ const current = Astro.url.pathname;
       grid-template-rows: 0fr;
       width: 100%;
       opacity: 0;
+      visibility: hidden;
       transform: translateY(-0.35rem);
       transition:
         grid-template-rows 220ms cubic-bezier(0.2, 0.7, 0.2, 1),
         opacity 160ms ease,
-        transform 220ms cubic-bezier(0.2, 0.7, 0.2, 1);
+        transform 220ms cubic-bezier(0.2, 0.7, 0.2, 1),
+        visibility 0s linear 220ms;
     }
 
     .primary-nav[data-open="true"] {
       grid-template-rows: 1fr;
       opacity: 1;
+      visibility: visible;
       transform: none;
+      transition-delay: 0s;
     }
 
     .nav-links {


### PR DESCRIPTION
## what changed

- hide the collapsed mobile primary navigation with `visibility: hidden`
- reveal it immediately when opened and defer hiding until the existing 220ms close animation finishes
- leave desktop navigation, typography, content, and theme tokens unchanged

## why

The mobile menu used a zero-row grid and opacity animation. Its links were visually collapsed but remained exposed in the accessibility tree and keyboard focus order.

## impact

At mobile widths, closed navigation links are no longer reachable or announced. Opening the menu restores all three links, and Escape closes and hides them after the existing transition. Desktop navigation remains visible.

## verification

- `pnpm exec prettier --check apps/www/src/components/Nav.astro`
- `git diff --check`
- `pnpm turbo typecheck --filter=@anipotts/www...`
- `pnpm turbo build --filter=@anipotts/www...`
- static security and literal-secret scans
- Browser QA at 390x844 for collapsed, expanded, and Escape-close states
- Browser QA at 1440x900 for unchanged desktop navigation
- zero horizontal overflow and zero console warnings or errors

No deploy, CMS/D1 mutation, admin change, or live configuration change was made.