### PR TITLE
refactor(ci): centralize public route inventory

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -150,7 +150,9 @@ jobs:
       - name: Smoke www routes
         run: |
           set -euo pipefail
-          for path in / /newsletter /newsletter/archive /making /orchestrating /projects /projects/chainedchat /projects/claude-code-tips /projects/imessage-mcp /projects/nyu-purity-test /projects/options-pricing-sensitivity /projects/pgi-research-platform /projects/quantercise /projects/quantercise-extension /projects/saeshify /writing /writing/i-built-a-monitor-for-my-claude-code-sessions /writing/saturdays-are-for-claude-code /writing/search-will-be-dead-by-2030 /writing/stop-ending-your-day-with-fix-the-bug; do
+          routes_file="$RUNNER_TEMP/public-routes.txt"
+          node scripts/ci/public-route-inventory.mjs > "$routes_file"
+          while IFS= read -r path; do
             ok=false
             for _ in $(seq 1 6); do
               code="$(curl -sS -o /dev/null -w '%{http_code}' "https://anipotts.com${path}")"
@@ -162,7 +164,7 @@ jobs:
               sleep 10
             done
             test "$ok" = "true"
-          done
+          done < "$routes_file"
 
   deploy-admin:
     name: Deploy admin

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -28,15 +28,19 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - uses: actions/checkout@v4
+
       - name: Smoke public site
         if: inputs.target == 'www'
         run: |
           set -euo pipefail
-          for path in / /newsletter /newsletter/archive /making /orchestrating /projects /projects/chainedchat /projects/claude-code-tips /projects/imessage-mcp /projects/nyu-purity-test /projects/options-pricing-sensitivity /projects/pgi-research-platform /projects/quantercise /projects/quantercise-extension /projects/saeshify /writing /writing/i-built-a-monitor-for-my-claude-code-sessions /writing/saturdays-are-for-claude-code /writing/search-will-be-dead-by-2030 /writing/stop-ending-your-day-with-fix-the-bug; do
+          routes_file="$RUNNER_TEMP/public-routes.txt"
+          node scripts/ci/public-route-inventory.mjs > "$routes_file"
+          while IFS= read -r path; do
             code="$(curl -sS -o /dev/null -w '%{http_code}' "https://anipotts.com${path}")"
             echo "https://anipotts.com${path} -> ${code}"
             test "$code" = "200"
-          done
+          done < "$routes_file"
           echo "commit_sha=${{ inputs.commit_sha }}"
 
       - name: Smoke admin unauthenticated block

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "test:admin-routes": "node scripts/ci/admin-route-parity.test.mjs",
     "test:content-platform": "pnpm --filter @anipotts/content build && node scripts/ci/content-platform.test.mjs",
     "test:public-boundary": "node scripts/ci/public-app-boundary.test.mjs",
-    "test:public-routes": "node scripts/ci/public-route-parity.test.mjs",
+    "test:public-routes": "node scripts/ci/public-route-inventory.test.mjs && node scripts/ci/public-route-parity.test.mjs",
     "test:path-hygiene": "node scripts/ci/path-hygiene.test.mjs",
     "test:workspace": "node scripts/ci/workspace-inventory.test.mjs",
     "test:workflows": "node scripts/ci/workflow-inventory.test.mjs",

--- a/scripts/admin/content-proof.mjs
+++ b/scripts/admin/content-proof.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { execFileSync } from "node:child_process";
+import { PUBLIC_SMOKE_ROUTES } from "../ci/public-route-inventory.mjs";
 
 const ADMIN_ORIGIN =
   process.env.ADMIN_ORIGIN?.replace(/\/$/, "") ?? "https://admin.anipotts.com";
@@ -83,28 +84,7 @@ const ADMIN_ROUTES = [
   "/content/operations",
   "/proof",
 ];
-const PUBLIC_ROUTES = [
-  "/",
-  "/newsletter",
-  "/newsletter/archive",
-  "/making",
-  "/orchestrating",
-  "/projects",
-  "/projects/chainedchat",
-  "/projects/claude-code-tips",
-  "/projects/imessage-mcp",
-  "/projects/nyu-purity-test",
-  "/projects/options-pricing-sensitivity",
-  "/projects/pgi-research-platform",
-  "/projects/quantercise",
-  "/projects/quantercise-extension",
-  "/projects/saeshify",
-  "/writing",
-  "/writing/i-built-a-monitor-for-my-claude-code-sessions",
-  "/writing/saturdays-are-for-claude-code",
-  "/writing/search-will-be-dead-by-2030",
-  "/writing/stop-ending-your-day-with-fix-the-bug",
-];
+const PUBLIC_ROUTES = PUBLIC_SMOKE_ROUTES;
 const DETAIL_PAGE_PROOF = {
   "project:chainedchat": {
     route: "/projects/chainedchat",

--- a/scripts/ci/public-route-inventory.mjs
+++ b/scripts/ci/public-route-inventory.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+
+import { realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const inventory = [
+  { route: "/", file: "apps/www/src/pages/index.astro" },
+  { route: "/newsletter", file: "apps/www/src/pages/newsletter.astro" },
+  {
+    route: "/newsletter/archive",
+    file: "apps/www/src/pages/newsletter/archive.astro",
+  },
+  { route: "/making", file: "apps/www/src/pages/making.astro" },
+  { route: "/orchestrating", file: "apps/www/src/pages/orchestrating.astro" },
+  { route: "/projects", file: "apps/www/src/pages/projects/index.astro" },
+  {
+    route: "/projects/chainedchat",
+    file: "apps/www/src/pages/projects/[slug].astro",
+  },
+  {
+    route: "/projects/claude-code-tips",
+    file: "apps/www/src/pages/projects/[slug].astro",
+  },
+  {
+    route: "/projects/imessage-mcp",
+    file: "apps/www/src/pages/projects/[slug].astro",
+  },
+  {
+    route: "/projects/nyu-purity-test",
+    file: "apps/www/src/pages/projects/[slug].astro",
+  },
+  {
+    route: "/projects/options-pricing-sensitivity",
+    file: "apps/www/src/pages/projects/[slug].astro",
+  },
+  {
+    route: "/projects/pgi-research-platform",
+    file: "apps/www/src/pages/projects/[slug].astro",
+  },
+  {
+    route: "/projects/quantercise",
+    file: "apps/www/src/pages/projects/[slug].astro",
+  },
+  {
+    route: "/projects/quantercise-extension",
+    file: "apps/www/src/pages/projects/[slug].astro",
+  },
+  {
+    route: "/projects/saeshify",
+    file: "apps/www/src/pages/projects/[slug].astro",
+  },
+  { route: "/writing", file: "apps/www/src/pages/writing/index.astro" },
+  {
+    route: "/writing/i-built-a-monitor-for-my-claude-code-sessions",
+    file: "apps/www/src/pages/writing/[slug].astro",
+  },
+  {
+    route: "/writing/saturdays-are-for-claude-code",
+    file: "apps/www/src/pages/writing/[slug].astro",
+  },
+  {
+    route: "/writing/search-will-be-dead-by-2030",
+    file: "apps/www/src/pages/writing/[slug].astro",
+  },
+  {
+    route: "/writing/stop-ending-your-day-with-fix-the-bug",
+    file: "apps/www/src/pages/writing/[slug].astro",
+  },
+];
+
+const SAFE_ROUTE_SEGMENT = /^[A-Za-z0-9._-]+$/;
+const SAFE_FILE_SEGMENT = /^[A-Za-z0-9._[\]-]+$/;
+
+export function validatePublicRouteInventory(records) {
+  if (!Array.isArray(records)) {
+    throw new TypeError("public route inventory must be an array");
+  }
+  if (records.length === 0) {
+    throw new TypeError("public route inventory must not be empty");
+  }
+
+  const routes = new Set();
+  for (const [index, record] of records.entries()) {
+    if (!record || typeof record !== "object" || Array.isArray(record)) {
+      throw new TypeError(`public route record ${index} must be an object`);
+    }
+    if (
+      Object.keys(record).length !== 2 ||
+      !Object.hasOwn(record, "route") ||
+      !Object.hasOwn(record, "file")
+    ) {
+      throw new TypeError(`public route record ${index} has an invalid shape`);
+    }
+    if (!isCanonicalRoute(record.route)) {
+      throw new TypeError(`public route record ${index} has an unsafe route`);
+    }
+    if (!isSafePageFile(record.file)) {
+      throw new TypeError(`public route record ${index} has an invalid file`);
+    }
+    if (routes.has(record.route)) {
+      throw new TypeError(`duplicate public route ${record.route}`);
+    }
+    routes.add(record.route);
+  }
+}
+
+function isCanonicalRoute(route) {
+  if (route === "/") return true;
+  if (typeof route !== "string" || !route.startsWith("/")) return false;
+  if (route.startsWith("//") || route.endsWith("/")) return false;
+  return route
+    .slice(1)
+    .split("/")
+    .every(
+      (segment) =>
+        segment !== "" &&
+        segment !== "." &&
+        segment !== ".." &&
+        SAFE_ROUTE_SEGMENT.test(segment),
+    );
+}
+
+function isSafePageFile(file) {
+  if (
+    typeof file !== "string" ||
+    !file.startsWith("apps/www/src/pages/") ||
+    !file.endsWith(".astro") ||
+    file.endsWith("/")
+  ) {
+    return false;
+  }
+  return file
+    .split("/")
+    .every(
+      (segment) =>
+        segment !== "" &&
+        segment !== "." &&
+        segment !== ".." &&
+        SAFE_FILE_SEGMENT.test(segment),
+    );
+}
+
+validatePublicRouteInventory(inventory);
+
+export const PUBLIC_ROUTE_INVENTORY = Object.freeze(
+  inventory.map((record) => Object.freeze(record)),
+);
+export const PUBLIC_SMOKE_ROUTES = Object.freeze(
+  PUBLIC_ROUTE_INVENTORY.map((record) => record.route),
+);
+
+if (isDirectExecution()) {
+  process.stdout.write(`${PUBLIC_SMOKE_ROUTES.join("\n")}\n`);
+}
+
+function isDirectExecution() {
+  if (!process.argv[1]) return false;
+  try {
+    return (
+      realpathSync(process.argv[1]) ===
+      realpathSync(fileURLToPath(import.meta.url))
+    );
+  } catch {
+    return false;
+  }
+}

--- a/scripts/ci/public-route-inventory.test.mjs
+++ b/scripts/ci/public-route-inventory.test.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import {
+  PUBLIC_ROUTE_INVENTORY,
+  PUBLIC_SMOKE_ROUTES,
+  validatePublicRouteInventory,
+} from "./public-route-inventory.mjs";
+
+assert.equal(PUBLIC_ROUTE_INVENTORY.length, 20);
+assert.equal(PUBLIC_SMOKE_ROUTES.length, 20);
+assert.deepEqual(
+  PUBLIC_SMOKE_ROUTES,
+  PUBLIC_ROUTE_INVENTORY.map((record) => record.route),
+);
+assert.equal(new Set(PUBLIC_SMOKE_ROUTES).size, PUBLIC_SMOKE_ROUTES.length);
+assert.equal(Object.isFrozen(PUBLIC_ROUTE_INVENTORY), true);
+assert.equal(Object.isFrozen(PUBLIC_SMOKE_ROUTES), true);
+
+for (const record of PUBLIC_ROUTE_INVENTORY) {
+  assert.deepEqual(Object.keys(record), ["route", "file"]);
+  assert.equal(Object.isFrozen(record), true);
+  assert.ok(existsSync(record.file), `${record.route} missing ${record.file}`);
+}
+
+assert.equal(
+  PUBLIC_ROUTE_INVENTORY.filter(
+    (record) => record.file === "apps/www/src/pages/projects/[slug].astro",
+  ).length,
+  9,
+);
+assert.equal(
+  PUBLIC_ROUTE_INVENTORY.filter(
+    (record) => record.file === "apps/www/src/pages/writing/[slug].astro",
+  ).length,
+  4,
+);
+
+const cli = spawnSync(
+  process.execPath,
+  ["scripts/ci/public-route-inventory.mjs"],
+  {
+    encoding: "utf8",
+  },
+);
+assert.equal(cli.status, 0, cli.stderr);
+assert.equal(cli.stderr, "");
+assert.equal(cli.stdout, `${PUBLIC_SMOKE_ROUTES.join("\n")}\n`);
+
+for (const unsafeRoute of [
+  "relative",
+  "/white space",
+  "/new\nline",
+  "/control\tcharacter",
+  "//double",
+  "/a//b",
+  "/./x",
+  "/../x",
+  "/trailing/",
+  "/query?value",
+  "/hash#value",
+  "/semi;colon",
+  "/dollar$sign",
+  "/back`tick",
+  "/pipe|value",
+]) {
+  assert.throws(
+    () =>
+      validatePublicRouteInventory([
+        { route: unsafeRoute, file: "apps/www/src/pages/index.astro" },
+      ]),
+    /unsafe route/,
+  );
+}
+
+assert.throws(
+  () =>
+    validatePublicRouteInventory([
+      { route: "/", file: "apps/www/src/pages/index.astro" },
+      { route: "/", file: "apps/www/src/pages/index.astro" },
+    ]),
+  /duplicate public route/,
+);
+assert.throws(() => validatePublicRouteInventory(null), /must be an array/);
+assert.throws(() => validatePublicRouteInventory([]), /must not be empty/);
+assert.throws(() => validatePublicRouteInventory([null]), /must be an object/);
+assert.throws(
+  () =>
+    validatePublicRouteInventory([
+      {
+        route: "/",
+        file: "apps/www/src/pages/index.astro",
+        smoke: true,
+      },
+    ]),
+  /invalid shape/,
+);
+assert.throws(
+  () => validatePublicRouteInventory([{ route: "/", file: "" }]),
+  /invalid file/,
+);
+for (const unsafeFile of [
+  "/apps/www/src/pages/index.astro",
+  "apps/admin/src/pages/index.astro",
+  "apps/www/src/pages/../secret.astro",
+  "apps/www/src/pages//index.astro",
+  "apps/www/src/pages/white space.astro",
+  "apps/www/src/pages/control\nfile.astro",
+  "apps/www/src/pages/index.ts",
+]) {
+  assert.throws(
+    () => validatePublicRouteInventory([{ route: "/", file: unsafeFile }]),
+    /invalid file/,
+  );
+}

--- a/scripts/ci/public-route-parity.test.mjs
+++ b/scripts/ci/public-route-parity.test.mjs
@@ -1,125 +1,83 @@
 #!/usr/bin/env node
 
 import assert from "node:assert/strict";
-import { existsSync, readFileSync } from "node:fs";
-
-const PUBLIC_ROUTES = [
-  { route: "/", file: "apps/www/src/pages/index.astro" },
-  { route: "/newsletter", file: "apps/www/src/pages/newsletter.astro" },
-  {
-    route: "/newsletter/archive",
-    file: "apps/www/src/pages/newsletter/archive.astro",
-  },
-  { route: "/making", file: "apps/www/src/pages/making.astro" },
-  { route: "/orchestrating", file: "apps/www/src/pages/orchestrating.astro" },
-  { route: "/projects", file: "apps/www/src/pages/projects/index.astro" },
-  {
-    route: "/projects/chainedchat",
-    file: "apps/www/src/pages/projects/[slug].astro",
-  },
-  {
-    route: "/projects/claude-code-tips",
-    file: "apps/www/src/pages/projects/[slug].astro",
-  },
-  {
-    route: "/projects/imessage-mcp",
-    file: "apps/www/src/pages/projects/[slug].astro",
-  },
-  {
-    route: "/projects/nyu-purity-test",
-    file: "apps/www/src/pages/projects/[slug].astro",
-  },
-  {
-    route: "/projects/options-pricing-sensitivity",
-    file: "apps/www/src/pages/projects/[slug].astro",
-  },
-  {
-    route: "/projects/pgi-research-platform",
-    file: "apps/www/src/pages/projects/[slug].astro",
-  },
-  {
-    route: "/projects/quantercise",
-    file: "apps/www/src/pages/projects/[slug].astro",
-  },
-  {
-    route: "/projects/quantercise-extension",
-    file: "apps/www/src/pages/projects/[slug].astro",
-  },
-  {
-    route: "/projects/saeshify",
-    file: "apps/www/src/pages/projects/[slug].astro",
-  },
-  { route: "/writing", file: "apps/www/src/pages/writing/index.astro" },
-  {
-    route: "/writing/i-built-a-monitor-for-my-claude-code-sessions",
-    file: "apps/www/src/pages/writing/[slug].astro",
-  },
-  {
-    route: "/writing/saturdays-are-for-claude-code",
-    file: "apps/www/src/pages/writing/[slug].astro",
-  },
-  {
-    route: "/writing/search-will-be-dead-by-2030",
-    file: "apps/www/src/pages/writing/[slug].astro",
-  },
-  {
-    route: "/writing/stop-ending-your-day-with-fix-the-bug",
-    file: "apps/www/src/pages/writing/[slug].astro",
-  },
-];
+import { readFileSync } from "node:fs";
+import { PUBLIC_SMOKE_ROUTES } from "./public-route-inventory.mjs";
 
 const deployWorkflow = readFileSync(".github/workflows/deploy.yml", "utf8");
 const smokeWorkflow = readFileSync(".github/workflows/smoke.yml", "utf8");
 const contentProof = readFileSync("scripts/admin/content-proof.mjs", "utf8");
-
-const expected = PUBLIC_ROUTES.map((item) => item.route).sort();
-const deploySmokeRoutes = extractRoutesFromStep(
+const deploySmokeStep = extractSection(
   deployWorkflow,
-  "Smoke www routes",
+  "      - name: Smoke www routes",
+  "\n  deploy-admin:",
 );
-const manualSmokeRoutes = extractRoutesFromStep(
+const manualSmokeStep = extractSection(
   smokeWorkflow,
-  "Smoke public site",
+  "      - name: Smoke public site",
+  "\n      - name: Smoke admin unauthenticated block",
 );
-const contentProofRoutes = extractConstList(contentProof, "PUBLIC_ROUTES");
 
-for (const { route, file } of PUBLIC_ROUTES) {
-  assert.ok(existsSync(file), `${route} missing route file ${file}`);
+assert.equal(PUBLIC_SMOKE_ROUTES.length, 20);
+
+for (const [sourceName, source] of [
+  ["deploy.yml", deployWorkflow],
+  ["smoke.yml", smokeWorkflow],
+]) {
+  assert.ok(
+    source.includes("node scripts/ci/public-route-inventory.mjs"),
+    `${sourceName} must load the shared public route inventory`,
+  );
+  assert.ok(
+    source.includes("while IFS= read -r path; do"),
+    `${sourceName} must read one inventory route per line`,
+  );
+  assert.ok(
+    source.includes('"https://anipotts.com${path}"'),
+    `${sourceName} must quote the public route path`,
+  );
 }
 
-assert.deepEqual(
-  deploySmokeRoutes,
-  expected,
-  "deploy.yml public smoke routes must match the stable public route proof set",
+assert.ok(
+  contentProof.includes(
+    'import { PUBLIC_SMOKE_ROUTES } from "../ci/public-route-inventory.mjs";',
+  ),
+  "content-proof must import shared public smoke routes",
+);
+assert.ok(
+  contentProof.includes("const PUBLIC_ROUTES = PUBLIC_SMOKE_ROUTES;"),
+  "content-proof must probe the shared public smoke route set",
 );
 
-assert.deepEqual(
-  manualSmokeRoutes,
-  expected,
-  "smoke.yml public smoke routes must match the stable public route proof set",
-);
+assert.ok(deploySmokeStep.includes("curl -sS"));
+assert.equal(deploySmokeStep.match(/curl -sS/g)?.length, 1);
+assert.equal(deploySmokeStep.includes("curl -I"), false);
+assert.ok(deploySmokeStep.includes("for _ in $(seq 1 6); do"));
+assert.ok(deploySmokeStep.includes("sleep 10"));
+assert.ok(manualSmokeStep.includes("curl -sS"));
+assert.equal(manualSmokeStep.match(/curl -sS/g)?.length, 1);
+assert.equal(manualSmokeStep.includes("curl -I"), false);
+assert.equal(manualSmokeStep.includes("seq 1 6"), false);
+assert.equal(manualSmokeStep.includes("sleep 10"), false);
 
-assert.deepEqual(
-  contentProofRoutes,
-  expected,
-  "content-proof public route probes must match the stable public route proof set",
-);
-
-function extractRoutesFromStep(source, stepName) {
-  const stepStart = source.indexOf(`name: ${stepName}`);
-  assert.notEqual(stepStart, -1, `missing workflow step ${stepName}`);
-  const fromStep = source.slice(stepStart);
-  const match = fromStep.match(/for path in ([^;]+); do/);
-  assert.ok(match, `${stepName} must use an explicit public route loop`);
-  return match[1]
-    .trim()
-    .split(/\s+/)
-    .filter((route) => route.startsWith("/"))
-    .sort();
+for (const marker of [
+  'method: "HEAD"',
+  "runD1(`",
+  "publishedEventRoutes",
+  "UNPUBLISHED_PUBLIC_ROUTES",
+  "publishedEventRouteChecks",
+  "unpublishedPublicRouteChecks",
+]) {
+  assert.ok(
+    contentProof.includes(marker),
+    `content-proof must retain ${marker}`,
+  );
 }
 
-function extractConstList(source, name) {
-  const match = source.match(new RegExp(`const ${name} = \\[([\\s\\S]*?)\\];`));
-  assert.ok(match, `missing const list ${name}`);
-  return [...match[1].matchAll(/"([^"]+)"/g)].map((item) => item[1]).sort();
+function extractSection(source, startMarker, endMarker) {
+  const start = source.indexOf(startMarker);
+  assert.notEqual(start, -1, `missing ${startMarker.trim()}`);
+  const end = source.indexOf(endMarker, start);
+  assert.notEqual(end, -1, `missing ${endMarker.trim()}`);
+  return source.slice(start, end);
 }


### PR DESCRIPTION
## what changed

- centralizes the 20 stable published routes and backing page files in one validated inventory
- makes deploy smoke, manual smoke, and content proof consume the shared route membership
- preserves deploy retries, manual single-attempt GET behavior, and content-proof HEAD and D1 behavior
- rejects non-canonical routes and unsafe backing-file classifications before CLI output

## why

The route set was duplicated across four consumers. A shared dependency-free inventory removes drift while leaving each consumer responsible for its own HTTP and proof policy.

## checks

- `node scripts/ci/public-route-inventory.test.mjs`
- `pnpm test:public-routes`
- `pnpm test:admin-routes`
- `pnpm test:workflows`
- `pnpm test:security-review`
- `pnpm format:check`
- scoped security review and all-false deploy-target calculation
- `pnpm validate`
- `git diff --check`

`actionlint` was not installed locally. Workflow coverage used the repository workflow, route-parity, security tests, formatting checks, and direct shell-policy assertions.

No deploy, migration, provider call, or live mutation is part of this PR.