### PR TITLE
test(ci): require worker inventory table rows

### DIFF
--- a/scripts/ci/workspace-inventory-parser.test.mjs
+++ b/scripts/ci/workspace-inventory-parser.test.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+
+const POSITIVE_FIXTURE = `
+# worker inventory
+
+## retained workers
+
+| Worker | Classification |
+| --- | --- |
+| \`workers/example\` | keep |
+
+## conclusion
+`;
+
+const NEGATIVE_FIXTURE = `
+# worker inventory
+
+The worker at \`workers/example\` is discussed here but is not classified.
+
+## deploy target mapping
+
+| Worker | Deploy input |
+| --- | --- |
+| \`workers/example\` | example=true |
+`;
+
+assert.deepEqual(classifiedWorkers(POSITIVE_FIXTURE), ["workers/example"]);
+assert.deepEqual(classifiedWorkers(NEGATIVE_FIXTURE), []);
+
+export function classifiedWorkers(source) {
+  const section = source.match(
+    /^## retained workers\s*$([\s\S]*?)(?=^##\s|(?![\s\S]))/m,
+  );
+  if (!section) return [];
+
+  return section[1]
+    .split("\n")
+    .map((line) => line.match(/^\|\s*`(workers\/[a-z0-9-]+)`\s*\|/i)?.[1])
+    .filter(Boolean)
+    .sort();
+}

--- a/scripts/ci/workspace-inventory.test.mjs
+++ b/scripts/ci/workspace-inventory.test.mjs
@@ -3,6 +3,7 @@
 import assert from "node:assert/strict";
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import { classifiedWorkers } from "./workspace-inventory-parser.test.mjs";
 
 const EXPECTED_APPS = ["admin", "admin-solid", "www"];
 const EXPECTED_PACKAGES = ["config", "content", "lib", "styles", "types"];
@@ -69,12 +70,11 @@ assert.equal(
 );
 
 const workerInventory = readFileSync("docs/worker-inventory.md", "utf8");
-for (const worker of EXPECTED_WORKERS) {
-  assert.ok(
-    workerInventory.includes(`workers/${worker}`),
-    `docs/worker-inventory.md must classify workers/${worker}`,
-  );
-}
+assert.deepEqual(
+  classifiedWorkers(workerInventory),
+  EXPECTED_WORKERS.map((worker) => `workers/${worker}`),
+  "docs/worker-inventory.md retained workers must match workspace workers",
+);
 
 function packageDirs(root) {
   return readdirSync(root, { withFileTypes: true })


### PR DESCRIPTION
## Summary

- parse retained workers from the actual inventory table
- reject prose mentions and unrelated-table rows as classification evidence
- require the documented retained set to exactly match workspace workers

## Test plan

- [x] `node scripts/ci/workspace-inventory-parser.test.mjs`
- [x] `pnpm test:workspace`
- [x] `pnpm test:ci-invariants`
- [x] focused Prettier check
- [x] security-review tests, diff check, and scoped secret-pattern scan

No merge, deploy, migration, or live-state change.