### PR TITLE
docs(ci): correct dependabot policy header

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,4 @@
-# Dependabot config: minimize PR noise, batch updates, hand off to auto-merge.
+# Dependabot config: minimize PR noise and batch scheduled updates.
 #
 # Strategy:
 #   - npm: weekly Monday morning, grouped by update-type. Security updates still
@@ -6,9 +6,9 @@
 #   - github-actions: monthly, low traffic.
 #   - open-pull-requests-limit caps the queue so a quiet week doesn't pile up.
 #
-# Auto-merge (.github/workflows/dependabot-automerge.yml) handles patches and
-# security advisories without human review once CI passes. Minor + major
-# updates wait for manual review.
+# Dependency PRs follow the normal CI and Security Review path, then require
+# manual review and merge. Agent auto-merge is limited to non-draft PRs from
+# codex/, claude/, or worktree/ branches.
 
 version: 2
 updates:


### PR DESCRIPTION
## Summary

- correct the stale Dependabot header that references a nonexistent auto-merge workflow
- document the current grouped-update, normal-check, and manual-review contract
- preserve every Dependabot YAML setting

## Validation

- `git diff --check`
- `pnpm exec prettier --check .github/dependabot.yml`
- `node scripts/ci/workflow-inventory.test.mjs`
- `node scripts/ci/security-review.test.mjs`
- scoped security review and literal-secret scan for `.github/dependabot.yml`

## Impact

Documentation only. No dependency behavior, deployment target, or live state changes.